### PR TITLE
fix: 修复 vitest 误扫描 scripts/ 下的 Playwright 测试文件

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "vue": "^3.5.13"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@types/file-saver": "^2.0.7",
         "@types/node": "^22.10.2",
         "@types/qrcode": "^1.5.6",
@@ -2432,6 +2433,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -7379,6 +7396,53 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "vue": "^3.5.13"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@types/file-saver": "^2.0.7",
     "@types/node": "^22.10.2",
     "@types/qrcode": "^1.5.6",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,6 +57,8 @@ export default defineConfig(async ({ command, mode }) => {
     base: '/flying-chess/',
     test: {
       setupFiles: ['src/tests/setup.ts'],
+      include: ['src/tests/**/*.test.ts'],
+      exclude: ['scripts/**', '**/e2e/**', 'node_modules/**'],
     },
     server: {
       // 允许内网访问


### PR DESCRIPTION
## Summary
- 在 vite.config.ts 中为 vitest 添加 `include` 和 `exclude` 配置，限制测试扫描范围为 `src/tests/**/*.test.ts`，排除 `scripts/` 目录
- 添加 `@playwright/test` 到 devDependencies（脚本实际依赖）

## 问题
CI 运行 `npm run test` 时，vitest 默认扫描了 `scripts/*.spec.ts`（Playwright E2E 测试文件），但 CI 环境未安装 `@playwright/test`，导致 import 失败。

## 修复
1. `vite.config.ts`: 添加 `include: ['src/tests/**/*.test.ts']` + `exclude: ['scripts/**', ...]`
2. `package.json`: 添加 `@playwright/test` 到 devDependencies

## 本地验证
- `npm run lint:check` ✓
- `npm run type-check` ✓  
- `npm run test` ✓ (只扫描 src/tests/ 下的 2 个测试文件)
- `npm run build` ✓

Made with [Cursor](https://cursor.com)