### PR TITLE
fix: establish reliable local game configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ coverage
 
 /cypress/videos/
 /cypress/screenshots/
+/playwright-report/
+/test-results/
 
 # Editor directories and files
 .vscode/*

--- a/docs/plans/2026-07-11-private-local-game-reliability-design.md
+++ b/docs/plans/2026-07-11-private-local-game-reliability-design.md
@@ -1,0 +1,107 @@
+# Private Local Game Reliability Design
+
+**Status:** Approved on 2026-07-11
+
+## Context
+
+Flying Chess is a private, local-only punishment game. It supports any player count, although two players are the most common case. The product must not split into separate two-player and multiplayer modes, and it must not encode fixed dominant/submissive roles. The same local game model and rules apply to every supported player count.
+
+Punishment is the core reward-and-risk loop. Failing to take off and landing on punishment cells are intentional sources of tension, so this work must not lower punishment density or remove takeoff-failure punishment. The problem to solve is whether the configured rule is resolved consistently, displayed truthfully, and kept private on the device.
+
+## Product Principles
+
+1. **One game model for all player counts.** Two players require no special mode or separate data model.
+2. **Local only.** No accounts, cloud storage, remote rooms, or online synchronization are introduced.
+3. **Punishment remains central.** Existing takeoff-failure punishment and default punishment density remain intact unless separately redesigned later.
+4. **Configuration is authoritative.** Every rule path must honor configured compatibility and limits.
+5. **Private by default.** Names, preferences, and current-game data stay on the device and can be cleared reliably at the end of play.
+6. **Results are deterministic after resolution.** Once a dice result is resolved, target, executor, count, source rule, and follow-up state cannot disagree across UI and engine code.
+
+## Architecture
+
+### Configuration and Reliability Boundary
+
+User-visible configuration must match the state used to generate the board. Validation will enforce cross-field constraints, including reserving start and finish cells. Imported data will be validated by the same runtime contract before it can replace stored configuration.
+
+UI health recovery must understand legitimate long-running game overlays. Waiting while players carry out an action is not a stuck movement state.
+
+### Rule Resolution Boundary
+
+A later MR will introduce a pure rule-resolution layer. Dice movement, takeoff failure, punishment cells, dynamic cells, traps, rest, bounce, and victory rewards will produce explicit resolved results before the UI displays them. The UI will render resolved state and emit player decisions; it will not infer target or count from descriptive strings.
+
+All punishment sources will use the same compatibility filter. Takeoff failure remains a punishment event, but it can no longer bypass the compatibility guarantees used by board combinations.
+
+### Local Game Data Lifetime
+
+Long-lived global defaults and current-game data will be separated conceptually while remaining browser-local. A current game may contain player names, optional per-player restrictions, board state, and resolution history. Ending and clearing a game removes current-game data and backup artifacts without requiring a server.
+
+Per-player restrictions are optional. A player inherits the global configuration when none are supplied, so existing multiplayer setup continues to work.
+
+### Interaction Model
+
+Resolved actions will support explicit decisions such as complete, use a preconfigured alternative, skip, or pause. These decisions are game state, not hidden UI shortcuts. Victory rewards become configurable rules processed through the same resolver instead of hard-coded component text.
+
+## Merge Request Sequence
+
+### MR 1: Reliability and Configuration Truth
+
+- Fix the desktop two-column root layout.
+- Make total-cell changes update parent state and regenerate the actual board.
+- Validate assigned cells against `totalCells - 2` and avoid silent truncation.
+- Prevent legitimate action, trap, bounce, and relief overlays from triggering the movement watchdog.
+- Clear the real local-storage keys and backup artifact.
+- Validate imported board, punishment, position, and trap data before persistence.
+- Add unit and Playwright regressions for each repaired behavior.
+
+This MR must not change punishment density, takeoff-failure punishment, player-count behavior, or introduce new gameplay.
+
+### MR 2: Trustworthy Rule Resolution
+
+- Add an immutable resolved-action contract.
+- Route takeoff failure and board punishment through one compatibility-aware generator.
+- Implement dynamic target and count rules as actual engine behavior.
+- Implement rest as a consumed skipped turn.
+- Represent traps as structured effects with a truthful completion state.
+- Remove description parsing as a source of rule behavior.
+- Add unit tests for every rule source and multiplayer target edge case.
+
+### MR 3: Private Local Game Lifecycle
+
+- Keep a single multiplayer-capable game model.
+- Add optional per-player restrictions that inherit global defaults.
+- Add explicit complete, alternative, skip, and pause decisions.
+- Make victory rewards configurable and resolver-driven.
+- Separate persistent defaults from current-game data.
+- Add a reliable local “end and clear” action with no network dependency.
+
+### MR 4: Accessibility, Reproducibility, and Release Gates
+
+- Replace click-only dice and board cells with semantic keyboard-accessible controls.
+- Add focus management and announcements for game dialogs and turn changes.
+- Restore browser zoom and fix small-screen control overlap.
+- Generate boards from a real seed and restore the exact exported board.
+- Run Playwright tests in CI across desktop and mobile viewports.
+- Align README, schema examples, and deployment documentation with actual behavior.
+
+## Error Handling
+
+- Reject invalid imported data before writing any storage key.
+- Preserve the previous valid configuration when import validation fails.
+- Do not reset turn state while an intentional overlay is active.
+- Surface recoverable configuration errors in the UI instead of silently truncating or regenerating different rules.
+
+## Testing Strategy
+
+- Use test-driven development for every behavior change.
+- Unit-test pure validation and rule resolution.
+- Component-test state transitions that cross Vue components.
+- Use Playwright for configuration truth, desktop layout, keyboard dice access, local-data clearing, and the complete configuration-to-game path.
+- Require lint, type-check, unit tests, production build, and Playwright tests before merging each MR.
+
+## Non-Goals
+
+- No cloud service, account system, online room, remote synchronization, or analytics backend.
+- No dedicated two-player mode.
+- No fixed dominant/submissive role model.
+- No reduction of punishment frequency as part of reliability work.
+- No visual redesign beyond changes required for correctness and accessibility.

--- a/docs/plans/2026-07-11-reliability-config-implementation.md
+++ b/docs/plans/2026-07-11-reliability-config-implementation.md
@@ -1,0 +1,299 @@
+# Reliability and Configuration Truth Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the current local multiplayer game display and execute the configuration users actually selected, without changing punishment frequency or game content.
+
+**Architecture:** Add small pure validators for board configuration, imported configuration, and movement-health state so the existing Vue component can delegate decisions instead of duplicating them. Use Playwright for browser-visible regressions and Vitest for state and validation behavior. Keep the existing GameService and App flow intact except at the repaired boundaries.
+
+**Tech Stack:** Vue 3, TypeScript, Vitest, Playwright, Vite
+
+---
+
+## Constraints
+
+- Preserve all player counts and the single shared game model.
+- Preserve takeoff-failure punishment and current punishment density.
+- Do not add cloud, accounts, rooms, or remote synchronization.
+- Do not introduce the resolved-action model planned for MR 2.
+- Each production behavior change requires a failing test first.
+
+### Task 1: Add a Repeatable Browser Regression Harness
+
+**Files:**
+- Create: playwright.config.ts
+- Create: tests/e2e/reliability.spec.ts
+- Modify: package.json
+
+**Step 1: Add the failing desktop-layout test**
+
+Create a Playwright test that:
+
+    test('desktop app fills the viewport width', async ({ page }) => {
+      await page.goto('/flying-chess/')
+      const viewportWidth = await page.evaluate(() => window.innerWidth)
+      const appWidth = await page.locator('.app').evaluate(element => element.getBoundingClientRect().width)
+      expect(appWidth).toBeGreaterThanOrEqual(viewportWidth - 1)
+    })
+
+Configure a 1280 x 900 Chrome project and a Vite web server on 127.0.0.1:4175. Add a test:e2e script that runs tests/e2e.
+
+**Step 2: Run the test and verify RED**
+
+Run:
+
+    env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm run test:e2e -- --grep "desktop app fills"
+
+Expected: FAIL because .app occupies only the first #app grid column.
+
+**Step 3: Commit the failing regression harness**
+
+    git add package.json playwright.config.ts tests/e2e/reliability.spec.ts
+    git commit -m "test: add reliability browser regressions"
+
+### Task 2: Fix the Desktop Root Layout
+
+**Files:**
+- Modify: src/assets/main.css
+- Test: tests/e2e/reliability.spec.ts
+
+**Step 1: Implement the minimal layout repair**
+
+Remove the legacy two-column #app grid at the desktop breakpoint. Retain the existing max-width behavior only where a specific page owns that constraint; the root app must span the viewport.
+
+**Step 2: Verify GREEN**
+
+Run the desktop-layout Playwright test. Expected: PASS.
+
+**Step 3: Run a mobile smoke check**
+
+Run the same spec with a 390 x 844 project. Expected: PASS with no horizontal overflow.
+
+**Step 4: Commit**
+
+    git add src/assets/main.css tests/e2e/reliability.spec.ts
+    git commit -m "fix: restore full-width desktop layout"
+
+### Task 3: Make Board Size Authoritative
+
+**Files:**
+- Create: src/tests/boardConfig.test.ts
+- Modify: src/services/gameService.ts
+- Modify: src/components/BoardConfig.vue
+- Modify: src/App.vue
+- Test: tests/e2e/reliability.spec.ts
+
+**Step 1: Write failing board validation tests**
+
+Add tests proving:
+
+    expect(GameService.validateBoardConfig({
+      totalCells: 40,
+      punishmentCells: 30,
+      bonusCells: 1,
+      reverseCells: 2,
+      restCells: 1,
+      restartCells: 4,
+      trapCells: 2,
+    })).toBe(false)
+
+The assigned total is 40, but only 38 cells are available after reserving start and finish.
+
+Add a test that createBoard rejects an invalid board configuration instead of silently dropping trailing cell types.
+
+**Step 2: Verify RED**
+
+Run:
+
+    env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm test -- src/tests/boardConfig.test.ts
+
+Expected: validation returns true or board generation silently truncates.
+
+**Step 3: Implement minimal service validation**
+
+Change validateBoardConfig so assigned effects must be less than or equal to totalCells - 2. Require integer counts and totalCells between 20 and 100. Have createBoard throw a descriptive error for an invalid board configuration before random assignment.
+
+**Step 4: Verify service tests GREEN**
+
+Run the board-config unit tests. Expected: PASS.
+
+**Step 5: Add a failing Playwright test for the input bug**
+
+In the browser:
+
+- enter 80 in the total-cell input;
+- assert the displayed value is 80;
+- assert window.gameState.boardConfig.totalCells is 80;
+- assert window.gameState.board.length is 80.
+
+Expected before the UI fix: FAIL with parent state and board length still 40.
+
+**Step 6: Implement the minimal component fix**
+
+Handle totalCells explicitly in BoardConfig. Emit valid total-cell changes to App. Do not auto-discard configured cell categories. When a local edit is invalid, keep it local, display invalid state, and leave the last valid generated board unchanged.
+
+**Step 7: Verify unit and Playwright tests GREEN**
+
+Run board-config unit tests and the total-cell Playwright test. Expected: PASS.
+
+**Step 8: Commit**
+
+    git add src/tests/boardConfig.test.ts src/services/gameService.ts src/components/BoardConfig.vue src/App.vue tests/e2e/reliability.spec.ts
+    git commit -m "fix: keep board size and generated board in sync"
+
+### Task 4: Make the Movement Watchdog Overlay-Aware
+
+**Files:**
+- Create: src/services/gameStateHealth.ts
+- Create: src/tests/gameStateHealth.test.ts
+- Modify: src/App.vue
+
+**Step 1: Write failing health-decision tests**
+
+Design a pure function:
+
+    shouldRecoverMovingState({
+      gameStatus: 'moving',
+      movingDurationMs: 6000,
+      hasBlockingOverlay: true,
+    })
+
+Assert it returns false when a takeoff punishment, trap, bounce, or takeoff-relief overlay is active, and true only when moving exceeds five seconds with no legitimate overlay.
+
+**Step 2: Verify RED**
+
+Run the new test file. Expected: module or function missing.
+
+**Step 3: Implement the pure decision helper**
+
+Keep time measurement in App, but delegate the reset decision to the helper. Treat all action-resolution overlays as legitimate blocking states.
+
+**Step 4: Verify GREEN and full unit suite**
+
+Run the new test and npm test. Expected: all tests pass.
+
+**Step 5: Commit**
+
+    git add src/services/gameStateHealth.ts src/tests/gameStateHealth.test.ts src/App.vue
+    git commit -m "fix: preserve turns while game overlays are active"
+
+### Task 5: Clear the Actual Local Game Data
+
+**Files:**
+- Modify: src/utils/cache.ts
+- Create: src/tests/cache.test.ts
+- Modify: src/components/IntroPage.vue
+
+**Step 1: Write a failing storage test**
+
+Use a small in-memory Storage test double. Seed:
+
+- ludo_game_config
+- ludo_player_settings
+- flying-chess-config-backup
+- hasShownGuide
+- autoGuideEnabled
+
+Call clearAllLocalGameData(storage) and assert every listed key is absent.
+
+**Step 2: Verify RED**
+
+Run the cache test. Expected: function missing.
+
+**Step 3: Implement the single clearing API**
+
+Export storage-key constants from cache.ts and add clearAllLocalGameData(storage = localStorage). Update IntroPage to call it rather than deleting stale literal keys. Keep the current refresh-based UI behavior; the dedicated end-of-game lifecycle remains MR 3.
+
+**Step 4: Verify GREEN**
+
+Run cache tests and the full unit suite. Expected: all tests pass.
+
+**Step 5: Commit**
+
+    git add src/utils/cache.ts src/tests/cache.test.ts src/components/IntroPage.vue
+    git commit -m "fix: clear persisted local game data"
+
+### Task 6: Reject Invalid Imports Before Persistence
+
+**Files:**
+- Create: src/utils/importValidation.ts
+- Create: src/tests/importValidation.test.ts
+- Modify: src/utils/export.ts
+
+**Step 1: Write focused failing validation tests**
+
+Cover these cases one at a time:
+
+- effect counts exceed totalCells - 2;
+- totalCells is outside 20 through 100;
+- tools, body parts, positions, or traps are empty;
+- intensity, sensitivity, ratio, strike range, step, or takeoff-failure values are outside supported ranges;
+- a position names a body part that is not present;
+- valid record-based current configuration passes;
+- valid legacy array-based configuration passes.
+
+Also test importFromJson with an invalid payload and assert existing local-storage values remain unchanged.
+
+**Step 2: Verify RED**
+
+Run the validation test file. Expected: malformed configuration is currently accepted.
+
+**Step 3: Implement runtime validation**
+
+Add pure validators that accept the current record representation and supported legacy array representation. Return path-specific error messages. Reuse board validation rules rather than duplicating the available-cell calculation.
+
+Update validateImportData to validate every supplied configuration section before performImport can write storage.
+
+**Step 4: Verify GREEN**
+
+Run import-validation tests and the full unit suite. Expected: all pass.
+
+**Step 5: Commit**
+
+    git add src/utils/importValidation.ts src/tests/importValidation.test.ts src/utils/export.ts
+    git commit -m "fix: validate imported game configuration"
+
+### Task 7: Verify MR 1 as a Whole
+
+**Files:**
+- Modify only if a verification failure identifies an MR 1 regression.
+
+**Step 1: Run formatting checks**
+
+    env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm run format:check
+
+Expected: PASS.
+
+**Step 2: Run lint and type checks**
+
+    env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm run lint:check
+    env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm run type-check
+
+Expected: zero errors. Existing unrelated warnings must not increase.
+
+**Step 3: Run unit and browser suites**
+
+    env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm test
+    env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm run test:e2e
+
+Expected: all tests pass.
+
+**Step 4: Run production build**
+
+    env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm run build
+
+Expected: build succeeds. Record pre-existing bundle-size and Browserslist warnings separately.
+
+**Step 5: Review scope**
+
+Inspect:
+
+    git diff --check origin/master...HEAD
+    git diff --stat origin/master...HEAD
+    git status --short
+
+Confirm no punishment-density, player-count, online-service, or unrelated visual changes.
+
+**Step 6: Request code review and publish MR 1**
+
+Use superpowers:requesting-code-review, address any verified finding, then use github:yeet to push the branch and open a draft pull request.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "validate-config": "node scripts/validate-config.js",
     "validate-demo": "node scripts/validate-config.js configs/exported-config-demo.json",
     "validate-example": "node scripts/validate-config.js examples/config-with-schema.json",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test tests/e2e"
   },
   "lint-staged": {
     "*.{js,ts,vue}": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  use: {
+    baseURL: 'http://127.0.0.1:4175',
+    channel: 'chrome',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 4175',
+    url: 'http://127.0.0.1:4175/flying-chess/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'desktop-chrome',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 900 },
+      },
+    },
+    {
+      name: 'mobile-chrome',
+      use: {
+        ...devices['Pixel 5'],
+        viewport: { width: 390, height: 844 },
+      },
+    },
+  ],
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,6 +33,11 @@
   import { saveConfig, loadConfig, loadPlayerSettings } from './utils/cache'
   import { SecureRandom } from './utils/secureRandom'
   import { devLog } from './utils/logger'
+  import {
+    hasBlockingOverlay,
+    shouldRecoverMovingState,
+    type BlockingOverlayState,
+  } from './services/gameStateHealth'
   import { usePlayerState } from './composables/usePlayerState'
   import { usePunishmentConfigNormalizer } from './composables/usePunishmentConfigNormalizer'
   import { useImportFeedbackDialog } from './composables/useImportFeedbackDialog'
@@ -349,11 +354,24 @@
 
   // 状态检查机制
   const checkGameStateHealth = () => {
+    const blockingOverlays: BlockingOverlayState = {
+      takeoffPunishment: showTakeoffPunishmentDisplay.value,
+      trap: showTrapDisplay.value,
+      bounce: showBounceDisplay.value,
+      takeoffRelief: showTakeoffReliefDisplay.value,
+    }
+
     // 检查是否卡在 moving 状态超过 5 秒
-    if (gameState.gameStatus === 'moving' && !showTakeoffPunishmentDisplay.value) {
+    if (gameState.gameStatus === 'moving' && !hasBlockingOverlay(blockingOverlays)) {
       if (movingStateEnteredAt.value === null) {
         movingStateEnteredAt.value = Date.now()
-      } else if (Date.now() - movingStateEnteredAt.value > 5000) {
+      } else if (
+        shouldRecoverMovingState(
+          gameState.gameStatus,
+          Date.now() - movingStateEnteredAt.value,
+          blockingOverlays
+        )
+      ) {
         console.warn('检测到游戏卡在moving状态超过5秒，正在重置...')
         movingStateEnteredAt.value = null
         resetGameStateOnError()

--- a/src/App.vue
+++ b/src/App.vue
@@ -430,9 +430,15 @@
     // 初始化后尝试读取本地缓存配置并应用
     const cached = loadConfig()
     if (cached) {
+      let shouldRepairCachedConfig = false
       if (cached.boardConfig) {
-        gameState.boardConfig = cached.boardConfig
-        devLog('已加载棋盘配置:', cached.boardConfig)
+        if (GameService.validateBoardConfig(cached.boardConfig)) {
+          gameState.boardConfig = cached.boardConfig
+          devLog('已加载棋盘配置:', cached.boardConfig)
+        } else {
+          shouldRepairCachedConfig = true
+          console.warn('忽略不兼容的旧棋盘配置，已恢复默认棋盘')
+        }
       }
       if (cached.punishmentConfig) {
         gameState.punishmentConfig = normalizePunishmentConfig(cached.punishmentConfig)
@@ -441,6 +447,14 @@
       if (cached.trapConfig) {
         trapConfig.value = cached.trapConfig
         devLog('已加载机关配置:', cached.trapConfig)
+      }
+
+      if (shouldRepairCachedConfig) {
+        saveConfig({
+          boardConfig: gameState.boardConfig,
+          punishmentConfig: gameState.punishmentConfig,
+          trapConfig: trapConfig.value,
+        })
       }
 
       // 根据缓存重新生成棋盘
@@ -482,6 +496,7 @@
         showTrapDisplay: typeof showTrapDisplay
         currentTrapPunishment: typeof currentTrapPunishment
         currentTrapDescription: typeof currentTrapDescription
+        checkGameStateHealth: typeof checkGameStateHealth
       }
 
       debugWindow.gameState = gameState
@@ -505,6 +520,7 @@
       debugWindow.showTrapDisplay = showTrapDisplay
       debugWindow.currentTrapPunishment = currentTrapPunishment
       debugWindow.currentTrapDescription = currentTrapDescription
+      debugWindow.checkGameStateHealth = checkGameStateHealth
     }
 
     // 从localStorage恢复设置

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -25,21 +25,6 @@ a,
   }
 }
 
-/* 桌面端布局 */
-@media (min-width: 1024px) {
-  body {
-    display: flex;
-    place-items: center;
-  }
-
-  #app {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    padding: 0 2rem;
-    max-width: 1280px;
-  }
-}
-
 /* 平板端布局 */
 @media (max-width: 1023px) and (min-width: 768px) {
   #app {

--- a/src/components/BoardConfig.vue
+++ b/src/components/BoardConfig.vue
@@ -26,7 +26,7 @@
       localConfig.value.restCells +
       localConfig.value.restartCells +
       localConfig.value.trapCells
-    return localConfig.value.totalCells - used
+    return localConfig.value.totalCells - 2 - used
   })
 
   // 检查配置是否有效
@@ -99,7 +99,7 @@
 
   // 自动分配格子
   const autoDistribute = () => {
-    const total = localConfig.value.totalCells
+    const total = localConfig.value.totalCells - 2
     // 按指定比例分配：惩罚格子75%，回到起点格子10%，前进格子2.5%，后退格子5%，休息格子2.5%，机关格子5%
     localConfig.value.punishmentCells = Math.floor(total * 0.75)
     localConfig.value.restartCells = Math.floor(total * 0.1)
@@ -117,7 +117,7 @@
       localConfig.value.restCells +
       localConfig.value.trapCells
 
-    // 将剩余的格子分配给惩罚格子，确保总和等于总数
+    // 将剩余的格子分配给惩罚格子，起点和终点不参与效果分配
     const remaining = total - assigned
     if (remaining > 0) {
       localConfig.value.punishmentCells += remaining

--- a/src/components/BoardConfig.vue
+++ b/src/components/BoardConfig.vue
@@ -99,30 +99,7 @@
 
   // 自动分配格子
   const autoDistribute = () => {
-    const total = localConfig.value.totalCells - 2
-    // 按指定比例分配：惩罚格子75%，回到起点格子10%，前进格子2.5%，后退格子5%，休息格子2.5%，机关格子5%
-    localConfig.value.punishmentCells = Math.floor(total * 0.75)
-    localConfig.value.restartCells = Math.floor(total * 0.1)
-    localConfig.value.bonusCells = Math.floor(total * 0.025)
-    localConfig.value.reverseCells = Math.floor(total * 0.05)
-    localConfig.value.restCells = Math.floor(total * 0.025)
-    localConfig.value.trapCells = Math.floor(total * 0.05)
-
-    // 计算已分配的格子总数
-    const assigned =
-      localConfig.value.punishmentCells +
-      localConfig.value.restartCells +
-      localConfig.value.bonusCells +
-      localConfig.value.reverseCells +
-      localConfig.value.restCells +
-      localConfig.value.trapCells
-
-    // 将剩余的格子分配给惩罚格子，起点和终点不参与效果分配
-    const remaining = total - assigned
-    if (remaining > 0) {
-      localConfig.value.punishmentCells += remaining
-    }
-
+    localConfig.value = GameService.createAutoBoardConfig(localConfig.value.totalCells)
     updateConfig()
   }
 </script>

--- a/src/components/BoardConfig.vue
+++ b/src/components/BoardConfig.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   import { ref, computed } from 'vue'
   import type { BoardConfig } from '../types/game'
+  import { GameService } from '../services/gameService'
 
   interface Props {
     config: BoardConfig
@@ -30,24 +31,23 @@
 
   // 检查配置是否有效
   const isConfigValid = computed(() => {
-    return (
-      remainingCells.value >= 0 &&
-      localConfig.value.punishmentCells >= 0 &&
-      localConfig.value.bonusCells >= 0 &&
-      localConfig.value.reverseCells >= 0 &&
-      localConfig.value.restCells >= 0 &&
-      localConfig.value.restartCells >= 0 &&
-      localConfig.value.trapCells >= 0
-    )
+    return GameService.validateBoardConfig(localConfig.value)
   })
 
   // 更新配置
   const updateConfig = () => {
-    emit('update', { ...localConfig.value })
+    if (isConfigValid.value) {
+      emit('update', { ...localConfig.value })
+    }
   }
 
   // 处理输入变化，自动调整后面格子
   const handleCellInput = (field: keyof BoardConfig) => {
+    if (field === 'totalCells') {
+      updateConfig()
+      return
+    }
+
     // 顺序：punishmentCells -> bonusCells -> reverseCells -> restCells -> restartCells -> trapCells
     const order: (keyof BoardConfig)[] = [
       'punishmentCells',
@@ -65,8 +65,9 @@
       used += Number(localConfig.value[order[i]])
     }
     // 如果超出总格子数，依次减少后面项
-    if (used > localConfig.value.totalCells) {
-      let remain = used - localConfig.value.totalCells
+    const assignableCells = localConfig.value.totalCells - 2
+    if (used > assignableCells) {
+      let remain = used - assignableCells
       for (let i = idx + 1; i < order.length; i++) {
         const v = Number(localConfig.value[order[i]])
         if (v >= remain) {

--- a/src/components/IntroPage.vue
+++ b/src/components/IntroPage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { ref, onMounted, onUnmounted, watch } from 'vue'
-  import { savePlayerSettings, loadPlayerSettings } from '../utils/cache'
+  import { savePlayerSettings, loadPlayerSettings, clearAllLocalGameData } from '../utils/cache'
   import { SecureRandom } from '../utils/secureRandom'
   import { devLog } from '../utils/logger'
   import VersionDisplay from './VersionDisplay.vue'
@@ -77,15 +77,7 @@
   // 清空缓存功能
   const clearCache = () => {
     try {
-      // 清空localStorage中的引导相关数据
-      localStorage.removeItem('hasShownGuide')
-      localStorage.removeItem('autoGuideEnabled')
-
-      // 清空玩家设置缓存
-      localStorage.removeItem('playerSettings')
-
-      // 清空游戏配置缓存
-      localStorage.removeItem('gameConfig')
+      clearAllLocalGameData()
 
       // 显示成功提示
       showClearSuccess.value = true
@@ -95,7 +87,7 @@
         showClearSuccess.value = false
       }, 3000)
 
-      devLog('缓存已清空，引导将重新触发')
+      devLog('本地游戏数据已清空')
     } catch (error) {
       console.error('清空缓存时出错:', error)
     }
@@ -335,19 +327,19 @@
         <div class="cache-controls">
           <button
             class="clear-cache-btn"
-            title="清空所有缓存数据，重新触发引导"
+            title="清除保存在此设备上的游戏配置、玩家设置和引导偏好"
             @click="clearCache"
           >
             <span class="btn-icon">🧹</span>
-            <span class="btn-text">重置新手引导</span>
+            <span class="btn-text">清除本地游戏数据</span>
           </button>
-          <p class="cache-hint">刷新页面可重新体验新手引导</p>
+          <p class="cache-hint">清除后刷新页面即可从默认配置重新开始</p>
         </div>
 
         <!-- 清空成功提示 -->
         <div v-if="showClearSuccess" class="clear-success-toast">
           <span class="toast-icon">✅</span>
-          <span class="toast-text">已重置！新手引导将重新触发</span>
+          <span class="toast-text">本地游戏数据已清除</span>
         </div>
       </div>
     </div>

--- a/src/services/gameService.ts
+++ b/src/services/gameService.ts
@@ -37,6 +37,10 @@ export class GameService {
     const boardConf = boardConfig || GAME_CONFIG.DEFAULT_BOARD_CONFIG
     const traps = customTraps || this.trapsToArray(GAME_CONFIG.DEFAULT_TRAPS)
 
+    if (!this.validateBoardConfig(boardConf)) {
+      throw new Error('棋盘配置无效：格子数量必须为整数，且需要为起点和终点预留两个格子')
+    }
+
     // 始终使用随机分配逻辑，确保所有格子都严格按照棋盘配置来生成
     const board = this.createBoardRandom(config, boardConf, traps)
     this.latestBoard = board
@@ -393,23 +397,22 @@ export class GameService {
   }
 
   static validateBoardConfig(config: BoardConfig): boolean {
-    const totalUsed =
-      config.punishmentCells +
-      config.bonusCells +
-      config.reverseCells +
-      config.restCells +
-      config.restartCells +
-      config.trapCells
+    const assignedCounts = [
+      config.punishmentCells,
+      config.bonusCells,
+      config.reverseCells,
+      config.restCells,
+      config.restartCells,
+      config.trapCells,
+    ]
+    const totalUsed = assignedCounts.reduce((sum, count) => sum + count, 0)
 
     return (
-      totalUsed <= config.totalCells &&
-      config.punishmentCells >= 0 &&
-      config.bonusCells >= 0 &&
-      config.reverseCells >= 0 &&
-      config.restCells >= 0 &&
-      config.restartCells >= 0 &&
-      config.trapCells >= 0 &&
-      config.totalCells >= 20
+      Number.isInteger(config.totalCells) &&
+      config.totalCells >= 20 &&
+      config.totalCells <= 100 &&
+      assignedCounts.every(count => Number.isInteger(count) && count >= 0) &&
+      totalUsed <= config.totalCells - 2
     )
   }
 

--- a/src/services/gameService.ts
+++ b/src/services/gameService.ts
@@ -14,6 +14,8 @@ import { GAME_CONFIG } from '../config/gameConfig'
 import { SecureRandom } from '../utils/secureRandom'
 import { devLog } from '../utils/logger'
 
+type BoardEffectCountField = Exclude<keyof BoardConfig, 'totalCells'>
+
 export class GameService {
   private static latestBoard: BoardCell[] = []
 
@@ -414,6 +416,54 @@ export class GameService {
       assignedCounts.every(count => Number.isInteger(count) && count >= 0) &&
       totalUsed <= config.totalCells - 2
     )
+  }
+
+  static createAutoBoardConfig(totalCells: number): BoardConfig {
+    if (!Number.isInteger(totalCells) || totalCells < 20 || totalCells > 100) {
+      throw new Error('自动分配要求总格子数为 20-100 范围内的整数')
+    }
+
+    const assignableCells = totalCells - 2
+    const targets: Array<{ field: BoardEffectCountField; ratio: number }> = [
+      { field: 'punishmentCells', ratio: 0.75 },
+      { field: 'restartCells', ratio: 0.1 },
+      { field: 'bonusCells', ratio: 0.025 },
+      { field: 'reverseCells', ratio: 0.05 },
+      { field: 'restCells', ratio: 0.025 },
+      { field: 'trapCells', ratio: 0.05 },
+    ]
+    const allocations = targets.map((target, index) => {
+      const exact = assignableCells * target.ratio
+      return {
+        ...target,
+        index,
+        count: Math.floor(exact),
+        remainder: exact - Math.floor(exact),
+      }
+    })
+    const assigned = allocations.reduce((sum, allocation) => sum + allocation.count, 0)
+    const remaining = assignableCells - assigned
+    const remainderOrder = [...allocations].sort(
+      (a, b) => b.remainder - a.remainder || a.index - b.index
+    )
+
+    for (let index = 0; index < remaining; index++) {
+      remainderOrder[index].count += 1
+    }
+
+    const config: BoardConfig = {
+      punishmentCells: 0,
+      bonusCells: 0,
+      reverseCells: 0,
+      restCells: 0,
+      restartCells: 0,
+      trapCells: 0,
+      totalCells,
+    }
+    allocations.forEach(allocation => {
+      config[allocation.field] = allocation.count
+    })
+    return config
   }
 
   static rollDice(): number {

--- a/src/services/gameStateHealth.ts
+++ b/src/services/gameStateHealth.ts
@@ -1,0 +1,17 @@
+import type { GameState } from '../types/game'
+
+export interface BlockingOverlayState {
+  takeoffPunishment: boolean
+  trap: boolean
+  bounce: boolean
+  takeoffRelief: boolean
+}
+
+export const hasBlockingOverlay = (overlays: BlockingOverlayState): boolean =>
+  Object.values(overlays).some(Boolean)
+
+export const shouldRecoverMovingState = (
+  gameStatus: GameState['gameStatus'],
+  movingDurationMs: number,
+  overlays: BlockingOverlayState
+): boolean => gameStatus === 'moving' && movingDurationMs > 5000 && !hasBlockingOverlay(overlays)

--- a/src/tests/boardConfig.test.ts
+++ b/src/tests/boardConfig.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { GameService } from '../services/gameService'
+import type { BoardConfig } from '../types/game'
+
+const createValidConfig = (): BoardConfig => ({
+  punishmentCells: 28,
+  bonusCells: 1,
+  reverseCells: 2,
+  restCells: 1,
+  restartCells: 4,
+  trapCells: 2,
+  totalCells: 40,
+})
+
+describe('棋盘配置校验', () => {
+  it('为起点和终点保留两个不可分配格子', () => {
+    const config: BoardConfig = {
+      punishmentCells: 30,
+      bonusCells: 1,
+      reverseCells: 2,
+      restCells: 1,
+      restartCells: 4,
+      trapCells: 2,
+      totalCells: 40,
+    }
+
+    expect(GameService.validateBoardConfig(config)).toBe(false)
+  })
+
+  it('拒绝静默截断无效棋盘配置', () => {
+    const config = createValidConfig()
+    config.trapCells += 1
+
+    expect(() => GameService.createBoard(undefined, config)).toThrowError('棋盘配置无效')
+  })
+
+  it.each([19, 101, 40.5])('拒绝不支持的总格子数 %s', totalCells => {
+    const config = createValidConfig()
+    config.totalCells = totalCells
+
+    expect(GameService.validateBoardConfig(config)).toBe(false)
+  })
+
+  it('接受默认棋盘配置', () => {
+    expect(GameService.validateBoardConfig(createValidConfig())).toBe(true)
+  })
+})

--- a/src/tests/boardConfig.test.ts
+++ b/src/tests/boardConfig.test.ts
@@ -44,4 +44,45 @@ describe('棋盘配置校验', () => {
   it('接受默认棋盘配置', () => {
     expect(GameService.validateBoardConfig(createValidConfig())).toBe(true)
   })
+
+  it.each([
+    [
+      20,
+      {
+        punishmentCells: 14,
+        bonusCells: 0,
+        reverseCells: 1,
+        restCells: 0,
+        restartCells: 2,
+        trapCells: 1,
+        totalCells: 20,
+      },
+    ],
+    [
+      40,
+      {
+        punishmentCells: 28,
+        bonusCells: 1,
+        reverseCells: 2,
+        restCells: 1,
+        restartCells: 4,
+        trapCells: 2,
+        totalCells: 40,
+      },
+    ],
+    [
+      80,
+      {
+        punishmentCells: 58,
+        bonusCells: 2,
+        reverseCells: 4,
+        restCells: 2,
+        restartCells: 8,
+        trapCells: 4,
+        totalCells: 80,
+      },
+    ],
+  ] as const)('为 %s 格棋盘稳定分配目标比例', (totalCells, expected) => {
+    expect(GameService.createAutoBoardConfig(totalCells)).toEqual(expected)
+  })
 })

--- a/src/tests/cache.test.ts
+++ b/src/tests/cache.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { clearAllLocalGameData, LOCAL_GAME_STORAGE_KEYS } from '../utils/cache'
+
+describe('本地游戏数据清理', () => {
+  it('清除配置、玩家、备份和引导偏好使用的实际键名', () => {
+    const values = new Map<string, string>(LOCAL_GAME_STORAGE_KEYS.map(key => [key, 'saved']))
+    const storage = {
+      removeItem(key: string) {
+        values.delete(key)
+      },
+    }
+
+    clearAllLocalGameData(storage)
+
+    expect([...values.keys()]).toEqual([])
+  })
+})

--- a/src/tests/gameStateHealth.test.ts
+++ b/src/tests/gameStateHealth.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { shouldRecoverMovingState } from '../services/gameStateHealth'
+
+const noBlockingOverlay = {
+  takeoffPunishment: false,
+  trap: false,
+  bounce: false,
+  takeoffRelief: false,
+}
+
+describe('游戏移动状态健康检查', () => {
+  it('只在移动状态无覆盖层且超时后恢复', () => {
+    expect(shouldRecoverMovingState('moving', 5001, noBlockingOverlay)).toBe(true)
+    expect(shouldRecoverMovingState('moving', 5000, noBlockingOverlay)).toBe(false)
+    expect(shouldRecoverMovingState('waiting', 5001, noBlockingOverlay)).toBe(false)
+  })
+
+  it.each(['takeoffPunishment', 'trap', 'bounce', 'takeoffRelief'] as const)(
+    '%s 覆盖层显示期间不恢复移动状态',
+    overlay => {
+      expect(
+        shouldRecoverMovingState('moving', 5001, {
+          ...noBlockingOverlay,
+          [overlay]: true,
+        })
+      ).toBe(false)
+    }
+  )
+})

--- a/src/tests/importValidation.test.ts
+++ b/src/tests/importValidation.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { importFromJson, validateImportData } from '../utils/export'
+
+const createValidImport = () => ({
+  version: '1.0.0',
+  exportedAt: '2026-07-11T00:00:00.000Z',
+  gameTitle: '飞行棋配置',
+  data: {
+    playerSettings: {
+      playerCount: 2,
+      playerNames: ['玩家1', '玩家2'],
+    },
+    punishmentConfig: {
+      tools: {
+        手掌: { name: '手掌', intensity: 2, ratio: 100 },
+      },
+      bodyParts: {
+        手心: { name: '手心', sensitivity: 3, ratio: 100 },
+      },
+      positions: {
+        站立: { name: '站立', ratio: 100, compatibleBodyParts: ['手心'] },
+      },
+      minStrikes: 5,
+      maxStrikes: 30,
+      step: 5,
+      maxTakeoffFailures: 5,
+    },
+    boardConfig: {
+      punishmentCells: 28,
+      bonusCells: 1,
+      reverseCells: 2,
+      restCells: 1,
+      restartCells: 4,
+      trapCells: 2,
+      totalCells: 40,
+    },
+    trapConfig: [{ name: '停留', description: '停留一分钟' }],
+  },
+})
+
+const cloneValidImport = () => structuredClone(createValidImport())
+type ImportFixture = ReturnType<typeof createValidImport>
+type FixtureMutation = (data: ImportFixture) => void
+
+const invalidPunishmentMutations: ReadonlyArray<readonly [string, FixtureMutation]> = [
+  ['工具强度', data => void (data.data.punishmentConfig.tools.手掌.intensity = 0)],
+  ['部位耐受度', data => void (data.data.punishmentConfig.bodyParts.手心.sensitivity = 11)],
+  ['工具比例', data => void (data.data.punishmentConfig.tools.手掌.ratio = -1)],
+  ['姿势比例', data => void (data.data.punishmentConfig.positions.站立.ratio = 101)],
+  ['最小次数', data => void (data.data.punishmentConfig.minStrikes = 0)],
+  ['最大次数', data => void (data.data.punishmentConfig.maxStrikes = 101)],
+  ['次数顺序', data => void (data.data.punishmentConfig.minStrikes = 31)],
+  ['次数步长', data => void (data.data.punishmentConfig.step = 0)],
+  ['起飞失败阈值', data => void (data.data.punishmentConfig.maxTakeoffFailures = 11)],
+]
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('导入配置校验', () => {
+  it('接受当前记录格式', () => {
+    expect(validateImportData(createValidImport()).isValid).toBe(true)
+  })
+
+  it('接受受支持的旧数组格式', () => {
+    const data = cloneValidImport()
+    data.data.punishmentConfig.tools = [{ name: '手掌', intensity: 2, ratio: 100 }] as never
+    data.data.punishmentConfig.bodyParts = [{ name: '手心', sensitivity: 3, ratio: 100 }] as never
+    data.data.punishmentConfig.positions = [
+      { name: '站立', ratio: 100, compatibleBodyParts: ['手心'] },
+    ] as never
+
+    expect(validateImportData(data).isValid).toBe(true)
+  })
+
+  it.each([19, 101])('拒绝总格子数 %s', totalCells => {
+    const data = cloneValidImport()
+    data.data.boardConfig.totalCells = totalCells
+
+    expect(validateImportData(data).isValid).toBe(false)
+  })
+
+  it('拒绝占用起点或终点的格子数量', () => {
+    const data = cloneValidImport()
+    data.data.boardConfig.punishmentCells = 30
+
+    expect(validateImportData(data).isValid).toBe(false)
+  })
+
+  it.each(['tools', 'bodyParts', 'positions'] as const)('拒绝空的 %s 配置', field => {
+    const data = cloneValidImport()
+    ;(data.data.punishmentConfig as unknown as Record<string, unknown>)[field] = {}
+
+    expect(validateImportData(data).isValid).toBe(false)
+  })
+
+  it('拒绝空机关配置', () => {
+    const data = cloneValidImport()
+    data.data.trapConfig = []
+
+    expect(validateImportData(data).isValid).toBe(false)
+  })
+
+  it.each(invalidPunishmentMutations)('拒绝超出范围的%s', (_label, mutate) => {
+    const data = cloneValidImport()
+    mutate(data)
+
+    expect(validateImportData(data).isValid).toBe(false)
+  })
+
+  it('拒绝姿势引用不存在的部位', () => {
+    const data = cloneValidImport()
+    data.data.punishmentConfig.positions.站立.compatibleBodyParts = ['不存在的部位']
+
+    expect(validateImportData(data).isValid).toBe(false)
+  })
+
+  it('无效数据不会改写现有本地存储', () => {
+    const values = new Map<string, string>([
+      ['ludo_game_config', 'existing-config'],
+      ['ludo_player_settings', 'existing-players'],
+      ['flying-chess-config-backup', 'existing-backup'],
+    ])
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+    })
+    const before = [...values.entries()]
+    const data = cloneValidImport()
+    data.data.boardConfig.totalCells = 19
+
+    const result = importFromJson(JSON.stringify(data))
+
+    expect(result.success).toBe(false)
+    expect([...values.entries()]).toEqual(before)
+  })
+})

--- a/src/tests/importValidation.test.ts
+++ b/src/tests/importValidation.test.ts
@@ -126,16 +126,23 @@ describe('导入配置校验', () => {
     expect(validateImportData(data).isValid).toBe(false)
   })
 
-  it('拒绝旧数组格式中全部为零的权重', () => {
-    const data = cloneValidImport()
-    data.data.punishmentConfig.tools = [{ name: '手掌', intensity: 2, ratio: 0 }] as never
-    data.data.punishmentConfig.bodyParts = [{ name: '手心', sensitivity: 3, ratio: 0 }] as never
-    data.data.punishmentConfig.positions = [
-      { name: '站立', ratio: 0, compatibleBodyParts: ['手心'] },
-    ] as never
+  it.each(['tools', 'bodyParts', 'positions'] as const)(
+    '拒绝旧数组格式中所有 %s 权重均为零',
+    field => {
+      const data = cloneValidImport()
+      data.data.punishmentConfig.tools = [{ name: '手掌', intensity: 2, ratio: 100 }] as never
+      data.data.punishmentConfig.bodyParts = [{ name: '手心', sensitivity: 3, ratio: 100 }] as never
+      data.data.punishmentConfig.positions = [
+        { name: '站立', ratio: 100, compatibleBodyParts: ['手心'] },
+      ] as never
+      const entries = data.data.punishmentConfig[field] as unknown as Array<{ ratio: number }>
+      entries.forEach(entry => {
+        entry.ratio = 0
+      })
 
-    expect(validateImportData(data).isValid).toBe(false)
-  })
+      expect(validateImportData(data).isValid).toBe(false)
+    }
+  )
 
   it('无效数据不会改写现有本地存储', () => {
     const values = new Map<string, string>([

--- a/src/tests/importValidation.test.ts
+++ b/src/tests/importValidation.test.ts
@@ -116,6 +116,27 @@ describe('导入配置校验', () => {
     expect(validateImportData(data).isValid).toBe(false)
   })
 
+  it.each(['tools', 'bodyParts', 'positions'] as const)('拒绝所有 %s 权重均为零', field => {
+    const data = cloneValidImport()
+    const entries = data.data.punishmentConfig[field] as Record<string, { ratio: number }>
+    Object.values(entries).forEach(entry => {
+      entry.ratio = 0
+    })
+
+    expect(validateImportData(data).isValid).toBe(false)
+  })
+
+  it('拒绝旧数组格式中全部为零的权重', () => {
+    const data = cloneValidImport()
+    data.data.punishmentConfig.tools = [{ name: '手掌', intensity: 2, ratio: 0 }] as never
+    data.data.punishmentConfig.bodyParts = [{ name: '手心', sensitivity: 3, ratio: 0 }] as never
+    data.data.punishmentConfig.positions = [
+      { name: '站立', ratio: 0, compatibleBodyParts: ['手心'] },
+    ] as never
+
+    expect(validateImportData(data).isValid).toBe(false)
+  })
+
   it('无效数据不会改写现有本地存储', () => {
     const values = new Map<string, string>([
       ['ludo_game_config', 'existing-config'],
@@ -132,6 +153,27 @@ describe('导入配置校验', () => {
     data.data.boardConfig.totalCells = 19
 
     const result = importFromJson(JSON.stringify(data))
+
+    expect(result.success).toBe(false)
+    expect([...values.entries()]).toEqual(before)
+  })
+
+  it('即使调用方关闭校验选项，无效数据仍不会写入本地存储', () => {
+    const values = new Map<string, string>([
+      ['ludo_game_config', 'existing-config'],
+      ['ludo_player_settings', 'existing-players'],
+      ['flying-chess-config-backup', 'existing-backup'],
+    ])
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+    })
+    const before = [...values.entries()]
+    const data = cloneValidImport()
+    data.data.boardConfig.totalCells = 19
+
+    const result = importFromJson(JSON.stringify(data), { validateData: false })
 
     expect(result.success).toBe(false)
     expect([...values.entries()]).toEqual(before)

--- a/src/types/export.ts
+++ b/src/types/export.ts
@@ -77,7 +77,7 @@ export interface QRCodeOptions {
 
 // 导入选项
 export interface ImportOptions {
-  validateData: boolean // 是否验证数据
+  validateData: boolean // 向后兼容字段；公共导入始终验证数据
   mergeMode: 'replace' | 'merge' | 'selective' // 导入模式
   backupCurrent: boolean // 是否备份当前配置
 }

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,7 +1,16 @@
-import { BoardConfig, PunishmentConfig, TrapAction } from '../types/game'
+import type { BoardConfig, PunishmentConfig, TrapAction } from '../types/game'
 
 // 缓存键名
-const STORAGE_KEY = 'ludo_game_config'
+export const GAME_CONFIG_STORAGE_KEY = 'ludo_game_config'
+export const PLAYER_SETTINGS_STORAGE_KEY = 'ludo_player_settings'
+export const CONFIG_BACKUP_STORAGE_KEY = 'flying-chess-config-backup'
+export const LOCAL_GAME_STORAGE_KEYS = [
+  GAME_CONFIG_STORAGE_KEY,
+  PLAYER_SETTINGS_STORAGE_KEY,
+  CONFIG_BACKUP_STORAGE_KEY,
+  'hasShownGuide',
+  'autoGuideEnabled',
+] as const
 // 12 个月有效期（毫秒）
 const DEFAULT_TTL = 1000 * 60 * 60 * 24 * 365
 
@@ -18,7 +27,7 @@ export interface CachedConfig {
 export function saveConfig(data: Omit<CachedConfig, 'savedAt'>) {
   const payload: CachedConfig = { ...data, savedAt: Date.now() }
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+    localStorage.setItem(GAME_CONFIG_STORAGE_KEY, JSON.stringify(payload))
   } catch (err) {
     console.warn('保存配置到 localStorage 失败:', err)
   }
@@ -30,13 +39,13 @@ export function saveConfig(data: Omit<CachedConfig, 'savedAt'>) {
  * @returns 配置或 null
  */
 export function loadConfig(ttl: number = DEFAULT_TTL): CachedConfig | null {
-  const raw = localStorage.getItem(STORAGE_KEY)
+  const raw = localStorage.getItem(GAME_CONFIG_STORAGE_KEY)
   if (!raw) return null
   try {
     const cached: CachedConfig = JSON.parse(raw)
     if (Date.now() - cached.savedAt > ttl) {
       // 过期，清理
-      localStorage.removeItem(STORAGE_KEY)
+      localStorage.removeItem(GAME_CONFIG_STORAGE_KEY)
       return null
     }
     return cached
@@ -50,7 +59,11 @@ export function loadConfig(ttl: number = DEFAULT_TTL): CachedConfig | null {
  * 清除本地缓存配置
  */
 export function clearConfig() {
-  localStorage.removeItem(STORAGE_KEY)
+  localStorage.removeItem(GAME_CONFIG_STORAGE_KEY)
+}
+
+export function clearAllLocalGameData(storage: Pick<Storage, 'removeItem'> = localStorage): void {
+  LOCAL_GAME_STORAGE_KEYS.forEach(key => storage.removeItem(key))
 }
 
 // ================= 玩家设置缓存 =================
@@ -60,18 +73,16 @@ export interface PlayerSettings {
   playerNames: string[]
 }
 
-const PLAYER_KEY = 'ludo_player_settings'
-
 export function savePlayerSettings(settings: PlayerSettings) {
   try {
-    localStorage.setItem(PLAYER_KEY, JSON.stringify(settings))
+    localStorage.setItem(PLAYER_SETTINGS_STORAGE_KEY, JSON.stringify(settings))
   } catch (err) {
     console.warn('保存玩家设置失败:', err)
   }
 }
 
 export function loadPlayerSettings(): PlayerSettings | null {
-  const raw = localStorage.getItem(PLAYER_KEY)
+  const raw = localStorage.getItem(PLAYER_SETTINGS_STORAGE_KEY)
   if (!raw) return null
   try {
     return JSON.parse(raw) as PlayerSettings

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -21,6 +21,7 @@ import {
 } from './cache'
 import { SecureRandom } from './secureRandom'
 import { devLog } from './logger'
+import { validateImportedConfigData } from './importValidation'
 import type { QRCodeToDataURLOptions } from 'qrcode'
 import QRCode from 'qrcode'
 import jsQR from 'jsqr'
@@ -370,24 +371,7 @@ export function validateImportData(data: unknown): ValidationResult {
 
   const configData = rawConfigData as Record<string, unknown>
 
-  // 验证玩家设置
-  const rawPlayerSettings = configData.playerSettings
-  if (rawPlayerSettings && typeof rawPlayerSettings === 'object') {
-    const playerSettings = rawPlayerSettings as { playerCount?: unknown; playerNames?: unknown }
-    if (
-      typeof playerSettings.playerCount !== 'number' ||
-      playerSettings.playerCount < 2 ||
-      playerSettings.playerCount > 4
-    ) {
-      errors.push('玩家数量必须在2-4之间')
-    }
-    if (
-      !Array.isArray(playerSettings.playerNames) ||
-      playerSettings.playerNames.length !== playerSettings.playerCount
-    ) {
-      errors.push('玩家姓名数量与玩家数量不匹配')
-    }
-  }
+  errors.push(...validateImportedConfigData(configData))
 
   return {
     isValid: errors.length === 0,

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -475,20 +475,16 @@ export function importFromJson(
   jsonString: string,
   options: Partial<ImportOptions> = {}
 ): ImportResult {
-  const importOptions = { ...DEFAULT_IMPORT_OPTIONS, ...options }
-
   try {
     // 解析JSON
     const data = JSON.parse(jsonString)
 
-    // 验证数据
-    if (importOptions.validateData) {
-      const validation = validateImportData(data)
-      if (!validation.isValid) {
-        return {
-          success: false,
-          error: `数据验证失败: ${validation.errors.join(', ')}`,
-        }
+    // 所有公共导入都必须先验证，避免任何选项绕过持久化边界
+    const validation = validateImportData(data)
+    if (!validation.isValid) {
+      return {
+        success: false,
+        error: `数据验证失败: ${validation.errors.join(', ')}`,
       }
     }
 

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -16,6 +16,7 @@ import {
   loadConfig,
   savePlayerSettings,
   saveConfig,
+  CONFIG_BACKUP_STORAGE_KEY,
   type CachedConfig,
 } from './cache'
 import { SecureRandom } from './secureRandom'
@@ -423,7 +424,7 @@ function performImport(data: ExportData, options: Partial<ImportOptions> = {}): 
           },
           undefined
         )
-        localStorage.setItem('flying-chess-config-backup', JSON.stringify(backupData))
+        localStorage.setItem(CONFIG_BACKUP_STORAGE_KEY, JSON.stringify(backupData))
       }
     }
 
@@ -586,7 +587,7 @@ export async function importFromQRCode(
 // 恢复备份配置
 export function restoreBackup(): ImportResult {
   try {
-    const backupString = localStorage.getItem('flying-chess-config-backup')
+    const backupString = localStorage.getItem(CONFIG_BACKUP_STORAGE_KEY)
     if (!backupString) {
       return {
         success: false,

--- a/src/utils/importValidation.ts
+++ b/src/utils/importValidation.ts
@@ -66,6 +66,18 @@ function readNamedEntries(raw: unknown, path: string, errors: string[]): NamedEn
   })
 }
 
+function requirePositiveWeight(entries: NamedEntry[], path: string, errors: string[]): void {
+  if (
+    entries.length > 0 &&
+    !entries.some(({ value }) => validateWeightWithoutReporting(value.ratio))
+  ) {
+    errors.push(`${path} 至少需要一个大于 0 的 ratio`)
+  }
+}
+
+const validateWeightWithoutReporting = (value: unknown): boolean =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0 && value <= 100
+
 function validatePlayerSettings(raw: unknown, errors: string[]): void {
   if (!isRecord(raw)) {
     errors.push('data.playerSettings 必须是对象')
@@ -132,6 +144,7 @@ function validatePunishmentConfig(raw: unknown, errors: string[]): void {
       max: 100,
     })
   })
+  requirePositiveWeight(tools, 'data.punishmentConfig.tools', errors)
 
   bodyParts.forEach(({ name, value }) => {
     validateNumber(
@@ -145,6 +158,7 @@ function validatePunishmentConfig(raw: unknown, errors: string[]): void {
       max: 100,
     })
   })
+  requirePositiveWeight(bodyParts, 'data.punishmentConfig.bodyParts', errors)
 
   const bodyPartNames = new Set(bodyParts.map(entry => entry.name))
   positions.forEach(({ name, value }) => {
@@ -169,6 +183,7 @@ function validatePunishmentConfig(raw: unknown, errors: string[]): void {
       }
     })
   })
+  requirePositiveWeight(positions, 'data.punishmentConfig.positions', errors)
 
   const minStrikes = raw.minStrikes
   const maxStrikes = raw.maxStrikes

--- a/src/utils/importValidation.ts
+++ b/src/utils/importValidation.ts
@@ -1,0 +1,287 @@
+import { GameService } from '../services/gameService'
+import type { BoardConfig } from '../types/game'
+
+type UnknownRecord = Record<string, unknown>
+
+interface NamedEntry {
+  name: string
+  value: UnknownRecord
+}
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0
+
+function validateNumber(
+  value: unknown,
+  path: string,
+  errors: string[],
+  { min, max, integer = false }: { min: number; max: number; integer?: boolean }
+): value is number {
+  const valid =
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    (!integer || Number.isInteger(value)) &&
+    value >= min &&
+    value <= max
+
+  if (!valid) {
+    errors.push(`${path} 必须是 ${min}-${max} 范围内的${integer ? '整数' : '数字'}`)
+  }
+  return valid
+}
+
+function readNamedEntries(raw: unknown, path: string, errors: string[]): NamedEntry[] {
+  if (Array.isArray(raw)) {
+    if (raw.length === 0) {
+      errors.push(`${path} 不能为空`)
+      return []
+    }
+
+    return raw.flatMap((entry, index) => {
+      if (!isRecord(entry) || !isNonEmptyString(entry.name)) {
+        errors.push(`${path}[${index}].name 必须是非空字符串`)
+        return []
+      }
+      return [{ name: entry.name, value: entry }]
+    })
+  }
+
+  if (!isRecord(raw) || Object.keys(raw).length === 0) {
+    errors.push(`${path} 必须是非空记录或数组`)
+    return []
+  }
+
+  return Object.entries(raw).flatMap(([name, entry]) => {
+    if (!isNonEmptyString(name) || !isRecord(entry)) {
+      errors.push(`${path}.${name || '<空名称>'} 必须是配置对象`)
+      return []
+    }
+    if (entry.name !== undefined && !isNonEmptyString(entry.name)) {
+      errors.push(`${path}.${name}.name 必须是非空字符串`)
+    }
+    return [{ name, value: entry }]
+  })
+}
+
+function validatePlayerSettings(raw: unknown, errors: string[]): void {
+  if (!isRecord(raw)) {
+    errors.push('data.playerSettings 必须是对象')
+    return
+  }
+
+  const countValid =
+    typeof raw.playerCount === 'number' && Number.isInteger(raw.playerCount) && raw.playerCount >= 1
+  if (!countValid) {
+    errors.push('data.playerSettings.playerCount 必须是至少为 1 的整数')
+  }
+
+  if (
+    !Array.isArray(raw.playerNames) ||
+    raw.playerNames.length !== raw.playerCount ||
+    !raw.playerNames.every(isNonEmptyString)
+  ) {
+    errors.push('data.playerSettings.playerNames 必须与玩家数量匹配且名称不能为空')
+  }
+}
+
+function validateBoardConfig(raw: unknown, errors: string[]): void {
+  if (!isRecord(raw)) {
+    errors.push('data.boardConfig 必须是对象')
+    return
+  }
+
+  const fields = [
+    'punishmentCells',
+    'bonusCells',
+    'reverseCells',
+    'restCells',
+    'restartCells',
+    'trapCells',
+    'totalCells',
+  ] as const
+  const allNumeric = fields.every(field => typeof raw[field] === 'number')
+
+  if (!allNumeric || !GameService.validateBoardConfig(raw as unknown as BoardConfig)) {
+    errors.push(
+      'data.boardConfig 格子数必须为整数，总格子数须为 20-100，且需为起点和终点预留两个格子'
+    )
+  }
+}
+
+function validatePunishmentConfig(raw: unknown, errors: string[]): void {
+  if (!isRecord(raw)) {
+    errors.push('data.punishmentConfig 必须是对象')
+    return
+  }
+
+  const tools = readNamedEntries(raw.tools, 'data.punishmentConfig.tools', errors)
+  const bodyParts = readNamedEntries(raw.bodyParts, 'data.punishmentConfig.bodyParts', errors)
+  const positions = readNamedEntries(raw.positions, 'data.punishmentConfig.positions', errors)
+
+  tools.forEach(({ name, value }) => {
+    validateNumber(value.intensity, `data.punishmentConfig.tools.${name}.intensity`, errors, {
+      min: 1,
+      max: 10,
+      integer: true,
+    })
+    validateNumber(value.ratio, `data.punishmentConfig.tools.${name}.ratio`, errors, {
+      min: 0,
+      max: 100,
+    })
+  })
+
+  bodyParts.forEach(({ name, value }) => {
+    validateNumber(
+      value.sensitivity,
+      `data.punishmentConfig.bodyParts.${name}.sensitivity`,
+      errors,
+      { min: 1, max: 10, integer: true }
+    )
+    validateNumber(value.ratio, `data.punishmentConfig.bodyParts.${name}.ratio`, errors, {
+      min: 0,
+      max: 100,
+    })
+  })
+
+  const bodyPartNames = new Set(bodyParts.map(entry => entry.name))
+  positions.forEach(({ name, value }) => {
+    validateNumber(value.ratio, `data.punishmentConfig.positions.${name}.ratio`, errors, {
+      min: 0,
+      max: 100,
+    })
+
+    if (value.compatibleBodyParts === undefined) return
+    if (
+      !Array.isArray(value.compatibleBodyParts) ||
+      !value.compatibleBodyParts.every(isNonEmptyString)
+    ) {
+      errors.push(`data.punishmentConfig.positions.${name}.compatibleBodyParts 必须是字符串数组`)
+      return
+    }
+    value.compatibleBodyParts.forEach(bodyPartName => {
+      if (!bodyPartNames.has(bodyPartName)) {
+        errors.push(
+          `data.punishmentConfig.positions.${name}.compatibleBodyParts 引用了不存在的部位 "${bodyPartName}"`
+        )
+      }
+    })
+  })
+
+  const minStrikes = raw.minStrikes
+  const maxStrikes = raw.maxStrikes
+  const step = raw.step
+  const minValid = validateNumber(minStrikes, 'data.punishmentConfig.minStrikes', errors, {
+    min: 1,
+    max: 100,
+    integer: true,
+  })
+  const maxValid = validateNumber(maxStrikes, 'data.punishmentConfig.maxStrikes', errors, {
+    min: 1,
+    max: 100,
+    integer: true,
+  })
+  const stepValid = validateNumber(step, 'data.punishmentConfig.step', errors, {
+    min: 1,
+    max: 100,
+    integer: true,
+  })
+  validateNumber(raw.maxTakeoffFailures, 'data.punishmentConfig.maxTakeoffFailures', errors, {
+    min: 1,
+    max: 10,
+    integer: true,
+  })
+
+  if (minValid && maxValid && minStrikes > maxStrikes) {
+    errors.push('data.punishmentConfig.minStrikes 不能大于 maxStrikes')
+  }
+  if (
+    minValid &&
+    maxValid &&
+    stepValid &&
+    Math.ceil(minStrikes / step) > Math.floor(maxStrikes / step)
+  ) {
+    errors.push('data.punishmentConfig.step 在惩罚次数范围内无法产生有效值')
+  }
+
+  const validToolIntensities = tools
+    .map(entry => entry.value.intensity)
+    .filter((value): value is number => typeof value === 'number' && value >= 1 && value <= 10)
+  const validSensitivities = bodyParts
+    .map(entry => entry.value.sensitivity)
+    .filter((value): value is number => typeof value === 'number' && value >= 1 && value <= 10)
+  if (
+    validToolIntensities.length === tools.length &&
+    validSensitivities.length === bodyParts.length
+  ) {
+    tools.forEach(({ name, value }) => {
+      if (!validSensitivities.some(sensitivity => sensitivity >= (value.intensity as number))) {
+        errors.push(`data.punishmentConfig.tools.${name} 没有可承受其强度的部位`)
+      }
+    })
+    bodyParts.forEach(({ name, value }) => {
+      if (!validToolIntensities.some(intensity => intensity <= (value.sensitivity as number))) {
+        errors.push(`data.punishmentConfig.bodyParts.${name} 没有可使用的工具`)
+      }
+    })
+  }
+}
+
+function validateTrapConfig(raw: unknown, errors: string[]): void {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    errors.push('data.trapConfig 必须是非空数组')
+    return
+  }
+
+  raw.forEach((trap, index) => {
+    if (!isRecord(trap) || !isNonEmptyString(trap.name) || !isNonEmptyString(trap.description)) {
+      errors.push(`data.trapConfig[${index}] 必须包含非空的 name 和 description`)
+    }
+  })
+}
+
+function validateBoardContent(raw: unknown, errors: string[]): void {
+  if (
+    !isRecord(raw) ||
+    !isNonEmptyString(raw.seed) ||
+    !Array.isArray(raw.board) ||
+    raw.board.length === 0
+  ) {
+    errors.push('data.boardContent 必须包含非空 seed 和 board 数组')
+  }
+}
+
+export function validateImportedConfigData(configData: UnknownRecord): string[] {
+  const errors: string[] = []
+
+  if (configData.playerSettings !== undefined) {
+    validatePlayerSettings(configData.playerSettings, errors)
+  }
+  if (configData.punishmentConfig !== undefined) {
+    validatePunishmentConfig(configData.punishmentConfig, errors)
+  }
+  if (configData.boardConfig !== undefined) {
+    validateBoardConfig(configData.boardConfig, errors)
+  }
+  if (configData.trapConfig !== undefined) {
+    validateTrapConfig(configData.trapConfig, errors)
+  }
+  if (configData.boardContent !== undefined) {
+    validateBoardContent(configData.boardContent, errors)
+  }
+
+  const knownSections = [
+    'playerSettings',
+    'punishmentConfig',
+    'boardConfig',
+    'trapConfig',
+    'boardContent',
+  ]
+  if (!knownSections.some(section => configData[section] !== undefined)) {
+    errors.push('data 至少需要包含一个可导入的配置项')
+  }
+
+  return errors
+}

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -23,3 +23,16 @@ test('desktop app fills the viewport width', async ({ page }, testInfo) => {
 
   expect(appWidth).toBeGreaterThanOrEqual(viewportWidth - 1)
 })
+
+test('mobile page has no horizontal overflow', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'mobile-chrome')
+
+  await page.goto('/flying-chess/')
+
+  const dimensions = await page.evaluate(() => ({
+    viewportWidth: window.innerWidth,
+    documentWidth: document.documentElement.scrollWidth,
+  }))
+
+  expect(dimensions.documentWidth).toBeLessThanOrEqual(dimensions.viewportWidth)
+})

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -63,3 +63,68 @@ test('total cell changes update the generated board', async ({ page }, testInfo)
 
   expect(state).toEqual({ configuredTotalCells: 80, boardLength: 80 })
 })
+
+test('clear local game data removes every persisted game key', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await page.goto('/flying-chess/')
+  const storageKeys = [
+    'ludo_game_config',
+    'ludo_player_settings',
+    'flying-chess-config-backup',
+    'hasShownGuide',
+    'autoGuideEnabled',
+  ]
+  await page.evaluate(keys => {
+    keys.forEach(key => localStorage.setItem(key, 'persisted'))
+  }, storageKeys)
+
+  await page.locator('.clear-cache-btn').click()
+
+  const remainingValues = await page.evaluate(
+    keys => keys.map(key => localStorage.getItem(key)),
+    storageKeys
+  )
+  expect(remainingValues).toEqual(storageKeys.map(() => null))
+  await expect(page.locator('.clear-success-toast')).toContainText('本地游戏数据已清除')
+})
+
+test('invalid import leaves existing local data unchanged', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await page.goto('/flying-chess/')
+  const existingData = {
+    ludo_game_config: 'existing-config',
+    ludo_player_settings: 'existing-players',
+    'flying-chess-config-backup': 'existing-backup',
+  }
+  await page.evaluate(entries => {
+    Object.entries(entries).forEach(([key, value]) => localStorage.setItem(key, value))
+  }, existingData)
+
+  await page.locator('.guide-controls .export-btn').click()
+  await page.getByRole('button', { name: '导入', exact: true }).click()
+  await page.locator('.json-textarea').fill(
+    JSON.stringify({
+      version: '1.0.0',
+      data: {
+        boardConfig: {
+          punishmentCells: 18,
+          bonusCells: 0,
+          reverseCells: 0,
+          restCells: 0,
+          restartCells: 0,
+          trapCells: 0,
+          totalCells: 19,
+        },
+      },
+    })
+  )
+  await page.locator('.import-text-btn').click()
+
+  await expect(page.locator('.import-feedback--error')).toBeVisible()
+  const storedData = await page.evaluate(keys => {
+    return Object.fromEntries(keys.map(key => [key, localStorage.getItem(key)]))
+  }, Object.keys(existingData))
+  expect(storedData).toEqual(existingData)
+})

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -90,15 +90,15 @@ test('automatic board distribution reserves start and finish', async ({ page }, 
       }
     ).gameState.boardConfig
   })
-  const assignedCells =
-    boardConfig.punishmentCells +
-    boardConfig.bonusCells +
-    boardConfig.reverseCells +
-    boardConfig.restCells +
-    boardConfig.restartCells +
-    boardConfig.trapCells
-
-  expect(assignedCells).toBe(boardConfig.totalCells - 2)
+  expect(boardConfig).toEqual({
+    punishmentCells: 58,
+    bonusCells: 2,
+    reverseCells: 4,
+    restCells: 2,
+    restartCells: 8,
+    trapCells: 4,
+    totalCells: 80,
+  })
 })
 
 test('default board reports no unassigned effect cells', async ({ page }, testInfo) => {
@@ -116,27 +116,42 @@ test('movement watchdog preserves a turn while a trap overlay is active', async 
   test.skip(testInfo.project.name !== 'desktop-chrome')
 
   await page.goto('/flying-chess/')
-  await page.evaluate(() => {
+  const states = await page.evaluate(() => {
     const debugWindow = window as typeof window & {
       gameState: { gameStatus: string }
       showTrapDisplay: { value: boolean }
+      checkGameStateHealth: () => void
     }
-    debugWindow.gameState.gameStatus = 'moving'
-    debugWindow.showTrapDisplay.value = true
+    const originalNow = Date.now
+    const startedAt = originalNow()
+
+    try {
+      Date.now = () => startedAt
+      debugWindow.gameState.gameStatus = 'moving'
+      debugWindow.showTrapDisplay.value = true
+      debugWindow.checkGameStateHealth()
+      Date.now = () => startedAt + 6001
+      debugWindow.checkGameStateHealth()
+      const withOverlay = debugWindow.gameState.gameStatus
+
+      debugWindow.showTrapDisplay.value = false
+      debugWindow.checkGameStateHealth()
+      Date.now = () => startedAt + 12002
+      debugWindow.checkGameStateHealth()
+
+      return {
+        withOverlay,
+        afterOverlay: debugWindow.gameState.gameStatus,
+      }
+    } finally {
+      Date.now = originalNow
+    }
   })
 
-  // 先让 watchdog 运行一次，再把时间推进超过恢复阈值。
-  await page.waitForTimeout(2200)
-  await page.evaluate(() => {
-    const future = Date.now() + 6000
-    Date.now = () => future
+  expect(states).toEqual({
+    withOverlay: 'moving',
+    afterOverlay: 'waiting',
   })
-  await page.waitForTimeout(2200)
-
-  const status = await page.evaluate(() => {
-    return (window as typeof window & { gameState: { gameStatus: string } }).gameState.gameStatus
-  })
-  expect(status).toBe('moving')
 })
 
 test('clear local game data removes every persisted game key', async ({ page }, testInfo) => {
@@ -202,4 +217,62 @@ test('invalid import leaves existing local data unchanged', async ({ page }, tes
     return Object.fromEntries(keys.map(key => [key, localStorage.getItem(key)]))
   }, Object.keys(existingData))
   expect(storedData).toEqual(existingData)
+})
+
+test('invalid legacy board cache does not break startup', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  const migrationPage = await page.context().newPage()
+  const pageErrors: string[] = []
+  migrationPage.on('pageerror', error => pageErrors.push(error.message))
+  await migrationPage.addInitScript(() => {
+    localStorage.setItem(
+      'ludo_game_config',
+      JSON.stringify({
+        boardConfig: {
+          punishmentCells: 30,
+          bonusCells: 1,
+          reverseCells: 2,
+          restCells: 1,
+          restartCells: 4,
+          trapCells: 2,
+          totalCells: 40,
+        },
+        savedAt: Date.now(),
+      })
+    )
+  })
+
+  await migrationPage.goto('/flying-chess/')
+  await expect(migrationPage.locator('.start-btn')).toBeVisible()
+  const boardState = await migrationPage.evaluate(() => {
+    const gameState = (
+      window as typeof window & {
+        gameState: { boardConfig: { totalCells: number }; board: unknown[] }
+      }
+    ).gameState
+    return {
+      totalCells: gameState.boardConfig.totalCells,
+      boardLength: gameState.board.length,
+    }
+  })
+
+  expect(boardState).toEqual({ totalCells: 40, boardLength: 40 })
+  const repairedBoardConfig = await migrationPage.evaluate(() => {
+    const cached = JSON.parse(localStorage.getItem('ludo_game_config') ?? '{}') as {
+      boardConfig?: unknown
+    }
+    return cached.boardConfig
+  })
+  expect(repairedBoardConfig).toEqual({
+    punishmentCells: 28,
+    bonusCells: 1,
+    reverseCells: 2,
+    restCells: 1,
+    restartCells: 4,
+    trapCells: 2,
+    totalCells: 40,
+  })
+  expect(pageErrors).toEqual([])
+  await migrationPage.close()
 })

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.clear()
+    localStorage.setItem('autoGuideEnabled', 'false')
+    localStorage.setItem(
+      'hasShownGuide',
+      JSON.stringify(['intro', 'board_settings', 'settings', 'game'])
+    )
+  })
+})
+
+test('desktop app fills the viewport width', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await page.goto('/flying-chess/')
+
+  const viewportWidth = await page.evaluate(() => window.innerWidth)
+  const appWidth = await page
+    .locator('.app')
+    .evaluate(element => element.getBoundingClientRect().width)
+
+  expect(appWidth).toBeGreaterThanOrEqual(viewportWidth - 1)
+})

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -36,3 +36,30 @@ test('mobile page has no horizontal overflow', async ({ page }, testInfo) => {
 
   expect(dimensions.documentWidth).toBeLessThanOrEqual(dimensions.viewportWidth)
 })
+
+test('total cell changes update the generated board', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await page.goto('/flying-chess/')
+  await page.locator('.start-btn').click()
+
+  const totalCellsInput = page.locator('.config-item', { hasText: '总格子数' }).locator('input')
+  await totalCellsInput.fill('80')
+
+  await expect(totalCellsInput).toHaveValue('80')
+
+  const state = await page.evaluate(() => {
+    const gameState = (
+      window as typeof window & {
+        gameState: { boardConfig: { totalCells: number }; board: unknown[] }
+      }
+    ).gameState
+
+    return {
+      configuredTotalCells: gameState.boardConfig.totalCells,
+      boardLength: gameState.board.length,
+    }
+  })
+
+  expect(state).toEqual({ configuredTotalCells: 80, boardLength: 80 })
+})

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -64,6 +64,81 @@ test('total cell changes update the generated board', async ({ page }, testInfo)
   expect(state).toEqual({ configuredTotalCells: 80, boardLength: 80 })
 })
 
+test('automatic board distribution reserves start and finish', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await page.goto('/flying-chess/')
+  await page.locator('.start-btn').click()
+  const totalCellsInput = page.locator('.config-item', { hasText: '总格子数' }).locator('input')
+  await totalCellsInput.fill('80')
+  await page.getByRole('button', { name: /自动分配/ }).click()
+
+  const boardConfig = await page.evaluate(() => {
+    return (
+      window as typeof window & {
+        gameState: {
+          boardConfig: {
+            punishmentCells: number
+            bonusCells: number
+            reverseCells: number
+            restCells: number
+            restartCells: number
+            trapCells: number
+            totalCells: number
+          }
+        }
+      }
+    ).gameState.boardConfig
+  })
+  const assignedCells =
+    boardConfig.punishmentCells +
+    boardConfig.bonusCells +
+    boardConfig.reverseCells +
+    boardConfig.restCells +
+    boardConfig.restartCells +
+    boardConfig.trapCells
+
+  expect(assignedCells).toBe(boardConfig.totalCells - 2)
+})
+
+test('default board reports no unassigned effect cells', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await page.goto('/flying-chess/')
+  await page.locator('.start-btn').click()
+
+  await expect(page.getByText('剩余可用格子：0 格')).toBeVisible()
+})
+
+test('movement watchdog preserves a turn while a trap overlay is active', async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await page.goto('/flying-chess/')
+  await page.evaluate(() => {
+    const debugWindow = window as typeof window & {
+      gameState: { gameStatus: string }
+      showTrapDisplay: { value: boolean }
+    }
+    debugWindow.gameState.gameStatus = 'moving'
+    debugWindow.showTrapDisplay.value = true
+  })
+
+  // 先让 watchdog 运行一次，再把时间推进超过恢复阈值。
+  await page.waitForTimeout(2200)
+  await page.evaluate(() => {
+    const future = Date.now() + 6000
+    Date.now = () => future
+  })
+  await page.waitForTimeout(2200)
+
+  const status = await page.evaluate(() => {
+    return (window as typeof window & { gameState: { gameStatus: string } }).gameState.gameStatus
+  })
+  expect(status).toBe('moving')
+})
+
 test('clear local game data removes every persisted game key', async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== 'desktop-chrome')
 


### PR DESCRIPTION
## Summary

- restore full-width desktop layout and add repeatable desktop/mobile Playwright coverage
- make board size and automatic effect distribution authoritative while reserving start and finish and preserving the intended punishment ratio
- keep legitimate punishment/trap/bounce/relief overlays from being mistaken for a stuck turn
- clear the actual local game keys and repair incompatible legacy board caches without adding any online/session model
- validate every public JSON/QR import before persistence, including current record and legacy array formats

## Why

The previous UI could display configuration values that were not applied to the generated board, delete stale storage keys instead of real local data, reset valid in-progress overlays, and persist malformed imports. These failures undermined trust in a private, local-only game even though the punishment density and takeoff-failure punishment were intentional gameplay.

## Scope guardrails

- preserves the single shared model for every player count
- preserves takeoff-failure punishment and current punishment density
- adds no accounts, rooms, cloud storage, remote synchronization, or fixed player roles

## Validation

- `npm test`: 52/52 passed
- `npm run test:e2e`: 9 passed; 9 project-specific skips across desktop/mobile Chrome
- `npm run type-check`: passed
- `npm run lint:check`: 0 errors; 20 pre-existing warnings
- production `npm run build`: passed
- Prettier check for all MR-owned source/docs/test files: passed
- independent final code review: 0 Critical, 0 Important, 0 Minor

## Known baseline warnings

- the repository-wide Prettier command already fails on 10 files present on `origin/master`; this MR does not reformat unrelated files
- the production build retains existing bundle-size and stale Browserslist-data warnings
