### PR TITLE
feat: model trustworthy rule resolution

### DIFF
--- a/docs/plans/2026-07-11-rule-resolution-design.md
+++ b/docs/plans/2026-07-11-rule-resolution-design.md
@@ -1,0 +1,74 @@
+# Trustworthy Rule Resolution Design
+
+**Status:** Approved on 2026-07-11
+
+## Goal
+
+Make every gameplay trigger resolve into one immutable, compatibility-aware result before the UI displays or acknowledges it. The same result must supply the target, executor, count, effect, and completion state throughout the turn.
+
+## Constraints
+
+- Keep one local-only game model for every player count.
+- Preserve current punishment density and takeoff-failure punishment.
+- Do not add accounts, rooms, synchronization, fixed roles, or a separate two-player mode.
+- Do not add a count-selection UI in this MR.
+- Do not infer behavior from action descriptions.
+
+## Chosen Architecture
+
+Add a pure rule-resolution layer that receives the current player, player order, dice value, board cell or takeoff source, and punishment configuration. It returns a `ResolvedRuleResult` with no random work left for the UI to perform.
+
+The result carries:
+
+- source: takeoff failure, board punishment, dynamic board punishment, trap, rest, movement, restart, or bounce;
+- actor, target, and executor indices when applicable;
+- a fixed punishment action when its count is known;
+- a structured pending external-count state for `other_player_choice`;
+- a structured effect and explicit acknowledgement requirement for traps;
+- an explicit turn consequence, including skipped turns for rest effects.
+
+The App component remains the orchestrator: it displays the already-resolved result, records acknowledgement, applies the deterministic state transition, and advances the turn. It does not select a target, executor, compatible combination, or count.
+
+## Dynamic Rule Semantics
+
+| Dynamic rule | MR2 result |
+| --- | --- |
+| `dice_multiplier` | Fixed count equals dice value multiplied by the configured multiplier. |
+| `previous_player` | Target resolves to the preceding player in circular order. |
+| `next_player` | Target resolves to the following player in circular order. |
+| `other_player_choice` | Target remains the triggering player; result is `awaiting_external_count` with the configured min, max, step and eligible chooser indices. No value is invented or randomized. |
+
+For a single-player game, previous, next, and eligible-other lookups safely fall back to the current player or no executor as appropriate. This is a technical fallback, not a role model.
+
+Existing confirmation means the people playing locally have completed the externally agreed action. MR3 will add explicit choice controls that attach a selected count to an `awaiting_external_count` result before completion.
+
+## Compatibility and Action Resolution
+
+Takeoff-failure punishment and generated board punishment use one compatibility-aware selector:
+
+1. select an enabled tool by configured weight;
+2. select only body parts with sufficient sensitivity for that tool;
+3. select only positions compatible with the selected body part;
+4. produce a valid stepped count when the source requires a fixed count.
+
+Board actions confirmed during setup retain their exact action. Resolving a landing copies that action into the result rather than generating another action. This prevents the board, display, and acknowledgement stages from disagreeing.
+
+## Effects and Turn Flow
+
+- Traps resolve to a structured acknowledgement-required effect. Acknowledgement, not string parsing, advances the turn.
+- Landing on rest increments the affected player's pending skipped-turn count. When that player next becomes active, one count is consumed and the turn advances without a dice roll.
+- Movement, reverse, restart, and bounce retain their existing movement behavior but enter the UI through an explicit resolved effect.
+- Existing chain guards remain in place and operate on resolved results.
+
+## Alternatives Rejected
+
+1. **Add optional fields to `PunishmentAction` and continue resolving in Vue.** This leaves target/count/executor decisions distributed across the UI and does not create a trustworthy boundary.
+2. **Replace the entire game with event sourcing now.** This would improve long-term replayability but expands MR2 beyond a safe, testable rule-resolution slice.
+
+## Testing
+
+- Unit-test each resolver source and all dynamic-target player-count boundaries.
+- Test that takeoff and board generation both reject incompatible body part and position combinations.
+- Test fixed counts, pending external counts, trap acknowledgement, and rest-turn consumption.
+- Add browser coverage for a resolved dynamic result and a consumed rest turn where practical.
+- Run lint, type checking, unit tests, production build, and Playwright before MR publication.

--- a/docs/plans/2026-07-11-rule-resolution-implementation.md
+++ b/docs/plans/2026-07-11-rule-resolution-implementation.md
@@ -1,0 +1,359 @@
+# Trustworthy Rule Resolution Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Resolve every takeoff and board rule into an immutable, compatibility-aware result before the Vue UI presents or acknowledges it, while deliberately deferring external count-selection controls to MR3.
+
+**Architecture:** Add a pure `ruleResolution` domain module and discriminated result types. `GameService` will use the module's shared compatible-action factory for both generated board punishments and takeoff failures; `App.vue` will retain presentation and acknowledgement responsibility, but consume already-resolved target/count/effect data rather than deciding gameplay rules. Rest effects will persist a pending skipped-turn counter on the player and the turn-advance path will consume it deterministically.
+
+**Tech Stack:** Vue 3, TypeScript, Vitest, Playwright
+
+---
+
+### Task 1: Define the resolved-rule domain contract
+
+**Files:**
+- Modify: `src/types/game.ts:1-123`
+- Create: `src/services/ruleResolution.ts`
+- Create: `src/tests/ruleResolution.test.ts`
+
+**Step 1: Write the failing test**
+
+Add tests that import a not-yet-created `resolveRule` and assert that a board punishment keeps its configured tool/body-part/position/count exactly, rather than generating a new action.
+
+```ts
+expect(resolveRule({ source: 'board_punishment', actorIndex: 1, players, boardAction }))
+  .toMatchObject({
+    kind: 'punishment',
+    source: 'board_punishment',
+    actorIndex: 1,
+    targetPlayerIndex: 1,
+    count: { kind: 'fixed', value: 10 },
+  })
+```
+
+**Step 2: Run the test to verify it fails**
+
+Run: `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm test -- src/tests/ruleResolution.test.ts`
+
+Expected: FAIL because `ruleResolution.ts` and its exported contract do not exist.
+
+**Step 3: Write minimal implementation**
+
+In `src/types/game.ts`, add explicit, discriminated types:
+
+```ts
+export type RuleResolutionSource =
+  | 'takeoff_failure'
+  | 'board_punishment'
+  | 'trap'
+  | 'cell_effect'
+
+export type ResolvedPunishmentCount =
+  | { kind: 'fixed'; value: number }
+  | {
+      kind: 'awaiting_external_count'
+      minimum: number
+      maximum: number
+      step: number
+      eligibleChooserIndices: number[]
+    }
+
+export interface ResolvedPunishmentResult {
+  kind: 'punishment'
+  source: 'takeoff_failure' | 'board_punishment'
+  actorIndex: number
+  targetPlayerIndex: number
+  executorIndex?: number
+  action: PunishmentAction
+  count: ResolvedPunishmentCount
+}
+```
+
+Include a structured acknowledgement-required trap result and a cell-effect result carrying its explicit `turnConsequence`. In `src/services/ruleResolution.ts`, implement the smallest pure resolver that copies a static board action into `ResolvedPunishmentResult`; use `Readonly` inputs and return a newly-built result without mutating players, board cells, or the action.
+
+**Step 4: Run the test to verify it passes**
+
+Run: `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm test -- src/tests/ruleResolution.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/types/game.ts src/services/ruleResolution.ts src/tests/ruleResolution.test.ts
+git commit -m "feat: add resolved rule domain contract"
+```
+
+### Task 2: Build and prove the shared compatible punishment selector
+
+**Files:**
+- Modify: `src/services/ruleResolution.ts`
+- Modify: `src/services/gameService.ts:53-105`
+- Modify: `src/services/gameService.ts:474-570`
+- Modify: `src/tests/takeoffLogic.test.ts`
+- Modify: `src/tests/ruleResolution.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add a deterministic config containing a high-ratio incompatible body part and position plus a single valid combination. Assert that the generated action never uses the incompatible candidates and that its count is in the configured range and is divisible by the configured step.
+
+```ts
+const action = createCompatiblePunishmentAction(config, {
+  randomInt: () => 1,
+  pickWeighted: entries => entries[0],
+})
+
+expect(action.tool.name).toBe('皮拍')
+expect(action.bodyPart.name).toBe('臀部')
+expect(action.position.name).toBe('俯卧')
+expect(action.strikes).toBe(10)
+```
+
+Add a takeoff-failure regression test using the same config and assert `GameService.movePlayer(...).punishment` is compatible. Add a board-generation assertion that every punishment cell has a compatible body part/position and a stepped count.
+
+**Step 2: Run the tests to verify they fail**
+
+Run: `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm test -- src/tests/ruleResolution.test.ts src/tests/takeoffLogic.test.ts`
+
+Expected: FAIL because board creation and takeoff failure still select each field independently.
+
+**Step 3: Write minimal implementation**
+
+Add `createCompatiblePunishmentAction(config, randomSource?)` to `ruleResolution.ts`. Its algorithm must:
+
+1. choose a weighted enabled tool;
+2. keep only body parts whose `sensitivity >= tool.intensity` (fall back to all enabled parts only when no compatible part exists, preserving a usable old configuration);
+3. choose only positions whose `compatibleBodyParts` is empty or contains the selected body part;
+4. calculate the legal stepped count using `ceil(min / step)` through `floor(max / step)`.
+
+Inject a tiny random-source interface only for the pure factory's tests; production defaults to the existing secure random helpers. Replace both independent-selection blocks in `GameService.createBoardRandom` and the takeoff-failure branch of `GameService.movePlayer` with this factory. Do not change the confirmed-board-action path.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm test -- src/tests/ruleResolution.test.ts src/tests/takeoffLogic.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/services/ruleResolution.ts src/services/gameService.ts src/tests/ruleResolution.test.ts src/tests/takeoffLogic.test.ts
+git commit -m "fix: resolve only compatible punishments"
+```
+
+### Task 3: Resolve dynamic targets and counts without inventing a player choice
+
+**Files:**
+- Modify: `src/services/ruleResolution.ts`
+- Modify: `src/tests/ruleResolution.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add a parameterized target-resolution suite for one, two, and three players. Include circular previous/next behavior, a dice multiplier fixed count, and an `other_player_choice` result that remains pending:
+
+```ts
+expect(resolveRule({
+  source: 'board_punishment',
+  actorIndex: 1,
+  players: threePlayers,
+  diceValue: 4,
+  boardAction: { ...action, dynamicType: 'other_player_choice' },
+})).toMatchObject({
+  targetPlayerIndex: 1,
+  count: {
+    kind: 'awaiting_external_count',
+    minimum: 5,
+    maximum: 15,
+    step: 5,
+    eligibleChooserIndices: [0, 2],
+  },
+})
+```
+
+Assert that the action's original `strikes` is not used as a random/default choice for an external-count rule.
+
+**Step 2: Run the tests to verify they fail**
+
+Run: `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm test -- src/tests/ruleResolution.test.ts`
+
+Expected: FAIL because only static actions are currently resolved.
+
+**Step 3: Write minimal implementation**
+
+Extend `resolveRule` to resolve `dynamicType` using data, not descriptions:
+
+```ts
+const previousIndex = actorIndex === 0 ? players.length - 1 : actorIndex - 1
+const nextIndex = (actorIndex + 1) % players.length
+```
+
+- `dice_multiplier`: retain the triggering player as target and return `{ kind: 'fixed', value: diceValue * multiplier }`.
+- `previous_player` / `next_player`: resolve circular target index, with the sole player as the safe fallback.
+- `other_player_choice`: retain the actor as target, return `awaiting_external_count`, and calculate eligible choosers as every non-actor index. Leave `executorIndex` absent when no eligible chooser exists.
+
+Keep returned actions copied and immutable. Do not add any UI or automatic choice fallback.
+
+**Step 4: Run the tests to verify they pass**
+
+Run: `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm test -- src/tests/ruleResolution.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/services/ruleResolution.ts src/tests/ruleResolution.test.ts
+git commit -m "feat: resolve dynamic punishment rules"
+```
+
+### Task 4: Model structured traps and rest-turn consumption
+
+**Files:**
+- Modify: `src/types/game.ts:1-123`
+- Modify: `src/services/ruleResolution.ts`
+- Modify: `src/tests/ruleResolution.test.ts`
+- Modify: `src/tests/bounceChainLogic.test.ts`
+
+**Step 1: Write the failing tests**
+
+Test a trap input returns a dedicated structured result with `acknowledgementRequired: true`. Test a rest cell result has `turnConsequence: { kind: 'skip_next_turns', count: 1 }`. Test that applying the consequence increments a player's counter and that consuming the start of their next turn decrements it and reports a skipped turn.
+
+```ts
+const rested = applyTurnConsequence(player, { kind: 'skip_next_turns', count: 1 })
+expect(rested.pendingSkippedTurns).toBe(1)
+expect(consumePendingSkippedTurn(rested)).toEqual({ shouldSkip: true, player: { ...rested, pendingSkippedTurns: 0 } })
+```
+
+**Step 2: Run the tests to verify they fail**
+
+Run: `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm test -- src/tests/ruleResolution.test.ts src/tests/bounceChainLogic.test.ts`
+
+Expected: FAIL because traps/rest are only description-driven and players have no skipped-turn state.
+
+**Step 3: Write minimal implementation**
+
+Add optional `pendingSkippedTurns?: number` to `Player`. Implement pure `resolveRule` branches for `trap` and ordinary cell effects, plus pure immutable helpers:
+
+```ts
+export const applyTurnConsequence = (player: Player, consequence: TurnConsequence): Player =>
+  consequence.kind === 'skip_next_turns'
+    ? { ...player, pendingSkippedTurns: (player.pendingSkippedTurns ?? 0) + consequence.count }
+    : player
+```
+
+`consumePendingSkippedTurn` must never make the counter negative and must leave a player with zero / missing counter able to roll. Do not change movement and bounce calculation rules in this task.
+
+**Step 4: Run the tests to verify they pass**
+
+Run: `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm test -- src/tests/ruleResolution.test.ts src/tests/bounceChainLogic.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/types/game.ts src/services/ruleResolution.ts src/tests/ruleResolution.test.ts src/tests/bounceChainLogic.test.ts
+git commit -m "feat: model trap acknowledgement and rest turns"
+```
+
+### Task 5: Adapt the Vue turn flow to resolved results
+
+**Files:**
+- Modify: `src/App.vue:1-1320`
+- Modify: `src/types/game.ts:94-123`
+- Modify: `tests/e2e/reliability.spec.ts`
+
+**Step 1: Write the failing browser checks**
+
+Add Playwright tests that use the existing development-only debug state to prove:
+
+1. a landing punishment with `other_player_choice` displays the existing punishment acknowledgement flow without synthesizing a strike count; and
+2. after an acknowledged rest result, the affected player's next active turn is automatically skipped and the following player becomes current without exposing a dice-roll state for the skipped player.
+
+Use text/visible modal assertions only; do not add a new count selector or rely on implementation-only globals beyond the existing test hook.
+
+**Step 2: Run the browser checks to verify they fail**
+
+Run: `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npx playwright test --project=chromium tests/e2e/reliability.spec.ts`
+
+Expected: FAIL because Vue still creates executor/target behavior across distributed handlers and rest only changes description text.
+
+**Step 3: Write minimal implementation**
+
+Add one `pendingResolution` field to `GameState` (or an equivalent single reactive reference typed as `ResolvedRuleResult | null`). In `moveCurrentPlayer` and `handleLandingCellEffect`, call `resolveRule` once and map the returned result to the existing display components:
+
+- populate punishment display from `result.action`, `result.targetPlayerIndex`, `result.executorIndex`, and `result.count`;
+- preserve the existing confirmation as the offline acknowledgement for fixed and external pending counts;
+- route trap confirmation from its structured acknowledgement requirement;
+- when rest is acknowledged, replace the player object with `applyTurnConsequence`'s result;
+- before a normal roll, use `consumePendingSkippedTurn`. When it returns `shouldSkip`, update the player, show a short neutral status message, and call the normal turn advance without rolling.
+
+Do not create an external-count selection UI, do not parse descriptions, and do not modify the game/player-count setup model.
+
+**Step 4: Run focused checks to verify they pass**
+
+Run:
+
+```bash
+env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm test -- src/tests/ruleResolution.test.ts src/tests/takeoffLogic.test.ts src/tests/bounceChainLogic.test.ts
+env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npx playwright test --project=chromium tests/e2e/reliability.spec.ts
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/App.vue src/types/game.ts tests/e2e/reliability.spec.ts
+git commit -m "feat: drive turns from resolved rules"
+```
+
+### Task 6: Verify the MR2 slice and prepare review evidence
+
+**Files:**
+- Modify only if a verification-driven correction is necessary: relevant source and test files above
+
+**Step 1: Run static and unit validation**
+
+Run:
+
+```bash
+env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm run type-check
+env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm run lint
+env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm test
+```
+
+Expected: type check and all unit tests pass; lint has no new errors (record pre-existing warnings separately if present).
+
+**Step 2: Build and run browser validation**
+
+Run:
+
+```bash
+env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npm run build
+env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy npx playwright test
+```
+
+Expected: production build succeeds and all desktop-enabled Playwright scenarios pass (mobile projects may retain their intentional skips).
+
+**Step 3: Inspect the final diff**
+
+Run:
+
+```bash
+git status --short
+git diff master...HEAD --check
+git log --oneline master..HEAD
+```
+
+Expected: clean worktree, no whitespace errors, and focused commits only.
+
+**Step 4: Commit only a necessary verification correction**
+
+```bash
+git add <affected-files>
+git commit -m "fix: correct rule resolution edge case"
+```
+
+Do not make unrelated cleanup commits.

--- a/src/services/gameService.ts
+++ b/src/services/gameService.ts
@@ -13,6 +13,7 @@ import type {
 import { GAME_CONFIG } from '../config/gameConfig'
 import { SecureRandom } from '../utils/secureRandom'
 import { devLog } from '../utils/logger'
+import { createCompatiblePunishmentAction } from './ruleResolution'
 
 type BoardEffectCountField = Exclude<keyof BoardConfig, 'totalCells'>
 
@@ -139,30 +140,7 @@ export class GameService {
 
     // 填充惩罚格子
     punishmentPositions.forEach(pos => {
-      const tool = this.selectByRatio(this.configToArray(config.tools))
-      const bodyPart = this.selectByRatio(this.configToArray(config.bodyParts))
-      const position = this.selectByRatio(this.configToArray(config.positions))
-
-      // 在配置的范围内随机生成惩罚次数，确保是步长的倍数
-      const minStrikes = Math.max(1, config.minStrikes || 10)
-      const maxStrikes = Math.max(minStrikes, config.maxStrikes || 30)
-      const step = config.step || 5
-
-      // 确保最小值和最大值都是步长的倍数
-      const minMultiple = Math.ceil(minStrikes / step)
-      const maxMultiple = Math.floor(maxStrikes / step)
-
-      // 在有效的倍数范围内随机选择
-      const randomMultiple = SecureRandom.randomInt(minMultiple, maxMultiple)
-      const strikes = randomMultiple * step
-
-      const punishment: PunishmentAction = {
-        tool,
-        bodyPart,
-        position,
-        strikes,
-        description: `用${tool.name}打${bodyPart.name}${strikes}下，姿势：${position.name}`,
-      }
+      const punishment = createCompatiblePunishmentAction(config)
 
       cellMap.set(pos, {
         id: pos,
@@ -553,22 +531,7 @@ export class GameService {
         }
 
         // 未达到上限，继续惩罚流程
-        const tool = this.selectByRatio(this.configToArray(punishmentConfig.tools))
-        const bodyPart = this.selectByRatio(this.configToArray(punishmentConfig.bodyParts))
-        const position = this.selectByRatio(this.configToArray(punishmentConfig.positions))
-
-        // 生成惩罚次数，确保是步长的倍数
-        const minStrikes = Math.max(1, punishmentConfig.minStrikes || 10)
-        const maxStrikes = Math.max(minStrikes, punishmentConfig.maxStrikes || 30)
-        const step = punishmentConfig.step || 5
-
-        // 确保最小值和最大值都是步长的倍数
-        const minMultiple = Math.ceil(minStrikes / step)
-        const maxMultiple = Math.floor(maxStrikes / step)
-
-        // 在有效的倍数范围内随机选择
-        const randomMultiple = SecureRandom.randomInt(minMultiple, maxMultiple)
-        const strikes = randomMultiple * step
+        const generatedPunishment = createCompatiblePunishmentAction(punishmentConfig)
 
         // 计算惩罚执行者 - 等概率随机选择其他玩家
         const otherPlayersCount = totalPlayers - 1
@@ -585,11 +548,8 @@ export class GameService {
         }
 
         punishment = {
-          tool,
-          bodyPart,
-          position,
-          strikes,
-          description: `未起飞，被惩罚：用${tool.name}打${bodyPart.name}${strikes}下，姿势：${position.name}`,
+          ...generatedPunishment,
+          description: `未起飞，被惩罚：${generatedPunishment.description}`,
         }
 
         effect = `未起飞！被惩罚`

--- a/src/services/ruleResolution.ts
+++ b/src/services/ruleResolution.ts
@@ -88,8 +88,7 @@ export const createCompatiblePunishmentAction = (
   const tool = chooseWeighted(viableTools, randomSource)
 
   const compatibleBodyParts = bodyParts.filter(
-    bodyPart =>
-      bodyPart.sensitivity >= tool.intensity && hasCompatiblePosition(positions, bodyPart)
+    bodyPart => bodyPart.sensitivity >= tool.intensity && hasCompatiblePosition(positions, bodyPart)
   )
   const bodyPart = chooseWeighted(compatibleBodyParts, randomSource)
 

--- a/src/services/ruleResolution.ts
+++ b/src/services/ruleResolution.ts
@@ -1,8 +1,13 @@
 import type {
   Player,
   PunishmentAction,
+  PunishmentBodyPart,
+  PunishmentConfig,
+  PunishmentPosition,
+  PunishmentTool,
   ResolvedPunishmentResult,
 } from '../types/game'
+import { SecureRandom } from '../utils/secureRandom'
 
 export type PunishmentRuleInput =
   | {
@@ -17,6 +22,93 @@ export type PunishmentRuleInput =
       players: readonly Player[]
       punishmentAction: PunishmentAction
     }
+
+export interface RuleRandomSource {
+  weightedChoice<T>(entries: readonly T[], weights: readonly number[]): T
+  randomInt(minimum: number, maximum: number): number
+}
+
+const secureRandomSource: RuleRandomSource = {
+  weightedChoice: (entries, weights) => SecureRandom.weightedChoice([...entries], [...weights]),
+  randomInt: (minimum, maximum) => SecureRandom.randomInt(minimum, maximum),
+}
+
+type NamedRatioEntry = { name: string; ratio: number }
+
+const entriesWithNames = <T extends { ratio: number }>(
+  config: Record<string, T>
+): Array<T & { name: string }> =>
+  Object.entries(config).map(([name, entry]) => ({ ...entry, name }))
+
+const chooseWeighted = <T extends NamedRatioEntry>(
+  entries: readonly T[],
+  randomSource: RuleRandomSource
+): T => {
+  const enabledEntries = entries.filter(entry => entry.ratio > 0)
+  if (enabledEntries.length === 0) {
+    throw new Error('没有启用的惩罚配置')
+  }
+
+  return randomSource.weightedChoice(
+    enabledEntries,
+    enabledEntries.map(entry => entry.ratio)
+  )
+}
+
+const isPositionCompatible = (
+  position: PunishmentPosition,
+  bodyPart: PunishmentBodyPart
+): boolean =>
+  position.compatibleBodyParts.length === 0 || position.compatibleBodyParts.includes(bodyPart.name)
+
+const hasCompatiblePosition = (
+  positions: readonly (PunishmentPosition & { name: string })[],
+  bodyPart: PunishmentBodyPart
+): boolean => positions.some(position => isPositionCompatible(position, bodyPart))
+
+export const createCompatiblePunishmentAction = (
+  config: PunishmentConfig,
+  randomSource: RuleRandomSource = secureRandomSource
+): PunishmentAction => {
+  const tools = entriesWithNames<PunishmentTool>(config.tools)
+  const bodyParts = entriesWithNames<PunishmentBodyPart>(config.bodyParts)
+  const positions = entriesWithNames<PunishmentPosition>(config.positions)
+
+  const viableTools = tools.filter(tool =>
+    bodyParts.some(
+      bodyPart =>
+        bodyPart.sensitivity >= tool.intensity && hasCompatiblePosition(positions, bodyPart)
+    )
+  )
+  const tool = chooseWeighted(viableTools, randomSource)
+
+  const compatibleBodyParts = bodyParts.filter(
+    bodyPart =>
+      bodyPart.sensitivity >= tool.intensity && hasCompatiblePosition(positions, bodyPart)
+  )
+  const bodyPart = chooseWeighted(compatibleBodyParts, randomSource)
+
+  const compatiblePositions = positions.filter(position => isPositionCompatible(position, bodyPart))
+  const position = chooseWeighted(compatiblePositions, randomSource)
+
+  const step = Math.max(1, config.step || 1)
+  const minimum = Math.max(1, config.minStrikes || step)
+  const maximum = Math.max(minimum, config.maxStrikes || minimum)
+  const minimumMultiple = Math.ceil(minimum / step)
+  const maximumMultiple = Math.floor(maximum / step)
+  if (minimumMultiple > maximumMultiple) {
+    throw new Error('惩罚次数范围内没有合法步长')
+  }
+
+  const strikes = randomSource.randomInt(minimumMultiple, maximumMultiple) * step
+  return {
+    tool,
+    bodyPart,
+    position,
+    strikes,
+    description: `用${tool.name}打${bodyPart.name}${strikes}下，姿势：${position.name}`,
+  }
+}
 
 const copyAction = (action: PunishmentAction): Readonly<PunishmentAction> =>
   Object.freeze({

--- a/src/services/ruleResolution.ts
+++ b/src/services/ruleResolution.ts
@@ -1,0 +1,52 @@
+import type {
+  Player,
+  PunishmentAction,
+  ResolvedPunishmentResult,
+} from '../types/game'
+
+export type PunishmentRuleInput =
+  | {
+      source: 'board_punishment'
+      actorIndex: number
+      players: readonly Player[]
+      boardAction: PunishmentAction
+    }
+  | {
+      source: 'takeoff_failure'
+      actorIndex: number
+      players: readonly Player[]
+      punishmentAction: PunishmentAction
+    }
+
+const copyAction = (action: PunishmentAction): Readonly<PunishmentAction> =>
+  Object.freeze({
+    ...action,
+    tool: Object.freeze({ ...action.tool }),
+    bodyPart: Object.freeze({ ...action.bodyPart }),
+    position: Object.freeze({
+      ...action.position,
+      compatibleBodyParts: Object.freeze([...action.position.compatibleBodyParts]),
+    }),
+  })
+
+export const resolveRule = (input: PunishmentRuleInput): ResolvedPunishmentResult => {
+  if (input.actorIndex < 0 || input.actorIndex >= input.players.length) {
+    throw new Error('规则解析需要有效的触发玩家索引')
+  }
+
+  const action = input.source === 'board_punishment' ? input.boardAction : input.punishmentAction
+  const strikes = action.strikes
+  if (strikes === undefined) {
+    throw new Error('静态惩罚动作需要固定次数')
+  }
+
+  return Object.freeze({
+    kind: 'punishment',
+    source: input.source,
+    actorIndex: input.actorIndex,
+    targetPlayerIndex: input.actorIndex,
+    action: copyAction(action),
+    count: Object.freeze({ kind: 'fixed', value: strikes }),
+    turnConsequence: Object.freeze({ kind: 'none' }),
+  })
+}

--- a/src/services/ruleResolution.ts
+++ b/src/services/ruleResolution.ts
@@ -5,6 +5,7 @@ import type {
   PunishmentConfig,
   PunishmentPosition,
   PunishmentTool,
+  ResolvedPunishmentAction,
   ResolvedPunishmentResult,
 } from '../types/game'
 import { SecureRandom } from '../utils/secureRandom'
@@ -14,12 +15,16 @@ export type PunishmentRuleInput =
       source: 'board_punishment'
       actorIndex: number
       players: readonly Player[]
+      punishmentConfig: PunishmentConfig
+      diceValue?: number
       boardAction: PunishmentAction
     }
   | {
       source: 'takeoff_failure'
       actorIndex: number
       players: readonly Player[]
+      punishmentConfig: PunishmentConfig
+      diceValue?: number
       punishmentAction: PunishmentAction
     }
 
@@ -110,9 +115,13 @@ export const createCompatiblePunishmentAction = (
   }
 }
 
-const copyAction = (action: PunishmentAction): Readonly<PunishmentAction> =>
+const copyAction = (
+  action: PunishmentAction,
+  strikes: number | undefined
+): ResolvedPunishmentAction =>
   Object.freeze({
     ...action,
+    strikes,
     tool: Object.freeze({ ...action.tool }),
     bodyPart: Object.freeze({ ...action.bodyPart }),
     position: Object.freeze({
@@ -127,18 +136,54 @@ export const resolveRule = (input: PunishmentRuleInput): ResolvedPunishmentResul
   }
 
   const action = input.source === 'board_punishment' ? input.boardAction : input.punishmentAction
-  const strikes = action.strikes
-  if (strikes === undefined) {
-    throw new Error('静态惩罚动作需要固定次数')
+  const playerCount = input.players.length
+  let targetPlayerIndex = input.actorIndex
+  let actionStrikes = action.strikes
+  let count: ResolvedPunishmentResult['count'] | undefined
+
+  switch (action.dynamicType) {
+    case 'dice_multiplier': {
+      if (input.diceValue === undefined || action.multiplier === undefined) {
+        throw new Error('骰子倍数惩罚需要骰子点数和倍数')
+      }
+      actionStrikes = input.diceValue * action.multiplier
+      count = Object.freeze({ kind: 'fixed', value: actionStrikes })
+      break
+    }
+    case 'previous_player':
+      targetPlayerIndex = (input.actorIndex + playerCount - 1) % playerCount
+      break
+    case 'next_player':
+      targetPlayerIndex = (input.actorIndex + 1) % playerCount
+      break
+    case 'other_player_choice':
+      actionStrikes = undefined
+      count = Object.freeze({
+        kind: 'awaiting_external_count',
+        minimum: input.punishmentConfig.minStrikes,
+        maximum: input.punishmentConfig.maxStrikes,
+        step: input.punishmentConfig.step,
+        eligibleChooserIndices: input.players.flatMap((_, index) =>
+          index === input.actorIndex ? [] : [index]
+        ),
+      })
+      break
+  }
+
+  if (!count) {
+    if (actionStrikes === undefined) {
+      throw new Error('静态惩罚动作需要固定次数')
+    }
+    count = Object.freeze({ kind: 'fixed', value: actionStrikes })
   }
 
   return Object.freeze({
     kind: 'punishment',
     source: input.source,
     actorIndex: input.actorIndex,
-    targetPlayerIndex: input.actorIndex,
-    action: copyAction(action),
-    count: Object.freeze({ kind: 'fixed', value: strikes }),
+    targetPlayerIndex,
+    action: copyAction(action, actionStrikes),
+    count,
     turnConsequence: Object.freeze({ kind: 'none' }),
   })
 }

--- a/src/services/ruleResolution.ts
+++ b/src/services/ruleResolution.ts
@@ -89,8 +89,9 @@ export const createCompatiblePunishmentAction = (
     tool =>
       tool.ratio > 0 &&
       enabledBodyParts.some(
-      bodyPart =>
-          bodyPart.sensitivity >= tool.intensity && hasCompatiblePosition(enabledPositions, bodyPart)
+        bodyPart =>
+          bodyPart.sensitivity >= tool.intensity &&
+          hasCompatiblePosition(enabledPositions, bodyPart)
       )
   )
   const tool = chooseWeighted(viableTools, randomSource)

--- a/src/services/ruleResolution.ts
+++ b/src/services/ruleResolution.ts
@@ -17,6 +17,7 @@ export type PunishmentRuleInput =
       players: readonly Player[]
       punishmentConfig: PunishmentConfig
       diceValue?: number
+      randomSource?: RuleRandomSource
       boardAction: PunishmentAction
     }
   | {
@@ -25,17 +26,20 @@ export type PunishmentRuleInput =
       players: readonly Player[]
       punishmentConfig: PunishmentConfig
       diceValue?: number
+      randomSource?: RuleRandomSource
       punishmentAction: PunishmentAction
     }
 
 export interface RuleRandomSource {
   weightedChoice<T>(entries: readonly T[], weights: readonly number[]): T
   randomInt(minimum: number, maximum: number): number
+  choice<T>(entries: readonly T[]): T
 }
 
 const secureRandomSource: RuleRandomSource = {
   weightedChoice: (entries, weights) => SecureRandom.weightedChoice([...entries], [...weights]),
   randomInt: (minimum, maximum) => SecureRandom.randomInt(minimum, maximum),
+  choice: entries => SecureRandom.choice([...entries]),
 }
 
 type NamedRatioEntry = { name: string; ratio: number }
@@ -78,21 +82,28 @@ export const createCompatiblePunishmentAction = (
   const tools = entriesWithNames<PunishmentTool>(config.tools)
   const bodyParts = entriesWithNames<PunishmentBodyPart>(config.bodyParts)
   const positions = entriesWithNames<PunishmentPosition>(config.positions)
+  const enabledBodyParts = bodyParts.filter(bodyPart => bodyPart.ratio > 0)
+  const enabledPositions = positions.filter(position => position.ratio > 0)
 
-  const viableTools = tools.filter(tool =>
-    bodyParts.some(
+  const viableTools = tools.filter(
+    tool =>
+      tool.ratio > 0 &&
+      enabledBodyParts.some(
       bodyPart =>
-        bodyPart.sensitivity >= tool.intensity && hasCompatiblePosition(positions, bodyPart)
-    )
+          bodyPart.sensitivity >= tool.intensity && hasCompatiblePosition(enabledPositions, bodyPart)
+      )
   )
   const tool = chooseWeighted(viableTools, randomSource)
 
-  const compatibleBodyParts = bodyParts.filter(
-    bodyPart => bodyPart.sensitivity >= tool.intensity && hasCompatiblePosition(positions, bodyPart)
+  const compatibleBodyParts = enabledBodyParts.filter(
+    bodyPart =>
+      bodyPart.sensitivity >= tool.intensity && hasCompatiblePosition(enabledPositions, bodyPart)
   )
   const bodyPart = chooseWeighted(compatibleBodyParts, randomSource)
 
-  const compatiblePositions = positions.filter(position => isPositionCompatible(position, bodyPart))
+  const compatiblePositions = enabledPositions.filter(position =>
+    isPositionCompatible(position, bodyPart)
+  )
   const position = chooseWeighted(compatiblePositions, randomSource)
 
   const step = Math.max(1, config.step || 1)
@@ -135,6 +146,7 @@ export const resolveRule = (input: PunishmentRuleInput): ResolvedPunishmentResul
   }
 
   const action = input.source === 'board_punishment' ? input.boardAction : input.punishmentAction
+  const randomSource = input.randomSource ?? secureRandomSource
   const playerCount = input.players.length
   let targetPlayerIndex = input.actorIndex
   let actionStrikes = action.strikes
@@ -162,8 +174,8 @@ export const resolveRule = (input: PunishmentRuleInput): ResolvedPunishmentResul
         minimum: input.punishmentConfig.minStrikes,
         maximum: input.punishmentConfig.maxStrikes,
         step: input.punishmentConfig.step,
-        eligibleChooserIndices: input.players.flatMap((_, index) =>
-          index === input.actorIndex ? [] : [index]
+        eligibleChooserIndices: Object.freeze(
+          input.players.flatMap((_, index) => (index === input.actorIndex ? [] : [index]))
         ),
       })
       break
@@ -176,11 +188,18 @@ export const resolveRule = (input: PunishmentRuleInput): ResolvedPunishmentResul
     count = Object.freeze({ kind: 'fixed', value: actionStrikes })
   }
 
+  const executorCandidates = input.players.flatMap((_, index) =>
+    index === targetPlayerIndex ? [] : [index]
+  )
+  const executorIndex =
+    executorCandidates.length > 0 ? randomSource.choice(executorCandidates) : undefined
+
   return Object.freeze({
     kind: 'punishment',
     source: input.source,
     actorIndex: input.actorIndex,
     targetPlayerIndex,
+    executorIndex,
     action: copyAction(action, actionStrikes),
     count,
     turnConsequence: Object.freeze({ kind: 'none' }),

--- a/src/tests/ruleResolution.test.ts
+++ b/src/tests/ruleResolution.test.ts
@@ -68,6 +68,28 @@ const boardConfig: BoardConfig = {
   totalCells: 20,
 }
 
+const disabledCompatibilityConfig: PunishmentConfig = {
+  ...compatibilityConfig,
+  tools: {
+    高强度工具: { name: '高强度工具', intensity: 5, ratio: 100 },
+    低强度工具: { name: '低强度工具', intensity: 1, ratio: 1 },
+  },
+  bodyParts: {
+    高耐受部位: { name: '高耐受部位', sensitivity: 5, ratio: 100 },
+    低耐受部位: { name: '低耐受部位', sensitivity: 1, ratio: 1 },
+  },
+  positions: {
+    已禁用姿势: { name: '已禁用姿势', ratio: 0, compatibleBodyParts: ['高耐受部位'] },
+    可用姿势: { name: '可用姿势', ratio: 1, compatibleBodyParts: ['低耐受部位'] },
+  },
+}
+
+const deterministicRandom = {
+  weightedChoice: <T,>(entries: readonly T[]) => entries[0],
+  randomInt: (minimum: number) => minimum,
+  choice: <T,>(entries: readonly T[]) => entries[entries.length - 1],
+}
+
 afterEach(() => {
   vi.restoreAllMocks()
 })
@@ -96,12 +118,21 @@ describe('规则结果解析', () => {
     const action = createCompatiblePunishmentAction(compatibilityConfig, {
       weightedChoice: entries => entries[0],
       randomInt: minimum => minimum,
+      choice: entries => entries[0],
     })
 
     expect(action.tool.name).toBe('皮拍')
     expect(action.bodyPart.name).toBe('臀部')
     expect(action.position.name).toBe('仰卧')
     expect(action.strikes).toBe(5)
+  })
+
+  it('忽略会令组合失效的零比例部位和姿势', () => {
+    const action = createCompatiblePunishmentAction(disabledCompatibilityConfig, deterministicRandom)
+
+    expect(action.tool.name).toBe('低强度工具')
+    expect(action.bodyPart.name).toBe('低耐受部位')
+    expect(action.position.name).toBe('可用姿势')
   })
 
   it('让随机棋盘和起飞失败共用兼容组合规则', () => {
@@ -187,5 +218,34 @@ describe('规则结果解析', () => {
         eligibleChooserIndices: [0, 2],
       },
     })
+
+    if (!('eligibleChooserIndices' in result.count)) {
+      throw new Error('预期得到待外部决定次数')
+    }
+    const eligibleChooserIndices = result.count.eligibleChooserIndices
+    expect(Object.isFrozen(eligibleChooserIndices)).toBe(true)
+    expect(() => (eligibleChooserIndices as number[]).push(7)).toThrow(TypeError)
+  })
+
+  it('在规则结果中解析执行者并安全处理单人局', () => {
+    const multiplayerResult = resolveRule({
+      source: 'board_punishment',
+      actorIndex: 1,
+      players: threePlayers,
+      punishmentConfig: compatibilityConfig,
+      randomSource: deterministicRandom,
+      boardAction,
+    })
+    const singlePlayerResult = resolveRule({
+      source: 'board_punishment',
+      actorIndex: 0,
+      players: [players[0]],
+      punishmentConfig: compatibilityConfig,
+      randomSource: deterministicRandom,
+      boardAction,
+    })
+
+    expect(multiplayerResult.executorIndex).toBe(2)
+    expect(singlePlayerResult.executorIndex).toBeUndefined()
   })
 })

--- a/src/tests/ruleResolution.test.ts
+++ b/src/tests/ruleResolution.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { resolveRule } from '../services/ruleResolution'
+import type { Player, PunishmentAction } from '../types/game'
+
+const players: Player[] = [
+  {
+    id: 1,
+    name: '红方',
+    color: '#ef4444',
+    position: 4,
+    isWinner: false,
+  },
+  {
+    id: 2,
+    name: '蓝方',
+    color: '#3b82f6',
+    position: 7,
+    isWinner: false,
+  },
+]
+
+const boardAction: PunishmentAction = {
+  tool: { name: '皮拍', intensity: 3, ratio: 100 },
+  bodyPart: { name: '臀部', sensitivity: 4, ratio: 100 },
+  position: { name: '俯卧', ratio: 100, compatibleBodyParts: ['臀部'] },
+  strikes: 10,
+  description: '用皮拍打臀部10下，姿势：俯卧',
+}
+
+describe('规则结果解析', () => {
+  it('保留棋盘上已确认的静态惩罚动作', () => {
+    const result = resolveRule({
+      source: 'board_punishment',
+      actorIndex: 1,
+      players,
+      boardAction,
+    })
+
+    expect(result).toMatchObject({
+      kind: 'punishment',
+      source: 'board_punishment',
+      actorIndex: 1,
+      targetPlayerIndex: 1,
+      action: boardAction,
+      count: { kind: 'fixed', value: 10 },
+    })
+  })
+})

--- a/src/tests/ruleResolution.test.ts
+++ b/src/tests/ruleResolution.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
-import { resolveRule } from '../services/ruleResolution'
-import type { Player, PunishmentAction } from '../types/game'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  createCompatiblePunishmentAction,
+  resolveRule,
+} from '../services/ruleResolution'
+import { GameService } from '../services/gameService'
+import { SecureRandom } from '../utils/secureRandom'
+import type { BoardConfig, Player, PunishmentAction, PunishmentConfig } from '../types/game'
 
 const players: Player[] = [
   {
@@ -27,6 +32,38 @@ const boardAction: PunishmentAction = {
   description: '用皮拍打臀部10下，姿势：俯卧',
 }
 
+const compatibilityConfig: PunishmentConfig = {
+  tools: {
+    皮拍: { name: '皮拍', intensity: 4, ratio: 100 },
+  },
+  bodyParts: {
+    低敏感部位: { name: '低敏感部位', sensitivity: 1, ratio: 100 },
+    臀部: { name: '臀部', sensitivity: 4, ratio: 1 },
+  },
+  positions: {
+    仰卧: { name: '仰卧', ratio: 100, compatibleBodyParts: ['臀部'] },
+    侧卧: { name: '侧卧', ratio: 1, compatibleBodyParts: ['低敏感部位'] },
+  },
+  minStrikes: 5,
+  maxStrikes: 15,
+  step: 5,
+  maxTakeoffFailures: 5,
+}
+
+const boardConfig: BoardConfig = {
+  punishmentCells: 1,
+  bonusCells: 0,
+  reverseCells: 0,
+  restCells: 0,
+  restartCells: 0,
+  trapCells: 0,
+  totalCells: 20,
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
 describe('规则结果解析', () => {
   it('保留棋盘上已确认的静态惩罚动作', () => {
     const result = resolveRule({
@@ -44,5 +81,44 @@ describe('规则结果解析', () => {
       action: boardAction,
       count: { kind: 'fixed', value: 10 },
     })
+  })
+
+  it('只生成工具强度和姿势都兼容的惩罚动作', () => {
+    const action = createCompatiblePunishmentAction(compatibilityConfig, {
+      weightedChoice: entries => entries[0],
+      randomInt: minimum => minimum,
+    })
+
+    expect(action.tool.name).toBe('皮拍')
+    expect(action.bodyPart.name).toBe('臀部')
+    expect(action.position.name).toBe('仰卧')
+    expect(action.strikes).toBe(5)
+  })
+
+  it('让随机棋盘和起飞失败共用兼容组合规则', () => {
+    vi.spyOn(SecureRandom, 'weightedChoice').mockImplementation(items => items[0])
+    vi.spyOn(SecureRandom, 'randomInt').mockImplementation(minimum => minimum)
+
+    const boardPunishment = GameService.createBoard(compatibilityConfig, boardConfig).find(
+      cell => cell.type === 'punishment'
+    )?.effect?.punishment
+    const takeoffPunishment = GameService.movePlayer(
+      { ...players[0], position: 0, hasTakenOff: false, failedTakeoffAttempts: 0 },
+      2,
+      GameService.createBoard(compatibilityConfig, boardConfig),
+      0,
+      players.length,
+      compatibilityConfig
+    ).punishment
+
+    for (const action of [boardPunishment, takeoffPunishment]) {
+      expect(action).toBeDefined()
+      expect(action?.bodyPart.sensitivity).toBeGreaterThanOrEqual(action?.tool.intensity ?? Infinity)
+      expect(
+        action?.position.compatibleBodyParts.length === 0 ||
+          action?.position.compatibleBodyParts.includes(action?.bodyPart.name ?? '')
+      ).toBe(true)
+      expect((action?.strikes ?? 0) % compatibilityConfig.step).toBe(0)
+    }
   })
 })

--- a/src/tests/ruleResolution.test.ts
+++ b/src/tests/ruleResolution.test.ts
@@ -85,9 +85,9 @@ const disabledCompatibilityConfig: PunishmentConfig = {
 }
 
 const deterministicRandom = {
-  weightedChoice: <T,>(entries: readonly T[]) => entries[0],
+  weightedChoice: <T>(entries: readonly T[]) => entries[0],
   randomInt: (minimum: number) => minimum,
-  choice: <T,>(entries: readonly T[]) => entries[entries.length - 1],
+  choice: <T>(entries: readonly T[]) => entries[entries.length - 1],
 }
 
 afterEach(() => {
@@ -128,7 +128,10 @@ describe('规则结果解析', () => {
   })
 
   it('忽略会令组合失效的零比例部位和姿势', () => {
-    const action = createCompatiblePunishmentAction(disabledCompatibilityConfig, deterministicRandom)
+    const action = createCompatiblePunishmentAction(
+      disabledCompatibilityConfig,
+      deterministicRandom
+    )
 
     expect(action.tool.name).toBe('低强度工具')
     expect(action.bodyPart.name).toBe('低耐受部位')

--- a/src/tests/ruleResolution.test.ts
+++ b/src/tests/ruleResolution.test.ts
@@ -24,6 +24,17 @@ const players: Player[] = [
   },
 ]
 
+const threePlayers: Player[] = [
+  ...players,
+  {
+    id: 3,
+    name: '绿方',
+    color: '#22c55e',
+    position: 10,
+    isWinner: false,
+  },
+]
+
 const boardAction: PunishmentAction = {
   tool: { name: '皮拍', intensity: 3, ratio: 100 },
   bodyPart: { name: '臀部', sensitivity: 4, ratio: 100 },
@@ -70,6 +81,7 @@ describe('规则结果解析', () => {
       source: 'board_punishment',
       actorIndex: 1,
       players,
+      punishmentConfig: compatibilityConfig,
       boardAction,
     })
 
@@ -120,5 +132,61 @@ describe('规则结果解析', () => {
       ).toBe(true)
       expect((action?.strikes ?? 0) % compatibilityConfig.step).toBe(0)
     }
+  })
+
+  it.each([
+    ['previous_player', 0, 2],
+    ['next_player', 2, 0],
+    ['previous_player', 0, 0],
+  ] as const)('按环状玩家顺序解析 %s 目标', (dynamicType, actorIndex, targetPlayerIndex) => {
+    const activePlayers = actorIndex === 0 && targetPlayerIndex === 0 ? [players[0]] : threePlayers
+    const result = resolveRule({
+      source: 'board_punishment',
+      actorIndex,
+      players: activePlayers,
+      punishmentConfig: compatibilityConfig,
+      boardAction: { ...boardAction, dynamicType },
+    })
+
+    expect(result.targetPlayerIndex).toBe(targetPlayerIndex)
+  })
+
+  it('把骰子倍数规则解析为固定次数', () => {
+    const result = resolveRule({
+      source: 'board_punishment',
+      actorIndex: 1,
+      players: threePlayers,
+      punishmentConfig: compatibilityConfig,
+      diceValue: 4,
+      boardAction: { ...boardAction, dynamicType: 'dice_multiplier', multiplier: 3 },
+    })
+
+    expect(result).toMatchObject({
+      targetPlayerIndex: 1,
+      count: { kind: 'fixed', value: 12 },
+      action: { strikes: 12 },
+    })
+  })
+
+  it('把其他玩家决定次数保留为待外部决定状态', () => {
+    const result = resolveRule({
+      source: 'board_punishment',
+      actorIndex: 1,
+      players: threePlayers,
+      punishmentConfig: compatibilityConfig,
+      boardAction: { ...boardAction, dynamicType: 'other_player_choice' },
+    })
+
+    expect(result).toMatchObject({
+      targetPlayerIndex: 1,
+      action: { strikes: undefined },
+      count: {
+        kind: 'awaiting_external_count',
+        minimum: 5,
+        maximum: 15,
+        step: 5,
+        eligibleChooserIndices: [0, 2],
+      },
+    })
   })
 })

--- a/src/tests/ruleResolution.test.ts
+++ b/src/tests/ruleResolution.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import {
-  createCompatiblePunishmentAction,
-  resolveRule,
-} from '../services/ruleResolution'
+import { createCompatiblePunishmentAction, resolveRule } from '../services/ruleResolution'
 import { GameService } from '../services/gameService'
 import { SecureRandom } from '../utils/secureRandom'
 import type { BoardConfig, Player, PunishmentAction, PunishmentConfig } from '../types/game'
@@ -125,7 +122,9 @@ describe('规则结果解析', () => {
 
     for (const action of [boardPunishment, takeoffPunishment]) {
       expect(action).toBeDefined()
-      expect(action?.bodyPart.sensitivity).toBeGreaterThanOrEqual(action?.tool.intensity ?? Infinity)
+      expect(action?.bodyPart.sensitivity).toBeGreaterThanOrEqual(
+        action?.tool.intensity ?? Infinity
+      )
       expect(
         action?.position.compatibleBodyParts.length === 0 ||
           action?.position.compatibleBodyParts.includes(action?.bodyPart.name ?? '')

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -77,13 +77,23 @@ export type TurnConsequence =
   | Readonly<{ kind: 'none' }>
   | Readonly<{ kind: 'skip_next_turns'; count: number }>
 
+export type ResolvedPunishmentAction = Readonly<
+  Omit<PunishmentAction, 'tool' | 'bodyPart' | 'position'>
+> & {
+  readonly tool: Readonly<PunishmentTool>
+  readonly bodyPart: Readonly<PunishmentBodyPart>
+  readonly position: Readonly<Omit<PunishmentPosition, 'compatibleBodyParts'>> & {
+    readonly compatibleBodyParts: readonly string[]
+  }
+}
+
 export interface ResolvedPunishmentResult {
   readonly kind: 'punishment'
   readonly source: 'takeoff_failure' | 'board_punishment'
   readonly actorIndex: number
   readonly targetPlayerIndex: number
   readonly executorIndex?: number
-  readonly action: Readonly<PunishmentAction>
+  readonly action: ResolvedPunishmentAction
   readonly count: ResolvedPunishmentCount
   readonly turnConsequence: TurnConsequence
 }

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -57,6 +57,59 @@ export interface PunishmentAction {
   targetPlayer?: 'current' | 'previous' | 'next' | 'other'
 }
 
+export type RuleResolutionSource =
+  | 'takeoff_failure'
+  | 'board_punishment'
+  | 'trap'
+  | 'cell_effect'
+
+export type ResolvedPunishmentCount =
+  | Readonly<{ kind: 'fixed'; value: number }>
+  | Readonly<{
+      kind: 'awaiting_external_count'
+      minimum: number
+      maximum: number
+      step: number
+      eligibleChooserIndices: number[]
+    }>
+
+export type TurnConsequence =
+  | Readonly<{ kind: 'none' }>
+  | Readonly<{ kind: 'skip_next_turns'; count: number }>
+
+export interface ResolvedPunishmentResult {
+  readonly kind: 'punishment'
+  readonly source: 'takeoff_failure' | 'board_punishment'
+  readonly actorIndex: number
+  readonly targetPlayerIndex: number
+  readonly executorIndex?: number
+  readonly action: Readonly<PunishmentAction>
+  readonly count: ResolvedPunishmentCount
+  readonly turnConsequence: TurnConsequence
+}
+
+export interface ResolvedTrapResult {
+  readonly kind: 'trap'
+  readonly source: 'trap'
+  readonly actorIndex: number
+  readonly acknowledgementRequired: true
+  readonly description: string
+  readonly turnConsequence: TurnConsequence
+}
+
+export interface ResolvedCellEffectResult {
+  readonly kind: 'cell_effect'
+  readonly source: 'cell_effect'
+  readonly actorIndex: number
+  readonly effect: NonNullable<BoardCell['effect']>
+  readonly turnConsequence: TurnConsequence
+}
+
+export type ResolvedRuleResult =
+  | ResolvedPunishmentResult
+  | ResolvedTrapResult
+  | ResolvedCellEffectResult
+
 export interface BoardCell {
   id: number
   type: 'punishment' | 'bonus' | 'special' | 'restart' | 'trap'

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -66,7 +66,7 @@ export type ResolvedPunishmentCount =
       minimum: number
       maximum: number
       step: number
-      eligibleChooserIndices: number[]
+      eligibleChooserIndices: readonly number[]
     }>
 
 export type TurnConsequence =

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -57,11 +57,7 @@ export interface PunishmentAction {
   targetPlayer?: 'current' | 'previous' | 'next' | 'other'
 }
 
-export type RuleResolutionSource =
-  | 'takeoff_failure'
-  | 'board_punishment'
-  | 'trap'
-  | 'cell_effect'
+export type RuleResolutionSource = 'takeoff_failure' | 'board_punishment' | 'trap' | 'cell_effect'
 
 export type ResolvedPunishmentCount =
   | Readonly<{ kind: 'fixed'; value: number }>


### PR DESCRIPTION
## 变更

- 新增纯规则解析领域模型：来源、触发者、目标、执行者、固定或待外部决定的次数，以及明确的回合后果。
- 起飞失败和随机棋盘统一改用兼容组合选择：仅选择启用、工具强度允许且姿势兼容的组合，并生成合法步长次数。
- 明确解析骰子倍数、前一位、后一位和其他玩家决定次数；后者不再生成默认次数。
- 冻结解析结果及外部选择者列表，避免确认流程读取到被篡改的结果。

## 范围

这是 MR2 的领域层增量：已建立可供 UI 消费的确定规则结果。休息回合消费、陷阱结果接入和 Vue 流程改造留给后续增量；本 MR 不添加次数选择 UI。

## 验证

- `npm test` — 62 passed
- `npm run type-check`
- `npm run lint` — 0 errors，20 个既有 warnings
- `npm run build`
- `npx playwright test` — 9 passed，9 skipped（按项目条件跳过）