### PR TITLE
feat: dark theme visual overhaul v0.2.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" class="dark-mode">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
@@ -10,7 +10,7 @@
     <!-- PWA相关 -->
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta name="theme-color" content="#0a0a1a" />
     
     <!-- 移动端优化 -->
     <meta name="mobile-web-app-capable" content="yes" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ludo-vue-demo",
       "version": "0.1.0",
       "dependencies": {
+        "@lucide/vue": "^1.24.0",
         "@primevue/themes": "^4.3.6",
         "driver.js": "^1.3.6",
         "fflate": "^0.8.2",
@@ -2382,6 +2383,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lucide/vue": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@lucide/vue/-/vue-1.24.0.tgz",
+      "integrity": "sha512-5bNPX0G2YEWdUlBYk7pE8SgDg/f1mkIFpJ9vtE44pW/cwRz7Ioc0tOTESoVJAPvxIELSmYekX+XXIJMjsswNIg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -36,6 +36,7 @@
     ]
   },
   "dependencies": {
+    "@lucide/vue": "^1.24.0",
     "@primevue/themes": "^4.3.6",
     "driver.js": "^1.3.6",
     "fflate": "^0.8.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,19 @@
   import { ref, reactive, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
   import { GameService } from './services/gameService'
   import { GAME_CONFIG } from './config/gameConfig'
+  import {
+    ArrowLeft,
+    Settings,
+    Target,
+    Rocket,
+    Skull,
+    Dices,
+    Upload,
+    HelpCircle,
+    RotateCcw,
+    Volume2,
+    VolumeX,
+  } from '@lucide/vue'
   import type {
     GameState,
     Player,
@@ -38,6 +51,7 @@
     shouldRecoverMovingState,
     type BlockingOverlayState,
   } from './services/gameStateHealth'
+  import { audioService } from './services/audioService'
   import { usePlayerState } from './composables/usePlayerState'
   import { usePunishmentConfigNormalizer } from './composables/usePunishmentConfigNormalizer'
   import { useImportFeedbackDialog } from './composables/useImportFeedbackDialog'
@@ -59,6 +73,12 @@
   // 游戏控制状态
   const gameStarted = ref(false)
   const gameFinished = ref(false)
+
+  // 设置页 Tab 状态
+  const settingsTab = ref<'board' | 'punishment' | 'trap'>('board')
+
+  // 音效状态
+  const audioEnabled = ref(true)
 
   const turnCount = ref(0)
   const lastEffect = ref<string>('')
@@ -183,12 +203,14 @@
       currentTakeoffDiceValue.value = diceValue ?? gameState.diceValue ?? 0
       currentTakeoffExecutorIndex.value = executorIndex !== undefined ? executorIndex : -1
       showTakeoffPunishmentDisplay.value = true
+      audioService.play('punishment')
       handleTakeoffPunishmentDisplay()
       return
     }
 
     if (resolvedPunishment) {
       currentPunishment.value = resolvedPunishment
+      audioService.play('punishment')
       if (
         executorIndex !== undefined &&
         executorIndex >= 0 &&
@@ -209,6 +231,7 @@
     if (resolvedCellEffect && resolvedCellEffect.type === 'trap') {
       currentTrapDescription.value = resolvedCellEffect.description || '未知机关'
       showTrapDisplay.value = true
+      audioService.play('trap')
       return
     }
 
@@ -229,6 +252,9 @@
         resolvedCellEffect.type === 'restart' ||
         resolvedCellEffect.type === 'rest')
     ) {
+      if (resolvedCellEffect.type === 'move' && resolvedCellEffect.value > 0) {
+        audioService.play('bonus')
+      }
       // 到达第1格（飞机场）时，不显示效果确认弹窗
       if (newPosition === 1) {
         await continueAfterMove()
@@ -304,14 +330,6 @@
   }
 
   // 页面导航
-  const showBoardSettings = () => {
-    gameState.gameStatus = 'board_settings'
-  }
-
-  const showSettings = () => {
-    gameState.gameStatus = 'settings'
-  }
-
   const showIntro = () => {
     gameState.gameStatus = 'intro'
   }
@@ -414,7 +432,14 @@
   }
 
   // 添加全局错误监听
+  const toggleAudio = () => {
+    audioEnabled.value = audioService.toggle()
+  }
+
   onMounted(() => {
+    audioService.init()
+    audioEnabled.value = audioService.enabled
+
     // 监听未捕获的 Promise 错误
     window.addEventListener('unhandledrejection', handleUnhandledRejection)
 
@@ -742,6 +767,7 @@
   const handleDiceRoll = async () => {
     if (!canRollDice.value) return
 
+    audioService.play('diceRoll')
     resetEffectChainCount()
     gameState.gameStatus = 'rolling'
     gameState.diceValue = GameService.rollDice()
@@ -787,6 +813,7 @@
 
       // 更新玩家位置
       currentPlayer.position = newPosition
+      audioService.play('pieceStep')
 
       // 显示移动路径信息或起飞信息
       if (canTakeOff) {
@@ -810,6 +837,7 @@
         gameState.gameStatus = 'finished'
         gameFinished.value = true
         showVictoryScreen.value = true
+        audioService.play('victory')
         resetEffectChainCount()
         return
       }
@@ -1814,66 +1842,91 @@
     <!-- 开始页面 -->
     <IntroPage v-if="gameState.gameStatus === 'intro'" @start="handleIntroStart" />
 
-    <!-- 棋盘设置页面 -->
-    <div v-else-if="gameState.gameStatus === 'board_settings'" class="settings-page">
+    <!-- 统一设置页面（Tab 布局） -->
+    <div
+      v-else-if="
+        gameState.gameStatus === 'board_settings' || gameState.gameStatus === 'settings'
+      "
+      class="settings-page"
+    >
       <div class="page-container">
         <div class="settings-header">
-          <h2>🎯 棋盘设置</h2>
-          <p>配置游戏中各种类型格子的数量</p>
+          <h2><Settings :size="24" /> 游戏设置</h2>
+          <p>配置棋盘、惩罚和陷阱</p>
         </div>
 
-        <BoardConfigPanel :config="gameState.boardConfig" @update="updateBoardConfig" />
-
-        <TrapConfigPanel :traps="trapConfig" @update="updateTrapConfig" />
-
-        <div class="page-actions">
-          <button class="btn-secondary" @click="showIntro">
-            <span class="btn-icon">⬅️</span>
-            <span class="btn-text">返回开始</span>
-          </button>
-          <button class="btn-primary" :disabled="!isBoardConfigValid" @click="showSettings">
-            <span class="btn-icon">⚙️</span>
-            <span class="btn-text">下一步：惩罚设置</span>
-          </button>
-        </div>
-      </div>
-    </div>
-
-    <!-- 设置页面 -->
-    <div v-else-if="gameState.gameStatus === 'settings'" class="settings-page">
-      <div class="page-container">
-        <div class="settings-header">
-          <h2>⚙️ 惩罚设置</h2>
-          <p>配置游戏中的工具、部位、姿势和比例</p>
-        </div>
-
-        <PunishmentConfigPanel
-          :config="gameState.punishmentConfig"
-          @update="updatePunishmentConfig"
-          @validation-failed="handleValidationFailed"
-        />
-
-        <div class="page-actions">
-          <button class="btn-secondary" @click="showBoardSettings">
-            <span class="btn-icon">⬅️</span>
-            <span class="btn-text">返回棋盘设置</span>
+        <!-- Tab 栏 -->
+        <div class="settings-tabs">
+          <button
+            class="tab-item"
+            :class="{ 'tab-item--active': settingsTab === 'board' }"
+            @click="settingsTab = 'board'"
+          >
+            <Target :size="16" />
+            <span>棋盘</span>
           </button>
           <button
-            class="btn-primary"
-            :disabled="!isConfigValid"
+            class="tab-item"
+            :class="{ 'tab-item--active': settingsTab === 'punishment' }"
+            @click="settingsTab = 'punishment'"
+          >
+            <Settings :size="16" />
+            <span>惩罚</span>
+          </button>
+          <button
+            class="tab-item"
+            :class="{ 'tab-item--active': settingsTab === 'trap' }"
+            @click="settingsTab = 'trap'"
+          >
+            <Skull :size="16" />
+            <span>陷阱</span>
+          </button>
+        </div>
+
+        <!-- Tab 内容 -->
+        <div class="settings-tab-content">
+          <BoardConfigPanel
+            v-show="settingsTab === 'board'"
+            :config="gameState.boardConfig"
+            @update="updateBoardConfig"
+          />
+
+          <PunishmentConfigPanel
+            v-show="settingsTab === 'punishment'"
+            :config="gameState.punishmentConfig"
+            @update="updatePunishmentConfig"
+            @validation-failed="handleValidationFailed"
+          />
+
+          <TrapConfigPanel
+            v-show="settingsTab === 'trap'"
+            :traps="trapConfig"
+            @update="updateTrapConfig"
+          />
+        </div>
+
+        <!-- 操作按钮 -->
+        <div class="page-actions">
+          <button class="btn btn-secondary" @click="showIntro">
+            <ArrowLeft :size="16" />
+            <span class="btn-text">返回</span>
+          </button>
+          <button
+            class="btn btn-primary"
+            :disabled="!isConfigValid || !isBoardConfigValid"
             @click="generatePunishmentCombinations"
           >
-            <span class="btn-icon">🎯</span>
+            <Target :size="16" />
             <span class="btn-text">生成惩罚组合</span>
           </button>
         </div>
 
         <div v-if="punishmentCombinations.length > 0" class="page-actions">
           <p class="combinations-info">
-            已生成 {{ punishmentCombinations.length }} 个惩罚组合，点击开始游戏继续
+            已生成 {{ punishmentCombinations.length }} 个惩罚组合
           </p>
-          <button class="btn-primary" @click="startGameWithStats">
-            <span class="btn-icon">🚀</span>
+          <button class="btn btn-primary" @click="startGameWithStats">
+            <Rocket :size="16" />
             <span class="btn-text">开始游戏</span>
           </button>
         </div>
@@ -1885,7 +1938,11 @@
       <!-- 移动端顶部栏 -->
       <header class="game-header">
         <div class="header-content">
-          <h1>🎲 惩罚飞行棋</h1>
+          <h1><Dices :size="24" /> 惩罚飞行棋</h1>
+          <button class="audio-toggle-btn" :title="audioEnabled ? '静音' : '开启声音'" @click="toggleAudio">
+            <Volume2 v-if="audioEnabled" :size="18" />
+            <VolumeX v-else :size="18" />
+          </button>
         </div>
         <p>环形棋盘游戏，支持自定义惩罚设置</p>
       </header>
@@ -2011,7 +2068,7 @@
                       backgroundColor: gameState.players[gameState.currentPlayerIndex].color,
                     }"
                   >
-                    ✈️
+                    {{ gameState.players[gameState.currentPlayerIndex].name.charAt(0) }}
                   </div>
                   <div class="current-info">
                     <div class="current-name">
@@ -2041,7 +2098,7 @@
                 <div class="compact-winner-display">
                   <i class="pi pi-trophy winner-icon"></i>
                   <div class="winner-avatar" :style="{ backgroundColor: gameState.winner.color }">
-                    🏆
+                    {{ gameState.winner.name.charAt(0) }}
                   </div>
                   <div class="winner-name">{{ gameState.winner.name }} 获胜!</div>
                 </div>
@@ -2147,14 +2204,12 @@
     <div class="guide-controls">
       <!-- 配置导出按钮 -->
       <button class="export-btn" title="导出配置" @click="openConfigExport">
-        <span class="export-icon">📤</span>
-        <span class="export-text">导出</span>
+        <Upload :size="20" />
       </button>
 
       <!-- 主要引导按钮 -->
       <button class="guide-btn" title="查看当前页面引导" @click="startGuide">
-        <span class="guide-icon">❓</span>
-        <span class="guide-text">帮助</span>
+        <HelpCircle :size="20" />
       </button>
 
       <!-- 引导设置菜单 -->
@@ -2164,7 +2219,7 @@
           title="引导设置"
           @click="showGuideSettings = !showGuideSettings"
         >
-          <span class="settings-icon">⚙️</span>
+          <Settings :size="18" />
         </button>
 
         <!-- 设置菜单 -->
@@ -2183,7 +2238,7 @@
 
           <div class="settings-item">
             <button class="reset-btn" title="重置引导状态" @click="resetGuideStatus">
-              <span class="reset-icon">🔄</span>
+              <RotateCcw :size="16" />
               <span class="reset-text">重置引导</span>
             </button>
           </div>
@@ -2215,7 +2270,7 @@
     >
       <div class="import-feedback" :class="`import-feedback--${importFeedbackType}`">
         <span class="import-feedback-icon">
-          {{ importFeedbackType === 'success' ? '✅' : '❌' }}
+          {{ importFeedbackType === 'success' ? '\u2713' : '\u2717' }}
         </span>
         <p class="import-feedback-message">{{ importFeedbackMessage }}</p>
       </div>
@@ -2226,7 +2281,8 @@
 <style scoped>
   .app {
     min-height: 100vh;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background-color: var(--bg-primary);
+    background-image: radial-gradient(ellipse at top, rgba(102, 126, 234, 0.15), transparent 60%);
   }
 
   .import-feedback {
@@ -2244,11 +2300,11 @@
     margin: 0;
     white-space: pre-line;
     line-height: 1.5;
-    color: #2f3542;
+    color: var(--text-secondary);
   }
 
   .import-feedback--error .import-feedback-message {
-    color: #c0392b;
+    color: var(--color-danger);
   }
 
   .page-container {
@@ -2266,13 +2322,14 @@
 
   .combinations-info {
     text-align: center;
-    color: white;
+    color: var(--text-primary);
     margin: clamp(0.5rem, 2vw, 1rem) 0;
     padding: clamp(0.5rem, 2vw, 1rem);
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: clamp(4px, 1vw, 8px);
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: var(--bg-glass);
+    border-radius: var(--radius-sm);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
     font-size: clamp(0.8rem, 2.5vw, 1rem);
   }
 
@@ -2281,11 +2338,54 @@
     min-height: 100vh;
     padding: clamp(0.5rem, 3vw, 1rem);
     width: 100%;
+    background-color: var(--bg-primary);
+  }
+
+  /* Tab 栏 */
+  .settings-tabs {
+    display: flex;
+    gap: var(--spacing-xs);
+    background: var(--bg-secondary);
+    border-radius: var(--radius-md);
+    padding: 4px;
+    margin-bottom: clamp(1rem, 3vw, 1.5rem);
+  }
+
+  .tab-item {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.6rem 1rem;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+  }
+
+  .tab-item:hover {
+    color: var(--text-primary);
+    background: var(--bg-glass);
+  }
+
+  .tab-item--active {
+    background: var(--bg-glass);
+    color: var(--text-primary);
+    box-shadow: var(--glow-sm) rgba(102, 126, 234, 0.2);
+    border: var(--glass-border);
+  }
+
+  .settings-tab-content {
+    min-height: 300px;
   }
 
   .settings-header {
     text-align: center;
-    color: white;
     margin-bottom: clamp(1rem, 4vw, 1.5rem);
   }
 
@@ -2293,13 +2393,14 @@
     margin: 0 0 clamp(0.25rem, 1vw, 0.5rem) 0;
     font-size: clamp(1.5rem, 6vw, 2rem);
     font-weight: bold;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+    color: var(--text-primary);
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
   }
 
   .settings-header p {
     margin: 0;
     font-size: clamp(0.8rem, 2.5vw, 1rem);
-    opacity: 0.9;
+    color: var(--text-secondary);
   }
 
   /* 游戏页面样式 */
@@ -2308,15 +2409,16 @@
     width: 100%;
     display: flex;
     flex-direction: column;
+    background-color: var(--bg-primary);
   }
 
   .game-header {
     text-align: center;
-    color: white;
     padding: clamp(0.5rem, 2vw, 1rem);
-    background: rgba(255, 255, 255, 0.1);
-    backdrop-filter: blur(10px);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border-bottom: var(--glass-border);
+    box-shadow: var(--glass-shadow);
   }
 
   .header-content {
@@ -2331,13 +2433,37 @@
     margin: 0;
     font-size: clamp(1.2rem, 4vw, 1.8rem);
     font-weight: bold;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+    color: var(--text-primary);
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .audio-toggle-btn {
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    padding: 0.4rem;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 32px;
+    min-width: 32px;
+  }
+
+  .audio-toggle-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-glass-hover);
   }
 
   .game-header p {
     margin: clamp(0.25rem, 1vw, 0.5rem) 0 0 0;
     font-size: clamp(0.7rem, 2vw, 0.9rem);
-    opacity: 0.9;
+    color: var(--text-secondary);
   }
 
   .game-main {
@@ -2355,9 +2481,10 @@
     min-width: 280px;
     display: flex;
     flex-direction: column;
-    background: rgba(255, 255, 255, 0.95);
-    backdrop-filter: blur(20px);
-    border-right: 1px solid rgba(0, 0, 0, 0.1);
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border-right: var(--glass-border);
+    box-shadow: var(--glass-shadow);
     overflow-y: auto;
   }
 
@@ -2377,9 +2504,10 @@
   }
 
   .top-status-area {
-    background: rgba(255, 255, 255, 0.95);
-    backdrop-filter: blur(20px);
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border-bottom: var(--glass-border);
+    box-shadow: var(--glass-shadow);
     padding: 1rem 2rem;
     display: flex;
     gap: 1rem;
@@ -2404,7 +2532,7 @@
     gap: 0.5rem;
     font-size: 1rem;
     font-weight: 600;
-    color: #333;
+    color: var(--text-primary);
   }
 
   .dice-card,
@@ -2429,9 +2557,11 @@
   .compact-players-card,
   .compact-winner-card {
     margin: 0;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    border-radius: 12px;
-    border: 1px solid rgba(0, 0, 0, 0.05);
+    background: var(--bg-glass);
+    box-shadow: var(--glass-shadow);
+    border-radius: var(--radius-md);
+    border: var(--glass-border);
+    backdrop-filter: blur(var(--glass-blur));
   }
 
   .compact-status-card .p-card-content,
@@ -2456,7 +2586,7 @@
   }
 
   .status-icon {
-    color: #667eea;
+    color: var(--color-accent);
     font-size: 1rem;
   }
 
@@ -2485,14 +2615,14 @@
 
   .compact-current-player .current-name {
     font-weight: 600;
-    color: #333;
+    color: var(--text-primary);
     font-size: 0.9rem;
     margin-bottom: 0.1rem;
   }
 
   .compact-current-player .current-position {
     font-size: 0.8rem;
-    color: #666;
+    color: var(--text-secondary);
   }
 
   .compact-players-list {
@@ -2506,16 +2636,17 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.4rem 0.6rem;
-    border-radius: 8px;
-    background: #f8f9fa;
-    border: 1px solid #e9ecef;
-    transition: all 0.3s ease;
+    border-radius: var(--radius-sm);
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    transition: all var(--transition-normal);
     font-size: 0.85rem;
   }
 
   .compact-player-item.current-player {
-    background: rgba(34, 197, 94, 0.1);
-    border-color: rgba(34, 197, 94, 0.3);
+    background: rgba(102, 126, 234, 0.15);
+    border-color: rgba(102, 126, 234, 0.4);
+    box-shadow: 0 0 16px rgba(102, 126, 234, 0.25);
     transform: scale(1.02);
   }
 
@@ -2538,18 +2669,18 @@
 
   .compact-player-item .player-name {
     font-weight: 600;
-    color: #333;
+    color: var(--text-primary);
     margin-bottom: 0.1rem;
     font-size: 0.8rem;
   }
 
   .compact-player-item .player-position {
     font-size: 0.7rem;
-    color: #666;
+    color: var(--text-secondary);
   }
 
   .compact-player-item .current-indicator {
-    color: #22c55e;
+    color: var(--color-accent-light);
     font-size: 0.8rem;
   }
 
@@ -2557,13 +2688,13 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    color: #f59e0b;
+    color: var(--color-warning);
     font-weight: 600;
   }
 
   .winner-icon {
     font-size: 1.2rem;
-    color: #f59e0b;
+    color: var(--color-warning);
   }
 
   .compact-winner-display .winner-avatar {
@@ -2607,18 +2738,19 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    background: rgba(255, 255, 255, 0.1);
-    backdrop-filter: blur(10px);
-    border-radius: 8px;
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border-radius: var(--radius-sm);
     padding: 0.5rem;
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
     flex-shrink: 0;
   }
 
   /* 移动端回合数显示 - 紧凑版 */
   .mobile-turn-display {
     text-align: center;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, var(--color-accent) 0%, #764ba2 100%);
     color: white;
     padding: 0.4rem 0.6rem;
     border-radius: 6px;
@@ -2672,11 +2804,11 @@
 
   .status-label {
     font-weight: 500;
-    color: #666;
+    color: var(--text-secondary);
   }
 
   .turn-badge {
-    background: #3b82f6;
+    background: var(--color-accent);
   }
 
   .status-tag {
@@ -2689,9 +2821,9 @@
     align-items: center;
     gap: 1rem;
     padding: 0.5rem;
-    background: rgba(59, 130, 246, 0.1);
-    border-radius: 8px;
-    border: 2px solid rgba(59, 130, 246, 0.2);
+    background: rgba(102, 126, 234, 0.12);
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(102, 126, 234, 0.25);
   }
 
   .current-avatar {
@@ -2714,13 +2846,13 @@
   .current-name {
     font-weight: bold;
     font-size: 1.1rem;
-    color: #333;
+    color: var(--text-primary);
     margin-bottom: 0.25rem;
   }
 
   .current-position {
     font-size: 0.9rem;
-    color: #666;
+    color: var(--text-secondary);
   }
 
   /* 玩家列表样式 */
@@ -2735,15 +2867,16 @@
     align-items: center;
     gap: 0.75rem;
     padding: 0.75rem;
-    border-radius: 8px;
-    background: #f8f9fa;
-    border: 1px solid #e9ecef;
-    transition: all 0.3s ease;
+    border-radius: var(--radius-sm);
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    transition: all var(--transition-normal);
   }
 
   .player-item.current-player {
-    background: rgba(34, 197, 94, 0.1);
-    border-color: rgba(34, 197, 94, 0.3);
+    background: rgba(102, 126, 234, 0.15);
+    border-color: rgba(102, 126, 234, 0.4);
+    box-shadow: 0 0 16px rgba(102, 126, 234, 0.25);
     transform: scale(1.02);
   }
 
@@ -2770,17 +2903,17 @@
 
   .player-name {
     font-weight: 600;
-    color: #333;
+    color: var(--text-primary);
     margin-bottom: 0.25rem;
   }
 
   .player-position {
     font-size: 0.85rem;
-    color: #666;
+    color: var(--text-secondary);
   }
 
   .current-indicator {
-    color: #22c55e;
+    color: var(--color-accent-light);
     font-size: 1.2rem;
     animation: bounce 1s infinite;
   }
@@ -2859,7 +2992,7 @@
       width: 100%;
       min-width: unset;
       border-right: none;
-      border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+      border-bottom: var(--glass-border);
       overflow-y: visible;
     }
 
@@ -2916,17 +3049,18 @@
     .mobile-control-panel {
       display: flex;
       height: 38vh; /* 增加到屏幕高度的38% */
-      background: rgba(255, 255, 255, 0.95);
-      backdrop-filter: blur(20px);
-      border-bottom: 2px solid rgba(0, 0, 0, 0.1);
+      background: var(--bg-glass);
+      backdrop-filter: blur(var(--glass-blur));
+      border-bottom: var(--glass-border);
+      box-shadow: var(--glass-shadow);
       flex-shrink: 0;
     }
 
     /* 左侧骰子区域 - 占据控制面板的30% */
     .mobile-dice-section {
       width: 30%;
-      border-right: 1px solid rgba(0, 0, 0, 0.1);
-      background: rgba(248, 249, 250, 0.5);
+      border-right: var(--glass-border);
+      background: var(--bg-secondary);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -2946,8 +3080,8 @@
       flex: 1;
       overflow: hidden;
       min-height: 0; /* 允许flex子项收缩 */
-      background: rgba(255, 255, 255, 0.05);
-      border-radius: 8px;
+      background: var(--bg-secondary);
+      border-radius: var(--radius-sm);
       margin-top: 0.3rem;
       padding: 0.2rem;
     }
@@ -2968,7 +3102,7 @@
     .mobile-player-panel .player-panel h3 {
       margin: 0 0 0.5rem 0;
       font-size: 0.9rem;
-      color: rgba(255, 255, 255, 0.9);
+      color: var(--text-primary);
       text-align: center;
       font-weight: 600;
     }
@@ -2989,16 +3123,17 @@
     .mobile-player-panel .player-card {
       padding: 0.5rem;
       border-width: 1px;
-      background: rgba(255, 255, 255, 0.95);
-      border-radius: 8px;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-      transition: all 0.2s ease;
+      background: var(--bg-glass);
+      border: var(--glass-border);
+      border-radius: var(--radius-sm);
+      box-shadow: var(--glass-shadow);
+      transition: all var(--transition-fast);
     }
 
     .mobile-player-panel .player-card.current {
-      background: rgba(59, 130, 246, 0.15);
-      border-color: rgba(59, 130, 246, 0.4);
-      box-shadow: 0 3px 8px rgba(59, 130, 246, 0.25);
+      background: rgba(102, 126, 234, 0.15);
+      border-color: rgba(102, 126, 234, 0.4);
+      box-shadow: 0 0 16px rgba(102, 126, 234, 0.25);
       transform: translateY(-1px);
     }
 
@@ -3024,7 +3159,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-      color: #333;
+      color: var(--text-primary);
     }
 
     .mobile-player-panel .player-stats {
@@ -3039,14 +3174,14 @@
     .mobile-player-panel .label {
       font-size: 0.75rem;
       min-width: 35px;
-      color: #666;
+      color: var(--text-secondary);
       font-weight: 500;
     }
 
     .mobile-player-panel .value {
       font-size: 0.75rem;
       font-weight: 600;
-      color: #333;
+      color: var(--text-primary);
     }
 
     .mobile-player-panel .players-container::-webkit-scrollbar {
@@ -3054,12 +3189,12 @@
     }
 
     .mobile-player-panel .players-container::-webkit-scrollbar-track {
-      background: rgba(255, 255, 255, 0.1);
+      background: var(--bg-secondary);
       border-radius: 1px;
     }
 
     .mobile-player-panel .players-container::-webkit-scrollbar-thumb {
-      background: rgba(255, 255, 255, 0.3);
+      background: rgba(255, 255, 255, 0.2);
       border-radius: 1px;
     }
 
@@ -3125,8 +3260,9 @@
     .mobile-dice-section .result-display {
       padding: 0.3rem 0.6rem;
       border-radius: 4px;
-      background: rgba(255, 255, 255, 0.9);
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      background: var(--bg-glass);
+      border: var(--glass-border);
+      box-shadow: var(--glass-shadow);
     }
 
     .mobile-dice-section .result-number {
@@ -3145,7 +3281,9 @@
       padding: 0.25rem 0.5rem;
       font-size: 0.65rem;
       border-radius: 3px;
-      background: rgba(255, 255, 255, 0.8);
+      background: var(--bg-glass);
+      border: var(--glass-border);
+      color: var(--text-secondary);
       text-align: center;
     }
   }
@@ -3329,12 +3467,12 @@
     }
 
     .player-item:hover {
-      background: #f8f9fa;
+      background: var(--bg-glass-hover);
       transform: none;
     }
 
     .player-item:active {
-      background: rgba(59, 130, 246, 0.1);
+      background: rgba(102, 126, 234, 0.15);
       transform: scale(0.98);
     }
 
@@ -3496,16 +3634,16 @@
     position: fixed;
     bottom: 1.5rem;
     right: 1.5rem;
-    background: #ff6b6b;
+    background: var(--color-punishment);
     color: #fff;
-    border: none;
+    border: 1px solid rgba(255, 71, 87, 0.4);
     border-radius: 50%;
     width: 60px;
     height: 60px;
     font-size: 1.8rem;
     cursor: pointer;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    transition: transform 0.2s ease;
+    box-shadow: 0 4px 16px rgba(255, 71, 87, 0.35);
+    transition: transform var(--transition-fast);
     z-index: 1100;
     display: flex;
     align-items: center;
@@ -3515,6 +3653,7 @@
 
   .guide-btn:hover {
     transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(255, 71, 87, 0.45);
   }
 
   .guide-icon {
@@ -3539,9 +3678,9 @@
   }
 
   .export-btn {
-    background: rgba(59, 130, 246, 0.9);
+    background: rgba(59, 130, 246, 0.75);
     color: white;
-    border: 2px solid rgba(59, 130, 246, 0.3);
+    border: 1px solid rgba(59, 130, 246, 0.35);
     border-radius: 50%;
     width: 60px;
     height: 60px;
@@ -3549,18 +3688,18 @@
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
-    transition: all 0.2s ease;
-    backdrop-filter: blur(10px);
+    box-shadow: 0 4px 16px rgba(59, 130, 246, 0.25);
+    transition: all var(--transition-fast);
+    backdrop-filter: blur(var(--glass-blur));
     font-size: 1.2rem;
     font-weight: 600;
   }
 
   .export-btn:hover {
     transform: translateY(-2px);
-    background: rgba(59, 130, 246, 1);
+    background: rgba(59, 130, 246, 0.9);
     border-color: rgba(59, 130, 246, 0.5);
-    box-shadow: 0 6px 16px rgba(59, 130, 246, 0.4);
+    box-shadow: 0 6px 20px rgba(59, 130, 246, 0.35);
   }
 
   .export-icon {
@@ -3579,37 +3718,37 @@
   }
 
   .settings-toggle {
-    background: rgba(255, 255, 255, 0.9);
-    color: #333;
-    border: 2px solid #ddd;
+    background: var(--bg-glass);
+    color: var(--text-primary);
+    border: var(--glass-border);
     border-radius: 50%;
     width: 50px;
     height: 50px;
     font-size: 1.2rem;
     cursor: pointer;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-    transition: all 0.2s ease;
-    backdrop-filter: blur(10px);
+    box-shadow: var(--glass-shadow);
+    transition: all var(--transition-fast);
+    backdrop-filter: blur(var(--glass-blur));
   }
 
   .settings-toggle:hover {
     transform: translateY(-2px);
-    background: rgba(255, 255, 255, 1);
-    border-color: #ff6b6b;
+    background: var(--bg-glass-hover);
+    border-color: rgba(255, 71, 87, 0.4);
   }
 
   .settings-menu {
     position: absolute;
     bottom: 60px;
     left: 0;
-    background: rgba(255, 255, 255, 0.95);
-    border-radius: 12px;
+    background: var(--bg-glass);
+    border-radius: var(--radius-md);
     padding: 1rem;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    box-shadow: var(--glass-shadow-lg);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
     min-width: 200px;
-    animation: fadeInUp 0.3s ease;
+    animation: fadeInUp var(--transition-normal);
   }
 
   @keyframes fadeInUp {
@@ -3639,29 +3778,30 @@
     align-items: center;
     gap: 0.5rem;
     font-size: 0.9rem;
-    color: #333;
+    color: var(--text-primary);
     cursor: pointer;
   }
 
   .setting-checkbox {
     width: 16px;
     height: 16px;
-    accent-color: #ff6b6b;
+    accent-color: var(--color-punishment);
   }
 
   .checkbox-text {
     font-weight: 500;
+    color: var(--text-primary);
   }
 
   .reset-btn {
-    background: #ff6b6b;
+    background: var(--color-punishment);
     color: #fff;
     border: none;
-    border-radius: 8px;
+    border-radius: var(--radius-sm);
     padding: 0.5rem 1rem;
     font-size: 0.85rem;
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: all var(--transition-fast);
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -3670,7 +3810,7 @@
   }
 
   .reset-btn:hover {
-    background: #e55a5a;
+    background: #e8414f;
     transform: translateY(-1px);
   }
 
@@ -3680,14 +3820,15 @@
 
   .reset-text {
     font-weight: 500;
+    color: var(--text-primary);
   }
 
   .settings-footer {
     margin-top: 0.75rem;
     padding-top: 0.75rem;
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
     font-size: 0.75rem;
-    color: #666;
+    color: var(--text-muted);
     text-align: center;
     line-height: 1.3;
   }

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -1,53 +1,81 @@
-/* color palette from <https://github.com/vuejs/theme> */
+/* Dark Premium Design Tokens */
 :root {
-  --vt-c-white: #ffffff;
-  --vt-c-white-soft: #f8f8f8;
-  --vt-c-white-mute: #f2f2f2;
+  /* Background layers */
+  --bg-primary: #0a0a1a;
+  --bg-secondary: rgba(255, 255, 255, 0.05);
+  --bg-glass: rgba(255, 255, 255, 0.08);
+  --bg-glass-hover: rgba(255, 255, 255, 0.12);
+  --bg-glass-active: rgba(255, 255, 255, 0.16);
+  --bg-surface: rgba(255, 255, 255, 0.04);
 
-  --vt-c-black: #181818;
-  --vt-c-black-soft: #222222;
-  --vt-c-black-mute: #282828;
+  /* Text */
+  --text-primary: rgba(255, 255, 255, 0.92);
+  --text-secondary: rgba(255, 255, 255, 0.6);
+  --text-muted: rgba(255, 255, 255, 0.35);
+  --text-inverse: #0a0a1a;
 
-  --vt-c-indigo: #2c3e50;
+  /* Cell type colors */
+  --color-punishment: #ff4757;
+  --color-bonus: #2ed573;
+  --color-special: #ffa502;
+  --color-restart: #a855f7;
+  --color-trap: #dc2626;
+  --color-normal: rgba(255, 255, 255, 0.2);
 
-  --vt-c-divider-light-1: rgba(60, 60, 60, 0.29);
-  --vt-c-divider-light-2: rgba(60, 60, 60, 0.12);
-  --vt-c-divider-dark-1: rgba(84, 84, 84, 0.65);
-  --vt-c-divider-dark-2: rgba(84, 84, 84, 0.48);
+  /* Accent */
+  --color-accent: #667eea;
+  --color-accent-light: #8b9cf7;
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-danger: #ef4444;
+  --color-info: #3b82f6;
 
-  --vt-c-text-light-1: var(--vt-c-indigo);
-  --vt-c-text-light-2: rgba(60, 60, 60, 0.66);
-  --vt-c-text-dark-1: var(--vt-c-white);
-  --vt-c-text-dark-2: rgba(235, 235, 235, 0.64);
-}
+  /* Player colors */
+  --player-1: #ff6b6b;
+  --player-2: #4ecdc4;
+  --player-3: #45b7d1;
+  --player-4: #feca57;
+  --player-5: #ff9ff3;
+  --player-6: #54a0ff;
+  --player-7: #5f27cd;
+  --player-8: #96ceb4;
 
-/* semantic color variables for this project */
-:root {
-  --color-background: var(--vt-c-white);
-  --color-background-soft: var(--vt-c-white-soft);
-  --color-background-mute: var(--vt-c-white-mute);
+  /* Player color RGB (for rgba usage) */
+  --player-1-rgb: 255, 107, 107;
+  --player-2-rgb: 78, 205, 196;
+  --player-3-rgb: 69, 183, 209;
+  --player-4-rgb: 254, 202, 87;
 
-  --color-border: var(--vt-c-divider-light-2);
-  --color-border-hover: var(--vt-c-divider-light-1);
+  /* Glass effects */
+  --glass-blur: 12px;
+  --glass-border: 1px solid rgba(255, 255, 255, 0.1);
+  --glass-border-hover: 1px solid rgba(255, 255, 255, 0.2);
+  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  --glass-shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.4);
 
-  --color-heading: var(--vt-c-text-light-1);
-  --color-text: var(--vt-c-text-light-1);
+  /* Border radius */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 20px;
+  --radius-full: 9999px;
 
-  --section-gap: 160px;
-}
+  /* Spacing */
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 16px;
+  --spacing-lg: 24px;
+  --spacing-xl: 32px;
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-background: var(--vt-c-black);
-    --color-background-soft: var(--vt-c-black-soft);
-    --color-background-mute: var(--vt-c-black-mute);
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 300ms ease;
+  --transition-slow: 500ms ease;
 
-    --color-border: var(--vt-c-divider-dark-2);
-    --color-border-hover: var(--vt-c-divider-dark-1);
-
-    --color-heading: var(--vt-c-text-dark-1);
-    --color-text: var(--vt-c-text-dark-2);
-  }
+  /* Glow */
+  --glow-sm: 0 0 8px;
+  --glow-md: 0 0 16px;
+  --glow-lg: 0 0 24px;
 }
 
 *,
@@ -60,11 +88,8 @@
 
 body {
   min-height: 100vh;
-  color: var(--color-text);
-  background: var(--color-background);
-  transition:
-    color 0.5s,
-    background-color 0.5s;
+  color: var(--text-primary);
+  background: var(--bg-primary);
   line-height: 1.6;
   font-family:
     Inter,
@@ -79,59 +104,13 @@ body {
     'Droid Sans',
     'Helvetica Neue',
     sans-serif;
-  font-size: clamp(12px, 2.5vw, 16px); /* 自适应字体大小 */
+  font-size: clamp(12px, 2.5vw, 16px);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  /* 移动端优化 */
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
   overflow-x: hidden;
-}
-
-/* 自适应布局系统 */
-@media (max-width: 1023px) {
-  /* 确保所有元素都能正确显示 */
-  * {
-    max-width: 100%;
-  }
-  
-  /* 防止水平滚动 */
-  html, body {
-    overflow-x: hidden;
-    width: 100%;
-  }
-  
-  /* 自适应容器 */
-  .container {
-    width: 100%;
-    padding: clamp(0.5rem, 2vw, 2rem);
-    margin: 0 auto;
-  }
-  
-  /* 自适应网格 */
-  .grid {
-    display: grid;
-    gap: clamp(0.5rem, 2vw, 2rem);
-    grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 1fr));
-  }
-  
-  /* 自适应按钮 */
-  .btn {
-    padding: clamp(0.5rem, 2vw, 1rem) clamp(1rem, 4vw, 2rem);
-    font-size: clamp(0.8rem, 2.5vw, 1rem);
-    border-radius: clamp(4px, 1vw, 8px);
-  }
-  
-  /* 自适应标题 */
-  h1 { font-size: clamp(1.5rem, 6vw, 3rem); }
-  h2 { font-size: clamp(1.2rem, 5vw, 2.5rem); }
-  h3 { font-size: clamp(1rem, 4vw, 2rem); }
-  h4 { font-size: clamp(0.9rem, 3.5vw, 1.5rem); }
-  
-  /* 自适应文本 */
-  p { font-size: clamp(0.8rem, 2.5vw, 1rem); }
-  span { font-size: clamp(0.7rem, 2vw, 0.9rem); }
 }
 
 @media (max-width: 480px) {

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -6,127 +6,208 @@
   padding: 0;
   font-weight: normal;
   min-height: 100vh;
-  /* 移动端优化 */
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
 }
 
+/* ===== Common Button Styles ===== */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-normal);
+  min-height: 44px;
+  touch-action: manipulation;
+  text-decoration: none;
+  line-height: 1.2;
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none !important;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--color-accent) 0%, #764ba2 100%);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
+}
+
+.btn-primary:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+}
+
+.btn-secondary {
+  background: var(--bg-glass);
+  color: var(--text-primary);
+  border: var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+}
+
+.btn-secondary:not(:disabled):hover {
+  background: var(--bg-glass-hover);
+  border-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.btn-danger {
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 4px 15px rgba(239, 68, 68, 0.3);
+}
+
+.btn-danger:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(239, 68, 68, 0.4);
+}
+
+.btn-success {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 4px 15px rgba(34, 197, 94, 0.3);
+}
+
+.btn-success:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(34, 197, 94, 0.4);
+}
+
+.btn-icon {
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.1em;
+}
+
+.btn-text {
+  white-space: nowrap;
+}
+
+/* ===== Common Glass Card ===== */
+.glass-card {
+  background: var(--bg-glass);
+  backdrop-filter: blur(var(--glass-blur));
+  border: var(--glass-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--glass-shadow);
+  padding: var(--spacing-lg);
+}
+
+.glass-card:hover {
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+/* ===== Common Modal Overlay ===== */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  padding: 1rem;
+  animation: modalFadeIn 0.3s ease;
+}
+
+.modal-content {
+  background: rgba(20, 20, 40, 0.95);
+  backdrop-filter: blur(var(--glass-blur));
+  border: var(--glass-border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--glass-shadow-lg);
+  max-width: min(500px, 92vw);
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: var(--spacing-xl);
+  animation: modalSlideIn 0.3s ease;
+}
+
+@keyframes modalFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes modalSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* ===== Scrollbar Styling ===== */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+/* ===== Links ===== */
 a,
 .green {
   text-decoration: none;
-  color: hsla(160, 100%, 37%, 1);
+  color: var(--color-accent-light);
   transition: 0.4s;
   padding: 3px;
 }
 
 @media (hover: hover) {
   a:hover {
-    background-color: hsla(160, 100%, 37%, 0.2);
+    background-color: rgba(102, 126, 234, 0.2);
   }
 }
 
-/* 平板端布局 */
-@media (max-width: 1023px) and (min-width: 768px) {
-  #app {
-    padding: 0 1rem;
-    width: 100%;
-    max-width: none;
-  }
-}
-
-/* 移动端布局 - 紧凑设计 */
+/* ===== Mobile Optimizations ===== */
 @media (max-width: 767px) {
-  #app {
-    padding: 0;
-    width: 100%;
-    max-width: none;
-  }
-  
-  /* 移动端全局样式优化 */
   * {
     -webkit-tap-highlight-color: transparent;
   }
-  
-  /* 触摸优化 */
-  button, .btn {
-    min-height: 44px; /* 确保触摸目标足够大 */
+
+  button,
+  .btn {
+    min-height: 44px;
     touch-action: manipulation;
   }
-  
-  /* 紧凑间距 */
-  .container {
-    padding: 0.5rem;
-  }
-  
-  /* 优化滚动 */
-  .scrollable {
-    -webkit-overflow-scrolling: touch;
-    scroll-behavior: smooth;
-  }
 }
 
-/* 小屏手机优化 */
-@media (max-width: 480px) {
-  #app {
-    padding: 0;
-  }
-  
-  /* 更紧凑的间距 */
-  .container {
-    padding: 0.25rem;
-  }
-  
-  /* 优化字体大小 */
-  body {
-    font-size: 14px;
-  }
-}
-
-/* 超小屏手机优化 */
 @media (max-width: 360px) {
-  #app {
-    padding: 0;
-  }
-  
-  body {
-    font-size: 13px;
-  }
-  
-  /* 最小触摸目标 */
-  button, .btn {
+  button,
+  .btn {
     min-height: 40px;
     padding: 0.5rem 0.75rem;
   }
 }
 
-/* 横屏模式优化 */
-@media (max-width: 767px) and (orientation: landscape) {
-  #app {
-    padding: 0.25rem;
-  }
-  
-  /* 横屏时更紧凑的布局 */
-  .game-board {
-    max-height: 80vh;
-  }
-}
-
-/* 高分辨率屏幕优化 */
-@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-  /* 确保在高分辨率屏幕上清晰显示 */
-  .board-cell,
-  .player-marker,
-  .btn {
-    border-width: 0.5px;
-  }
-}
-
-/* 深色模式支持 */
-@media (prefers-color-scheme: dark) {
-  /* 可以在这里添加深色模式样式 */
-}
-
-/* 减少动画偏好 */
+/* ===== Reduced Motion ===== */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/src/components/BoardConfig.vue
+++ b/src/components/BoardConfig.vue
@@ -1,5 +1,17 @@
 <script setup lang="ts">
-  import { ref, computed } from 'vue'
+  import { ref, computed, watch } from 'vue'
+  import {
+    Target,
+    Settings,
+    AlertTriangle,
+    Rocket,
+    ArrowLeft,
+    Info,
+    RotateCcw,
+    Skull,
+    Check,
+    X,
+  } from '@lucide/vue'
   import type { BoardConfig } from '../types/game'
   import { GameService } from '../services/gameService'
 
@@ -16,6 +28,14 @@
 
   // 本地配置状态
   const localConfig = ref<BoardConfig>({ ...props.config })
+
+  watch(
+    () => props.config,
+    (newConfig) => {
+      localConfig.value = { ...newConfig }
+    },
+    { deep: true }
+  )
 
   // 计算剩余可用格子数
   const remainingCells = computed(() => {
@@ -105,9 +125,12 @@
 </script>
 
 <template>
-  <div class="board-config">
+  <div class="board-config glass-card">
     <div class="config-section">
-      <h3>🎯 棋盘格子配置</h3>
+      <h3>
+        <Target :size="20" />
+        棋盘格子配置
+      </h3>
       <p class="section-description">
         设置游戏中各种类型格子的数量。总格子数：{{ localConfig.totalCells }}
       </p>
@@ -116,7 +139,7 @@
         <!-- 总格子数 -->
         <div class="config-item">
           <label class="config-label">
-            <span class="label-icon">📏</span>
+            <span class="label-icon"><Settings :size="18" /></span>
             总格子数
           </label>
           <div class="input-group">
@@ -135,7 +158,7 @@
         <!-- 惩罚格子 -->
         <div class="config-item">
           <label class="config-label">
-            <span class="label-icon">⚡</span>
+            <span class="label-icon"><AlertTriangle :size="18" /></span>
             惩罚格子
           </label>
           <div class="input-group">
@@ -155,7 +178,7 @@
         <!-- 奖励格子 -->
         <div class="config-item">
           <label class="config-label">
-            <span class="label-icon">🎁</span>
+            <span class="label-icon"><Rocket :size="18" /></span>
             奖励格子
           </label>
           <div class="input-group">
@@ -175,7 +198,7 @@
         <!-- 后退格子 -->
         <div class="config-item">
           <label class="config-label">
-            <span class="label-icon">⬅️</span>
+            <span class="label-icon"><ArrowLeft :size="18" /></span>
             后退格子
           </label>
           <div class="input-group">
@@ -195,7 +218,7 @@
         <!-- 休息格子 -->
         <div class="config-item">
           <label class="config-label">
-            <span class="label-icon">🛌</span>
+            <span class="label-icon"><Info :size="18" /></span>
             休息格子
           </label>
           <div class="input-group">
@@ -215,7 +238,7 @@
         <!-- 回到起点格子 -->
         <div class="config-item">
           <label class="config-label">
-            <span class="label-icon">🔄</span>
+            <span class="label-icon"><RotateCcw :size="18" /></span>
             回到起点格子
           </label>
           <div class="input-group">
@@ -235,7 +258,7 @@
         <!-- 机关格子 -->
         <div class="config-item">
           <label class="config-label">
-            <span class="label-icon">💀</span>
+            <span class="label-icon"><Skull :size="18" /></span>
             机关格子
           </label>
           <div class="input-group">
@@ -259,7 +282,10 @@
           class="status-item"
           :class="{ 'status-error': remainingCells < 0, 'status-success': remainingCells >= 0 }"
         >
-          <span class="status-icon">{{ remainingCells >= 0 ? '✅' : '❌' }}</span>
+          <span class="status-icon">
+            <Check v-if="remainingCells >= 0" :size="16" />
+            <X v-else :size="16" />
+          </span>
           <span class="status-text">剩余可用格子：{{ remainingCells }} 格</span>
         </div>
 
@@ -267,19 +293,22 @@
           class="status-item"
           :class="{ 'status-error': !isConfigValid, 'status-success': isConfigValid }"
         >
-          <span class="status-icon">{{ isConfigValid ? '✅' : '❌' }}</span>
+          <span class="status-icon">
+            <Check v-if="isConfigValid" :size="16" />
+            <X v-else :size="16" />
+          </span>
           <span class="status-text">配置状态：{{ isConfigValid ? '有效' : '无效' }}</span>
         </div>
       </div>
 
       <!-- 快捷操作 -->
       <div class="quick-actions">
-        <button class="btn-secondary" @click="resetToDefault">
-          <span class="btn-icon">🔄</span>
+        <button class="btn btn-secondary" @click="resetToDefault">
+          <RotateCcw :size="16" />
           重置默认
         </button>
-        <button class="btn-secondary" @click="autoDistribute">
-          <span class="btn-icon">🎯</span>
+        <button class="btn btn-secondary" @click="autoDistribute">
+          <Target :size="16" />
           自动分配
         </button>
       </div>
@@ -289,23 +318,25 @@
 
 <style scoped>
   .board-config {
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 12px;
-    padding: 20px;
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
     margin-bottom: 20px;
   }
 
+  .board-config:hover {
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+
   .config-section h3 {
-    color: white;
+    color: var(--text-primary);
     margin: 0 0 10px 0;
     font-size: 1.2rem;
     font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
   }
 
   .section-description {
-    color: rgba(255, 255, 255, 0.8);
+    color: var(--text-secondary);
     margin: 0 0 20px 0;
     font-size: 0.9rem;
   }
@@ -318,16 +349,16 @@
   }
 
   .config-item {
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: 8px;
+    background: var(--bg-surface);
+    border-radius: var(--radius-sm);
     padding: 15px;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: var(--glass-border);
   }
 
   .config-label {
     display: flex;
     align-items: center;
-    color: white;
+    color: var(--text-primary);
     font-weight: 500;
     margin-bottom: 10px;
     font-size: 0.95rem;
@@ -335,7 +366,9 @@
 
   .label-icon {
     margin-right: 8px;
-    font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    color: var(--text-secondary);
   }
 
   .input-group {
@@ -346,18 +379,18 @@
 
   .config-input {
     flex: 1;
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: var(--radius-sm);
     padding: 8px 12px;
-    color: white;
+    color: var(--text-primary);
     font-size: 0.9rem;
     outline: none;
-    transition: border-color 0.3s;
+    transition: border-color var(--transition-normal);
   }
 
   .config-input:focus {
-    border-color: #4caf50;
+    border-color: var(--color-accent);
   }
 
   .config-input::-webkit-inner-spin-button,
@@ -366,22 +399,23 @@
   }
 
   .input-unit {
-    color: rgba(255, 255, 255, 0.7);
+    color: var(--text-muted);
     margin-left: 8px;
     font-size: 0.85rem;
   }
 
   .cell-description {
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--text-muted);
     font-size: 0.8rem;
     line-height: 1.3;
   }
 
   .status-section {
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: 8px;
+    background: var(--bg-surface);
+    border-radius: var(--radius-sm);
     padding: 15px;
     margin-bottom: 20px;
+    border: var(--glass-border);
   }
 
   .status-item {
@@ -389,8 +423,8 @@
     align-items: center;
     margin-bottom: 8px;
     padding: 8px;
-    border-radius: 6px;
-    transition: background-color 0.3s;
+    border-radius: var(--radius-sm);
+    transition: background-color var(--transition-normal);
   }
 
   .status-item:last-child {
@@ -398,22 +432,31 @@
   }
 
   .status-success {
-    background: rgba(76, 175, 80, 0.2);
-    border: 1px solid rgba(76, 175, 80, 0.3);
+    background: rgba(34, 197, 94, 0.12);
+    border: 1px solid rgba(34, 197, 94, 0.25);
   }
 
   .status-error {
-    background: rgba(244, 67, 54, 0.2);
-    border: 1px solid rgba(244, 67, 54, 0.3);
+    background: rgba(239, 68, 68, 0.12);
+    border: 1px solid rgba(239, 68, 68, 0.25);
   }
 
   .status-icon {
     margin-right: 8px;
-    font-size: 1rem;
+    display: flex;
+    align-items: center;
+  }
+
+  .status-success .status-icon {
+    color: var(--color-success);
+  }
+
+  .status-error .status-icon {
+    color: var(--color-danger);
   }
 
   .status-text {
-    color: white;
+    color: var(--text-primary);
     font-size: 0.9rem;
   }
 
@@ -421,28 +464,6 @@
     display: flex;
     gap: 10px;
     justify-content: center;
-  }
-
-  .btn-secondary {
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    border-radius: 6px;
-    padding: 8px 16px;
-    color: white;
-    cursor: pointer;
-    transition: all 0.3s;
-    display: flex;
-    align-items: center;
-    font-size: 0.85rem;
-  }
-
-  .btn-secondary:hover {
-    background: rgba(255, 255, 255, 0.2);
-    border-color: rgba(255, 255, 255, 0.5);
-  }
-
-  .btn-icon {
-    margin-right: 6px;
   }
 
   @media (max-width: 768px) {

--- a/src/components/BounceDisplay.vue
+++ b/src/components/BounceDisplay.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import { Undo2, Check, Trophy } from '@lucide/vue'
+
   interface Props {
     visible: boolean
     fromPosition: number
@@ -21,23 +23,33 @@
 </script>
 
 <template>
-  <div v-if="visible" class="bounce-display">
-    <div class="bounce-header">
-      <h3>🏐 反弹效果</h3>
-      <p>超出终点，按飞行棋规则反弹！</p>
-    </div>
-
-    <div class="bounce-content">
-      <div class="bounce-message">
-        <p class="main-message">
-          超出终点🏁(第{{ endPoint }}格) {{ overflowSteps }}格子，所以倒退{{
-            overflowSteps
-          }}格，最后是第{{ finalPosition }}格
-        </p>
+  <div v-if="visible" class="modal-overlay">
+    <div class="modal-content bounce-display">
+      <div class="bounce-header">
+        <h3>
+          <Undo2 :size="20" />
+          反弹效果
+        </h3>
+        <p>超出终点，按飞行棋规则反弹！</p>
       </div>
 
-      <div class="bounce-actions">
-        <button class="btn-confirm" @click="confirmBounce">✅ 确认反弹</button>
+      <div class="bounce-content">
+        <div class="bounce-message">
+          <p class="main-message">
+            超出终点
+            <Trophy :size="18" class="inline-icon" />
+            (第{{ endPoint }}格) {{ overflowSteps }}格子，所以倒退{{
+              overflowSteps
+            }}格，最后是第{{ finalPosition }}格
+          </p>
+        </div>
+
+        <div class="bounce-actions">
+          <button class="btn btn-confirm" @click="confirmBounce">
+            <Check :size="18" />
+            确认反弹
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -45,20 +57,8 @@
 
 <style scoped>
   .bounce-display {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background: white;
-    border-radius: 12px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-    padding: 2rem;
     max-width: 500px;
-    width: 90%;
-    z-index: 1000;
-    border: 3px solid #ff9500;
-    max-height: 90vh;
-    overflow-y: auto;
+    border: 1px solid rgba(255, 165, 2, 0.3);
   }
 
   .bounce-header {
@@ -67,13 +67,17 @@
   }
 
   .bounce-header h3 {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
     font-size: 1.5rem;
-    color: #ff9500;
+    color: var(--color-special);
     margin-bottom: 0.5rem;
   }
 
   .bounce-header p {
-    color: #666;
+    color: var(--text-secondary);
     font-size: 1rem;
   }
 
@@ -84,20 +88,27 @@
   }
 
   .bounce-message {
-    background: linear-gradient(135deg, #fff4e6, #ffeaa7);
-    border-radius: 12px;
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border-radius: var(--radius-md);
     padding: 2rem;
-    border: 2px solid #ff9500;
+    border: 1px solid rgba(255, 165, 2, 0.4);
     text-align: center;
     margin: 1rem 0;
   }
 
   .main-message {
     margin: 0;
-    color: #e17055;
+    color: var(--color-special);
     font-weight: bold;
     font-size: 1.4rem;
     line-height: 1.5;
+  }
+
+  .inline-icon {
+    display: inline-block;
+    vertical-align: -3px;
+    margin: 0 2px;
   }
 
   .bounce-actions {
@@ -107,20 +118,15 @@
   }
 
   .btn-confirm {
-    background: linear-gradient(135deg, #ff9500, #ff7675);
+    background: linear-gradient(135deg, var(--color-special), #ff7675);
     color: white;
-    border: none;
-    border-radius: 8px;
-    padding: 0.75rem 2rem;
-    font-size: 1.1rem;
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s ease;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 4px 15px rgba(255, 165, 2, 0.3);
   }
 
-  .btn-confirm:hover {
+  .btn-confirm:not(:disabled):hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(255, 149, 0, 0.3);
+    box-shadow: 0 6px 20px rgba(255, 165, 2, 0.4);
   }
 
   .btn-confirm:active {
@@ -131,7 +137,6 @@
   @media (max-width: 768px) {
     .bounce-display {
       padding: 1.5rem;
-      width: 95%;
     }
 
     .bounce-message {

--- a/src/components/ConfigErrorModal.vue
+++ b/src/components/ConfigErrorModal.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import { AlertTriangle, X, CircleX, Lightbulb } from '@lucide/vue'
+
   interface Props {
     show: boolean
     errorMessage?: string
@@ -22,16 +24,26 @@
     <div class="modal-overlay" @click="closeModal"></div>
     <div class="modal-content">
       <div class="modal-header">
-        <h3>⚠️ 配置错误</h3>
-        <button class="close-btn" @click="closeModal">×</button>
+        <h3>
+          <AlertTriangle :size="22" />
+          配置错误
+        </h3>
+        <button class="close-btn" @click="closeModal">
+          <X :size="20" />
+        </button>
       </div>
 
       <div class="modal-body">
-        <div class="error-icon">❌</div>
+        <div class="error-icon">
+          <CircleX :size="48" />
+        </div>
         <p class="error-message">{{ errorMessage }}</p>
 
         <div v-if="requiredSensitivity" class="suggestion">
-          <h4>💡 建议解决方案：</h4>
+          <h4>
+            <Lightbulb :size="18" />
+            建议解决方案：
+          </h4>
           <ul>
             <li>添加耐受度为 {{ requiredSensitivity }} 或更高的部位</li>
             <li>或者降低工具的强度到 {{ requiredSensitivity }} 或更低</li>
@@ -40,7 +52,7 @@
       </div>
 
       <div class="modal-footer">
-        <button class="btn-primary" @click="closeModal">我知道了</button>
+        <button class="btn btn-primary" @click="closeModal">我知道了</button>
       </div>
     </div>
   </div>
@@ -66,18 +78,22 @@
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
   }
 
   .modal-content {
     position: relative;
-    background: white;
-    border-radius: 12px;
+    background: rgba(20, 20, 40, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    border-radius: var(--radius-xl);
     max-width: 500px;
     width: 90%;
     max-height: 90vh;
     overflow: hidden;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    box-shadow: var(--glass-shadow-lg);
     animation: slideIn 0.3s ease-out;
+    padding: 0;
   }
 
   @keyframes slideIn {
@@ -92,8 +108,9 @@
   }
 
   .modal-header {
-    background: linear-gradient(135deg, #ff6b6b, #ee5a52);
-    color: white;
+    background: rgba(239, 68, 68, 0.15);
+    border-bottom: 1px solid rgba(239, 68, 68, 0.3);
+    color: var(--text-primary);
     padding: 1.5rem;
     display: flex;
     justify-content: space-between;
@@ -104,26 +121,30 @@
     margin: 0;
     font-size: 1.3rem;
     font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--color-danger);
   }
 
   .close-btn {
-    background: none;
-    border: none;
-    color: white;
-    font-size: 1.5rem;
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    color: var(--text-secondary);
     cursor: pointer;
     padding: 0;
-    width: 30px;
-    height: 30px;
+    width: 32px;
+    height: 32px;
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 50%;
-    transition: background-color 0.2s;
+    border-radius: var(--radius-sm);
+    transition: all var(--transition-fast);
   }
 
   .close-btn:hover {
-    background: rgba(255, 255, 255, 0.2);
+    background: var(--bg-glass-hover);
+    color: var(--text-primary);
   }
 
   .modal-body {
@@ -132,35 +153,40 @@
   }
 
   .error-icon {
-    font-size: 3rem;
     margin-bottom: 1rem;
+    color: var(--color-danger);
+    display: flex;
+    justify-content: center;
   }
 
   .error-message {
     font-size: 1.1rem;
-    color: #333;
+    color: var(--color-danger);
     line-height: 1.6;
     margin-bottom: 1.5rem;
   }
 
   .suggestion {
-    background: #f8f9fa;
-    border: 1px solid #e9ecef;
-    border-radius: 8px;
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    border-radius: var(--radius-md);
     padding: 1rem;
     text-align: left;
   }
 
   .suggestion h4 {
     margin: 0 0 0.5rem 0;
-    color: #495057;
+    color: var(--color-warning);
     font-size: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
   }
 
   .suggestion ul {
     margin: 0;
     padding-left: 1.5rem;
-    color: #6c757d;
+    color: var(--text-secondary);
   }
 
   .suggestion li {
@@ -170,24 +196,8 @@
   .modal-footer {
     padding: 1.5rem;
     text-align: center;
-    border-top: 1px solid #e9ecef;
-  }
-
-  .btn-primary {
-    background: linear-gradient(135deg, #667eea, #764ba2);
-    color: white;
-    border: none;
-    padding: 0.75rem 2rem;
-    border-radius: 6px;
-    font-size: 1rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s ease;
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+    border-top: var(--glass-border);
+    background: var(--bg-surface);
   }
 
   /* 移动端适配 */
@@ -209,8 +219,9 @@
       padding: 1.5rem;
     }
 
-    .error-icon {
-      font-size: 2.5rem;
+    .error-icon :deep(svg) {
+      width: 40px;
+      height: 40px;
     }
 
     .error-message {
@@ -221,7 +232,7 @@
       padding: 1rem;
     }
 
-    .btn-primary {
+    .modal-footer .btn {
       width: 100%;
       padding: 1rem;
       font-size: 1.1rem;

--- a/src/components/ConfigExport.vue
+++ b/src/components/ConfigExport.vue
@@ -1,5 +1,23 @@
 <script setup lang="ts">
   import { ref, computed, watch } from 'vue'
+  import {
+    Upload,
+    Download,
+    BookOpen,
+    X,
+    Users,
+    Settings,
+    Target,
+    Wrench,
+    Dices,
+    FolderOpen,
+    FileText,
+    QrCode,
+    FileJson,
+    Save,
+    Lightbulb,
+    AlertTriangle,
+  } from '@lucide/vue'
   import type { ExportOptions, ExportStats, QRCodeOptions } from '../types/export'
   import type { BoardCell } from '../types/game'
   import {
@@ -299,7 +317,11 @@
     <div class="export-modal">
       <div class="export-header">
         <div class="header-content">
-          <h3>{{ currentMode === 'export' ? '📤 导出配置' : '📥 导入配置' }}</h3>
+          <h3>
+            <Upload v-if="currentMode === 'export'" :size="20" />
+            <Download v-else :size="20" />
+            {{ currentMode === 'export' ? '导出配置' : '导入配置' }}
+          </h3>
           <div class="mode-tabs">
             <button
               class="mode-tab"
@@ -318,8 +340,12 @@
           </div>
         </div>
         <div class="header-actions">
-          <button class="doc-btn" title="查看配置文档" @click="showDocumentation = true">📖</button>
-          <button class="close-btn" @click="handleClose">✕</button>
+          <button class="doc-btn" title="查看配置文档" @click="showDocumentation = true">
+            <BookOpen :size="18" />
+          </button>
+          <button class="close-btn" @click="handleClose">
+            <X :size="20" />
+          </button>
         </div>
       </div>
 
@@ -345,7 +371,7 @@
                   type="checkbox"
                   :disabled="!availableOptions.playerSettings"
                 />
-                <span class="option-icon">👥</span>
+                <span class="option-icon"><Users :size="20" /></span>
                 <div class="option-info">
                   <div class="option-title">玩家设置</div>
                   <div class="option-desc">玩家数量和姓名配置</div>
@@ -359,7 +385,7 @@
                   type="checkbox"
                   :disabled="!availableOptions.punishmentConfig"
                 />
-                <span class="option-icon">⚙️</span>
+                <span class="option-icon"><Settings :size="20" /></span>
                 <div class="option-info">
                   <div class="option-title">惩罚设置</div>
                   <div class="option-desc">工具、部位、姿势等惩罚配置</div>
@@ -373,7 +399,7 @@
                   type="checkbox"
                   :disabled="!availableOptions.boardConfig"
                 />
-                <span class="option-icon">🎯</span>
+                <span class="option-icon"><Target :size="20" /></span>
                 <div class="option-info">
                   <div class="option-title">棋盘设置</div>
                   <div class="option-desc">各种格子数量的配置</div>
@@ -387,7 +413,7 @@
                   type="checkbox"
                   :disabled="!availableOptions.trapConfig"
                 />
-                <span class="option-icon">🔧</span>
+                <span class="option-icon"><Wrench :size="20" /></span>
                 <div class="option-info">
                   <div class="option-title">机关设置</div>
                   <div class="option-desc">机关格子的配置</div>
@@ -401,7 +427,7 @@
                   type="checkbox"
                   :disabled="!availableOptions.boardContent"
                 />
-                <span class="option-icon">🎲</span>
+                <span class="option-icon"><Dices :size="20" /></span>
                 <div class="option-info">
                   <div class="option-title">棋盘布局</div>
                   <div class="option-desc">
@@ -459,7 +485,7 @@
 
           <div class="import-methods">
             <div class="import-method">
-              <h4>📁 文件导入</h4>
+              <h4><FolderOpen :size="18" /> 文件导入</h4>
               <div class="file-upload">
                 <input
                   id="import-file"
@@ -478,7 +504,7 @@
             </div>
 
             <div class="import-method">
-              <h4>📝 文本导入</h4>
+              <h4><FileText :size="18" /> 文本导入</h4>
               <div class="text-import">
                 <textarea
                   v-model="importJsonText"
@@ -488,7 +514,7 @@
                   rows="8"
                 ></textarea>
                 <button
-                  class="import-text-btn"
+                  class="btn btn-success import-text-btn"
                   :disabled="!importJsonText.trim() || isImporting"
                   @click="handleJsonTextImport"
                 >
@@ -503,43 +529,43 @@
       </div>
 
       <div class="export-actions">
-        <button class="cancel-btn" :disabled="isExporting || isImporting" @click="handleClose">
+          <button class="btn btn-secondary cancel-btn" :disabled="isExporting || isImporting" @click="handleClose">
           取消
         </button>
 
         <!-- 导出模式按钮 -->
         <div v-if="currentMode === 'export'" class="export-buttons">
           <button
-            class="export-btn secondary"
+            class="btn btn-secondary export-btn"
             :disabled="!canGenerateQRCode"
             :class="{ loading: isExporting }"
             @click="handleGenerateQRCode"
           >
             <span v-if="isExporting">生成中...</span>
-            <span v-else>🔲 生成二维码</span>
+            <span v-else class="btn-content"><QrCode :size="16" /> 生成二维码</span>
           </button>
           <button
-            class="export-btn"
+            class="btn btn-primary export-btn"
             :disabled="!canExport"
             :class="{ loading: isExporting }"
             @click="handleExportJson"
           >
             <span v-if="isExporting">导出中...</span>
-            <span v-else>📄 导出 JSON</span>
+            <span v-else class="btn-content"><FileJson :size="16" /> 导出 JSON</span>
           </button>
           <button
             v-if="showQRCode"
-            class="export-btn secondary"
+            class="btn btn-secondary export-btn"
             :disabled="!qrCodeDataURL || qrCapacityExceeded"
             @click="handleExportQRCode"
           >
-            💾 保存二维码
+            <span class="btn-content"><Save :size="16" /> 保存二维码</span>
           </button>
         </div>
 
         <!-- 导入模式提示 -->
         <div v-else-if="currentMode === 'import'" class="import-tip">
-          <p>💡 请选择上方的导入方式来导入配置</p>
+          <p class="tip-content"><Lightbulb :size="16" /> 请选择上方的导入方式来导入配置</p>
         </div>
       </div>
     </div>
@@ -548,12 +574,14 @@
     <div v-if="showDocumentation" class="documentation-overlay">
       <div class="documentation-modal">
         <div class="documentation-header">
-          <h3>📖 配置文档</h3>
-          <button class="close-btn" @click="showDocumentation = false">✕</button>
+          <h3><BookOpen :size="20" /> 配置文档</h3>
+          <button class="close-btn" @click="showDocumentation = false">
+            <X :size="20" />
+          </button>
         </div>
         <div class="documentation-content">
           <div class="doc-section">
-            <h4>🎯 配置类型说明</h4>
+            <h4><Target :size="18" /> 配置类型说明</h4>
             <ul>
               <li>
                 <strong>玩家设置：</strong>
@@ -579,7 +607,7 @@
           </div>
 
           <div class="doc-section">
-            <h4>📤 导出功能</h4>
+            <h4><Upload :size="18" /> 导出功能</h4>
             <ul>
               <li>
                 <strong>JSON文件：</strong>
@@ -595,7 +623,7 @@
           </div>
 
           <div class="doc-section">
-            <h4>📥 导入功能</h4>
+            <h4><Download :size="18" /> 导入功能</h4>
             <ul>
               <li>
                 <strong>文件导入：</strong>
@@ -611,7 +639,7 @@
           </div>
 
           <div class="doc-section">
-            <h4>⚠️ 注意事项</h4>
+            <h4><AlertTriangle :size="18" /> 注意事项</h4>
             <ul>
               <li>导入配置会覆盖当前设置，请注意备份</li>
               <li>二维码适合小量数据，大配置建议使用JSON文件</li>
@@ -621,7 +649,7 @@
           </div>
 
           <div class="doc-section">
-            <h4>🔧 版本兼容性</h4>
+            <h4><Wrench :size="18" /> 版本兼容性</h4>
             <p>
               当前配置版本：
               <code>1.0.0</code>
@@ -630,7 +658,7 @@
           </div>
         </div>
         <div class="documentation-footer">
-          <button class="btn-primary" @click="showDocumentation = false">我知道了</button>
+          <button class="btn btn-primary" @click="showDocumentation = false">我知道了</button>
         </div>
       </div>
     </div>
@@ -644,7 +672,8 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -653,9 +682,11 @@
   }
 
   .export-modal {
-    background: white;
-    border-radius: 12px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    background: rgba(20, 20, 40, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--glass-shadow-lg);
     max-width: 600px;
     width: 100%;
     max-height: 90vh;
@@ -669,8 +700,8 @@
     align-items: center;
     justify-content: space-between;
     padding: 20px 24px;
-    border-bottom: 1px solid #e5e7eb;
-    background: #f9fafb;
+    border-bottom: var(--glass-border);
+    background: var(--bg-surface);
   }
 
   .header-content {
@@ -683,13 +714,17 @@
     margin: 0;
     font-size: 18px;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
   .mode-tabs {
     display: flex;
-    background: #e5e7eb;
-    border-radius: 8px;
+    background: var(--bg-secondary);
+    border: var(--glass-border);
+    border-radius: var(--radius-sm);
     padding: 2px;
   }
 
@@ -700,19 +735,19 @@
     border-radius: 6px;
     font-size: 14px;
     font-weight: 500;
-    color: #6b7280;
+    color: var(--text-muted);
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all var(--transition-fast);
   }
 
   .mode-tab.active {
-    background: white;
-    color: #1f2937;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    background: var(--bg-glass-hover);
+    color: var(--text-primary);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   }
 
   .mode-tab:hover:not(.active) {
-    color: #374151;
+    color: var(--text-secondary);
   }
 
   .header-actions {
@@ -722,35 +757,39 @@
   }
 
   .doc-btn {
-    background: #f3f4f6;
-    border: 1px solid #d1d5db;
-    border-radius: 6px;
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    border-radius: var(--radius-sm);
     padding: 6px 8px;
-    font-size: 16px;
-    color: #374151;
+    color: var(--text-secondary);
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all var(--transition-fast);
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .doc-btn:hover {
-    background: #e5e7eb;
-    border-color: #9ca3af;
+    background: var(--bg-glass-hover);
+    color: var(--text-primary);
   }
 
   .close-btn {
-    background: none;
-    border: none;
-    font-size: 20px;
-    color: #6b7280;
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    color: var(--text-secondary);
     cursor: pointer;
-    padding: 4px;
-    border-radius: 4px;
-    transition: all 0.2s;
+    padding: 6px;
+    border-radius: var(--radius-sm);
+    transition: all var(--transition-fast);
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .close-btn:hover {
-    background: #e5e7eb;
-    color: #374151;
+    background: var(--bg-glass-hover);
+    color: var(--text-primary);
   }
 
   .export-content {
@@ -759,13 +798,15 @@
     padding: 24px;
   }
 
-  .export-description {
+  .export-description,
+  .import-description {
     margin-bottom: 24px;
   }
 
-  .export-description p {
+  .export-description p,
+  .import-description p {
     margin: 0;
-    color: #6b7280;
+    color: var(--text-secondary);
     line-height: 1.5;
   }
 
@@ -784,23 +825,23 @@
     margin: 0;
     font-size: 16px;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--text-primary);
   }
 
   .toggle-all-btn {
-    background: #f3f4f6;
-    border: 1px solid #d1d5db;
-    border-radius: 6px;
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    border-radius: var(--radius-sm);
     padding: 6px 12px;
     font-size: 14px;
-    color: #374151;
+    color: var(--text-secondary);
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all var(--transition-fast);
   }
 
   .toggle-all-btn:hover {
-    background: #e5e7eb;
-    border-color: #9ca3af;
+    background: var(--bg-glass-hover);
+    color: var(--text-primary);
   }
 
   .option-list {
@@ -814,28 +855,29 @@
     align-items: center;
     gap: 12px;
     padding: 16px;
-    border: 2px solid #e5e7eb;
-    border-radius: 8px;
+    border: var(--glass-border);
+    border-radius: var(--radius-sm);
     cursor: pointer;
-    transition: all 0.2s;
-    background: white;
+    transition: all var(--transition-fast);
+    background: var(--bg-glass);
   }
 
   .option-item:hover:not(.disabled) {
-    border-color: #3b82f6;
-    background: #f8faff;
+    border-color: rgba(102, 126, 234, 0.4);
+    background: var(--bg-glass-hover);
   }
 
   .option-item.disabled {
     opacity: 0.5;
     cursor: not-allowed;
-    background: #f9fafb;
+    background: var(--bg-surface);
   }
 
   .option-item input[type='checkbox'] {
     width: 18px;
     height: 18px;
     cursor: pointer;
+    accent-color: var(--color-accent);
   }
 
   .option-item.disabled input[type='checkbox'] {
@@ -843,8 +885,10 @@
   }
 
   .option-icon {
-    font-size: 20px;
     flex-shrink: 0;
+    color: var(--color-accent-light);
+    display: flex;
+    align-items: center;
   }
 
   .option-info {
@@ -853,29 +897,29 @@
 
   .option-title {
     font-weight: 600;
-    color: #1f2937;
+    color: var(--text-primary);
     margin-bottom: 4px;
   }
 
   .option-desc {
     font-size: 14px;
-    color: #6b7280;
+    color: var(--text-secondary);
     line-height: 1.4;
   }
 
   .option-status {
     font-size: 12px;
-    color: #ef4444;
-    background: #fef2f2;
+    color: var(--color-danger);
+    background: rgba(239, 68, 68, 0.1);
     padding: 4px 8px;
-    border-radius: 4px;
-    border: 1px solid #fecaca;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(239, 68, 68, 0.25);
   }
 
   .export-stats {
-    background: #f8faff;
-    border: 1px solid #e0e7ff;
-    border-radius: 8px;
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    border-radius: var(--radius-md);
     padding: 16px;
     margin-bottom: 24px;
   }
@@ -884,7 +928,7 @@
     margin: 0 0 12px 0;
     font-size: 14px;
     font-weight: 600;
-    color: #1e40af;
+    color: var(--color-accent-light);
   }
 
   .stats-grid {
@@ -897,35 +941,42 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    background: var(--bg-surface);
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    border: var(--glass-border);
   }
 
   .stat-label {
     font-size: 14px;
-    color: #6b7280;
+    color: var(--text-muted);
   }
 
   .stat-value {
     font-size: 14px;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--text-primary);
   }
 
   .stat-value.danger {
-    color: #dc2626;
+    color: var(--color-danger);
   }
 
   .qrcode-warning {
     margin: 12px 0 0 0;
     font-size: 13px;
-    color: #dc2626;
+    color: var(--color-danger);
     line-height: 1.4;
+    background: rgba(239, 68, 68, 0.08);
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(239, 68, 68, 0.2);
   }
 
-  /* 二维码预览样式 */
   .qrcode-preview {
-    background: #f8faff;
-    border: 1px solid #e0e7ff;
-    border-radius: 8px;
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    border-radius: var(--radius-md);
     padding: 16px;
     margin-top: 16px;
     text-align: center;
@@ -935,7 +986,7 @@
     margin: 0 0 12px 0;
     font-size: 14px;
     font-weight: 600;
-    color: #1e40af;
+    color: var(--color-accent-light);
   }
 
   .qrcode-container {
@@ -943,31 +994,24 @@
     flex-direction: column;
     align-items: center;
     gap: 12px;
+    background: var(--bg-primary);
+    border: var(--glass-border);
+    border-radius: var(--radius-md);
+    padding: 16px;
   }
 
   .qrcode-image {
     width: min(420px, 80vw);
     max-width: 80%;
     height: auto;
-    border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--glass-shadow);
   }
 
   .qrcode-tip {
     margin: 0;
     font-size: 14px;
-    color: #6b7280;
-  }
-
-  /* 导入样式 */
-  .import-description {
-    margin-bottom: 24px;
-  }
-
-  .import-description p {
-    margin: 0;
-    color: #6b7280;
-    line-height: 1.5;
+    color: var(--text-secondary);
   }
 
   .import-methods {
@@ -977,23 +1021,26 @@
   }
 
   .import-method {
-    border: 1px solid #e5e7eb;
-    border-radius: 8px;
+    border: var(--glass-border);
+    border-radius: var(--radius-md);
     padding: 20px;
-    background: white;
+    background: var(--bg-glass);
   }
 
   .import-method h4 {
     margin: 0 0 12px 0;
     font-size: 16px;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
   .method-desc {
     margin: 8px 0 0 0;
     font-size: 14px;
-    color: #6b7280;
+    color: var(--text-muted);
   }
 
   .file-upload {
@@ -1005,18 +1052,21 @@
   }
 
   .file-label {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     padding: 12px 24px;
-    background: #3b82f6;
+    background: linear-gradient(135deg, var(--color-accent) 0%, #764ba2 100%);
     color: white;
-    border-radius: 8px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     font-weight: 500;
-    transition: all 0.2s;
+    transition: all var(--transition-fast);
+    border: 1px solid rgba(255, 255, 255, 0.1);
   }
 
   .file-label:hover {
-    background: #2563eb;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
   }
 
   .text-import {
@@ -1028,53 +1078,54 @@
   .json-textarea {
     width: 100%;
     padding: 12px;
-    border: 1px solid #d1d5db;
-    border-radius: 6px;
+    background: var(--bg-secondary);
+    border: var(--glass-border);
+    border-radius: var(--radius-sm);
     font-family: 'Courier New', monospace;
     font-size: 14px;
+    color: var(--text-primary);
     resize: vertical;
     min-height: 120px;
+    transition: border-color var(--transition-fast);
+  }
+
+  .json-textarea::placeholder {
+    color: var(--text-muted);
   }
 
   .json-textarea:focus {
     outline: none;
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    border-color: rgba(102, 126, 234, 0.5);
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+  }
+
+  .json-textarea:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   .import-text-btn {
     align-self: flex-start;
-    padding: 10px 20px;
-    background: #10b981;
-    color: white;
-    border: none;
-    border-radius: 6px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-
-  .import-text-btn:hover:not(:disabled) {
-    background: #059669;
-  }
-
-  .import-text-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
   }
 
   .export-actions {
     display: flex;
     gap: 12px;
     padding: 20px 24px;
-    border-top: 1px solid #e5e7eb;
-    background: #f9fafb;
+    border-top: var(--glass-border);
+    background: var(--bg-surface);
   }
 
   .export-buttons {
     display: flex;
     gap: 8px;
     flex: 1;
+  }
+
+  .btn-content {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
   }
 
   .import-tip {
@@ -1084,66 +1135,26 @@
     justify-content: center;
   }
 
-  .import-tip p {
+  .tip-content {
     margin: 0;
-    color: #6b7280;
+    color: var(--text-secondary);
     font-style: italic;
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
   .cancel-btn {
     flex: 1;
-    padding: 12px 24px;
-    border: 1px solid #d1d5db;
-    border-radius: 8px;
-    background: white;
-    color: #374151;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-
-  .cancel-btn:hover:not(:disabled) {
-    background: #f3f4f6;
-    border-color: #9ca3af;
-  }
-
-  .cancel-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
   }
 
   .export-btn {
     flex: 1;
-    padding: 12px 16px;
-    border: none;
-    border-radius: 8px;
-    background: #3b82f6;
-    color: white;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
     font-size: 14px;
   }
 
-  .export-btn.secondary {
-    background: #6b7280;
-  }
-
-  .export-btn:hover:not(:disabled) {
-    background: #2563eb;
-  }
-
-  .export-btn.secondary:hover:not(:disabled) {
-    background: #4b5563;
-  }
-
-  .export-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
   .export-btn.loading {
-    background: #6b7280;
+    opacity: 0.7;
   }
 
   /* 文档对话框样式 */
@@ -1153,7 +1164,8 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1162,9 +1174,11 @@
   }
 
   .documentation-modal {
-    background: white;
-    border-radius: 12px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    background: rgba(20, 20, 40, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--glass-shadow-lg);
     max-width: 700px;
     width: 100%;
     max-height: 90vh;
@@ -1178,15 +1192,18 @@
     align-items: center;
     justify-content: space-between;
     padding: 20px 24px;
-    border-bottom: 1px solid #e5e7eb;
-    background: #f9fafb;
+    border-bottom: var(--glass-border);
+    background: var(--bg-surface);
   }
 
   .documentation-header h3 {
     margin: 0;
     font-size: 18px;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
   .documentation-content {
@@ -1207,7 +1224,10 @@
     margin: 0 0 12px 0;
     font-size: 16px;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
   .doc-section ul {
@@ -1218,44 +1238,34 @@
   .doc-section li {
     margin-bottom: 8px;
     line-height: 1.5;
-    color: #374151;
+    color: var(--text-secondary);
+  }
+
+  .doc-section li strong {
+    color: var(--text-primary);
   }
 
   .doc-section p {
     margin: 8px 0 0 0;
     line-height: 1.5;
-    color: #374151;
+    color: var(--text-secondary);
   }
 
   .doc-section code {
-    background: #f3f4f6;
+    background: var(--bg-glass);
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     font-family: 'Courier New', monospace;
     font-size: 14px;
-    color: #1f2937;
+    color: var(--color-accent-light);
+    border: var(--glass-border);
   }
 
   .documentation-footer {
     padding: 20px 24px;
-    border-top: 1px solid #e5e7eb;
-    background: #f9fafb;
+    border-top: var(--glass-border);
+    background: var(--bg-surface);
     text-align: center;
-  }
-
-  .btn-primary {
-    padding: 12px 24px;
-    background: #3b82f6;
-    color: white;
-    border: none;
-    border-radius: 8px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-
-  .btn-primary:hover {
-    background: #2563eb;
   }
 
   @media (max-width: 640px) {
@@ -1275,8 +1285,18 @@
       padding: 16px;
     }
 
+    .header-content {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 12px;
+    }
+
     .export-actions {
       padding: 16px;
+      flex-direction: column;
+    }
+
+    .export-buttons {
       flex-direction: column;
     }
 

--- a/src/components/CoolDice.vue
+++ b/src/components/CoolDice.vue
@@ -145,6 +145,7 @@
     align-items: center;
     gap: 1.5rem;
     padding: 2rem;
+    background: transparent;
   }
 
   .dice-scene {
@@ -160,12 +161,12 @@
     transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
     cursor: pointer;
     margin: 3rem;
-    filter: drop-shadow(0 10px 20px rgba(0, 0, 0, 0.3));
+    filter: drop-shadow(0 4px 12px rgba(102, 126, 234, 0.3));
   }
 
   .dice-cube:hover:not(.rolling) {
     transform: scale(1.05) rotateX(5deg) rotateY(5deg);
-    filter: drop-shadow(0 15px 30px rgba(0, 0, 0, 0.4));
+    filter: drop-shadow(0 6px 16px rgba(102, 126, 234, 0.5));
   }
 
   .dice-cube.can-roll {
@@ -174,7 +175,7 @@
 
   .dice-cube.rolling {
     animation: roll 2.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-    filter: drop-shadow(0 15px 40px rgba(0, 0, 0, 0.5));
+    filter: drop-shadow(0 6px 20px rgba(102, 126, 234, 0.5));
   }
 
   /* 骰子面 */
@@ -182,17 +183,16 @@
     position: absolute;
     width: 100px;
     height: 100px;
-    background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 50%, #e9ecef 100%);
-    border: 4px solid #dee2e6;
+    background: rgba(20, 20, 40, 0.9);
+    border: 1px solid rgba(255, 255, 255, 0.15);
     border-radius: 20px;
     display: flex;
     align-items: center;
     justify-content: center;
     box-shadow:
-      inset 0 0 20px rgba(0, 0, 0, 0.1),
-      inset 0 3px 6px rgba(255, 255, 255, 0.8),
-      0 8px 16px rgba(0, 0, 0, 0.3),
-      0 16px 32px rgba(0, 0, 0, 0.2);
+      inset 0 0 20px rgba(0, 0, 0, 0.3),
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      var(--glass-shadow);
     backface-visibility: hidden;
   }
 
@@ -205,9 +205,9 @@
     bottom: 4px;
     background: linear-gradient(
       135deg,
-      rgba(255, 255, 255, 0.9) 0%,
-      rgba(255, 255, 255, 0.6) 50%,
-      rgba(255, 255, 255, 0.3) 100%
+      rgba(255, 255, 255, 0.06) 0%,
+      rgba(255, 255, 255, 0.02) 50%,
+      transparent 100%
     );
     border-radius: 16px;
     z-index: 1;
@@ -223,14 +223,14 @@
     background: linear-gradient(
       45deg,
       transparent 20%,
-      rgba(255, 255, 255, 0.4) 40%,
-      rgba(255, 255, 255, 0.6) 50%,
-      rgba(255, 255, 255, 0.4) 60%,
+      rgba(255, 255, 255, 0.06) 40%,
+      rgba(255, 255, 255, 0.1) 50%,
+      rgba(255, 255, 255, 0.06) 60%,
       transparent 80%
     );
     border-radius: 20px;
     z-index: 3;
-    opacity: 0.8;
+    opacity: 0.6;
   }
 
   /* 3D定位 */
@@ -257,13 +257,11 @@
   .dot {
     width: 16px;
     height: 16px;
-    background: radial-gradient(circle at 25% 25%, #ff4757, #ff3742, #c44569);
+    background: var(--text-primary);
     border-radius: 50%;
     box-shadow:
-      0 4px 8px rgba(0, 0, 0, 0.5),
-      0 2px 4px rgba(0, 0, 0, 0.3),
-      inset 0 1px 2px rgba(255, 255, 255, 0.4),
-      inset 0 -1px 1px rgba(0, 0, 0, 0.1);
+      0 0 6px rgba(255, 255, 255, 0.4),
+      0 2px 4px rgba(0, 0, 0, 0.3);
     z-index: 4;
     position: relative;
   }
@@ -381,11 +379,12 @@
   /* 结果显示 */
   .result-display {
     text-align: center;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
     padding: 1rem 2rem;
-    border-radius: 20px;
-    box-shadow: 0 8px 32px rgba(102, 126, 234, 0.4);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--glass-shadow);
     animation: resultPop 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
   }
 
@@ -393,11 +392,12 @@
     font-size: 2.5rem;
     font-weight: bold;
     margin-bottom: 0.5rem;
+    color: var(--text-primary);
   }
 
   .result-label {
     font-size: 1rem;
-    opacity: 0.9;
+    color: var(--text-secondary);
   }
 
   @keyframes resultPop {
@@ -438,26 +438,16 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.75rem 1.5rem;
-    border-radius: 12px;
+    border-radius: var(--radius-md);
     font-weight: 600;
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    background: var(--bg-glass);
+    color: var(--text-secondary);
   }
 
   .status-rolling {
-    background: rgba(255, 107, 107, 0.2);
-    color: #ff6b6b;
     animation: pulse 1.5s ease-in-out infinite;
-  }
-
-  .status-result {
-    background: rgba(34, 197, 94, 0.2);
-    color: #22c55e;
-  }
-
-  .status-prompt {
-    background: rgba(59, 130, 246, 0.2);
-    color: #3b82f6;
   }
 
   .icon {

--- a/src/components/EffectDisplay.vue
+++ b/src/components/EffectDisplay.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import { computed } from 'vue'
+  import { Gift, ArrowLeft, RotateCcw, Moon, Sparkles } from '@lucide/vue'
 
   interface Effect {
     type: 'move' | 'skip' | 'reverse' | 'restart' | 'rest' | 'bounce'
@@ -63,21 +64,20 @@
     return ''
   }
 
-  const getEffectIcon = (): string => {
-    if (!props.effect) return '✨'
+  const getEffectIconComponent = () => {
+    if (!props.effect) return Sparkles
 
     switch (props.effect.type) {
       case 'move':
-        return props.effect.value > 0 ? '🎁' : '⬅️'
+        return props.effect.value > 0 ? Gift : ArrowLeft
       case 'restart':
-        return '🔄'
+        return RotateCcw
       case 'rest':
-        return '😴'
+        return Moon
       case 'reverse':
-        return '⬅️'
-
+        return ArrowLeft
       default:
-        return '✨'
+        return Sparkles
     }
   }
 
@@ -105,10 +105,12 @@
 </script>
 
 <template>
-  <div v-if="visible" class="effect-display-overlay">
-    <div class="effect-display-modal">
+  <div v-if="visible" class="modal-overlay">
+    <div class="modal-content effect-display-modal">
       <div class="effect-header">
-        <div class="effect-icon">{{ getEffectIcon() }}</div>
+        <div class="effect-icon">
+          <component :is="getEffectIconComponent()" :size="48" />
+        </div>
         <div class="effect-title">{{ getEffectTitle() }}</div>
       </div>
 
@@ -139,50 +141,30 @@
 
         <div v-else-if="effect?.type === 'restart'" class="restart-effect">
           <div class="effect-value">
-            <span class="value-icon">🔄</span>
+            <span class="value-icon"><RotateCcw :size="36" /></span>
             <span class="value-text">回到起点</span>
           </div>
         </div>
 
         <div v-else-if="effect?.type === 'rest'" class="rest-effect">
           <div class="effect-value">
-            <span class="value-icon">😴</span>
+            <span class="value-icon"><Moon :size="36" /></span>
             <span class="value-text">休息一回合</span>
           </div>
         </div>
       </div>
 
       <div class="effect-footer">
-        <button class="confirm-btn" @click="handleConfirm">确认</button>
+        <button class="btn confirm-btn" @click="handleConfirm">确认</button>
       </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-  .effect-display-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.7);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-    animation: fadeIn 0.3s ease;
-  }
-
   .effect-display-modal {
-    background: white;
-    border-radius: 16px;
-    padding: 2rem;
     max-width: 400px;
-    width: 90%;
     text-align: center;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
-    animation: slideIn 0.3s ease;
   }
 
   .effect-header {
@@ -190,14 +172,14 @@
   }
 
   .effect-icon {
-    font-size: 3rem;
     margin-bottom: 0.5rem;
+    color: var(--color-accent-light);
   }
 
   .effect-title {
     font-size: 1.5rem;
     font-weight: bold;
-    color: #333;
+    color: var(--text-primary);
   }
 
   .effect-content {
@@ -206,23 +188,23 @@
 
   .effect-description {
     font-size: 1.1rem;
-    color: #666;
+    color: var(--text-secondary);
     margin-bottom: 1.5rem;
     line-height: 1.5;
   }
 
-  /* 移动路径信息样式 */
   .move-path-info {
-    background: linear-gradient(135deg, #f8f9fa, #e9ecef);
-    border-radius: 8px;
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border-radius: var(--radius-sm);
     padding: 1rem;
     margin-bottom: 1.5rem;
-    border: 1px solid #dee2e6;
+    border: var(--glass-border);
   }
 
   .path-label {
     font-size: 0.9rem;
-    color: #666;
+    color: var(--text-secondary);
     margin-bottom: 0.5rem;
     font-weight: bold;
   }
@@ -234,33 +216,28 @@
     gap: 0.5rem;
     font-size: 1.1rem;
     font-weight: bold;
+    flex-wrap: wrap;
   }
 
   .from-position {
-    color: #ff6b6b;
-    background: rgba(255, 107, 107, 0.1);
+    color: var(--color-punishment);
+    background: rgba(255, 71, 87, 0.15);
     padding: 0.25rem 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
   }
 
   .path-arrow {
-    color: #4ecdc4;
+    color: var(--player-2);
     font-size: 1.2rem;
     font-weight: bold;
   }
 
-  .to-position {
-    color: #2ed573;
-    background: rgba(46, 213, 115, 0.1);
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-  }
-
+  .to-position,
   .final-position {
-    color: #2ed573;
-    background: rgba(46, 213, 115, 0.1);
+    color: var(--color-bonus);
+    background: rgba(46, 213, 115, 0.15);
     padding: 0.25rem 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
   }
 
   .move-effect,
@@ -281,26 +258,28 @@
   }
 
   .value-number {
-    color: #4ecdc4;
+    color: var(--player-2);
   }
 
   .value-unit {
-    color: #666;
+    color: var(--text-secondary);
     font-size: 1.2rem;
   }
 
   .value-icon {
-    font-size: 2.5rem;
+    display: flex;
+    align-items: center;
+    color: var(--color-accent-light);
   }
 
   .value-text {
-    color: #ab47bc;
+    color: var(--color-restart);
     font-size: 1.5rem;
   }
 
   .effect-direction {
     font-size: 1.2rem;
-    color: #666;
+    color: var(--text-secondary);
     font-weight: bold;
   }
 
@@ -310,47 +289,21 @@
   }
 
   .confirm-btn {
-    background: linear-gradient(135deg, #4ecdc4, #44a08d);
+    background: linear-gradient(135deg, var(--color-accent) 0%, #764ba2 100%);
     color: white;
-    border: none;
-    border-radius: 8px;
-    padding: 0.75rem 2rem;
-    font-size: 1.1rem;
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s ease;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
   }
 
-  .confirm-btn:hover {
+  .confirm-btn:not(:disabled):hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(78, 205, 196, 0.3);
-  }
-
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
-
-  @keyframes slideIn {
-    from {
-      transform: translateY(-50px);
-      opacity: 0;
-    }
-    to {
-      transform: translateY(0);
-      opacity: 1;
-    }
+    box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
   }
 
   /* 移动端适配 */
   @media (max-width: 768px) {
     .effect-display-modal {
       padding: 1.5rem;
-      margin: 1rem;
     }
 
     .effect-icon {

--- a/src/components/GameBoard.vue
+++ b/src/components/GameBoard.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
   import { computed, ref } from 'vue'
   import type { BoardCell, Player } from '../types/game'
-  import { CELL_ICONS } from '../config/gameConfig'
+  import { CELL_ICON_NAMES } from '../config/gameConfig'
+  import { Zap, Gift, Undo2, Moon, RotateCcw, Skull, Rocket, Sparkles } from '@lucide/vue'
 
   interface Props {
     board: BoardCell[]
@@ -16,6 +17,8 @@
 
   const props = defineProps<Props>()
   const emit = defineEmits<Emits>()
+
+  const iconComponents: Record<string, any> = { Zap, Gift, Undo2, Moon, RotateCcw, Skull, Rocket, Sparkles }
 
   // 浮窗状态
   const tooltipVisible = ref(false)
@@ -103,15 +106,17 @@
     return `${baseClass} ${highlightClass}`.trim()
   }
 
-  const getCellIcon = (position: number): string => {
+  const getCellIconComponent = (position: number): string | null => {
     const cell = getCellByPosition(position)
+    if (cell.effect?.type === 'rest') return 'Moon'
+    if (cell.effect?.type === 'reverse') return 'Undo2'
+    const name = CELL_ICON_NAMES[cell.type]
+    return name || null
+  }
 
-    // 特殊处理休息格子
-    if (cell.effect?.type === 'rest') {
-      return '😴'
-    }
-
-    return CELL_ICONS[cell.type] || ''
+  const getCellIcon = (position: number) => {
+    const name = getCellIconComponent(position)
+    return name ? iconComponents[name] : null
   }
 
   const getCellEffect = (position: number): string => {
@@ -191,7 +196,9 @@
               >
                 <div class="cell-content">
                   <div class="cell-number">{{ cellNum }}</div>
-                  <div class="cell-icon">{{ getCellIcon(cellNum) }}</div>
+                  <div class="cell-icon">
+                    <component :is="getCellIcon(cellNum)" v-if="getCellIcon(cellNum)" :size="14" />
+                  </div>
                   <div class="cell-effect">{{ getCellEffect(cellNum) }}</div>
                 </div>
                 <!-- 玩家标记 -->
@@ -206,7 +213,7 @@
                     'player-moving': player.isMoving,
                   }"
                 >
-                  ✈️
+                  {{ player.name.charAt(0) }}
                 </div>
               </div>
             </template>
@@ -223,7 +230,9 @@
         >
           <div class="cell-content">
             <div class="cell-number">START</div>
-            <div class="cell-icon">🚀</div>
+            <div class="cell-icon">
+              <Rocket :size="20" />
+            </div>
           </div>
           <!-- 玩家标记 -->
           <div
@@ -237,7 +246,7 @@
               'player-moving': player.isMoving,
             }"
           >
-            ✈️
+            {{ player.name.charAt(0) }}
           </div>
         </div>
       </div>
@@ -246,7 +255,7 @@
     <!-- 效果显示 -->
     <div v-if="lastEffect" class="effect-display">
       <div class="effect-content">
-        <span class="effect-icon">✨</span>
+        <span class="effect-icon"><Sparkles :size="16" /></span>
         <span class="effect-text">{{ lastEffect }}</span>
       </div>
     </div>
@@ -348,11 +357,10 @@
     align-items: center;
     gap: 1rem;
     padding: 1rem;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0.05));
-    border-radius: 16px;
-    backdrop-filter: blur(15px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    background: var(--bg-surface);
+    border-radius: var(--radius-lg);
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
   }
 
   .board-row {
@@ -364,20 +372,22 @@
     position: relative;
     width: 70px;
     height: 70px;
-    border-radius: 8px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: all var(--transition-fast);
     display: flex;
     align-items: center;
     justify-content: center;
-    border: 2px solid transparent;
-    background: white;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    background: var(--bg-glass);
+    backdrop-filter: blur(8px);
+    border: var(--glass-border);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   }
 
   .board-cell:hover {
+    background: var(--bg-glass-hover);
     transform: translateY(-2px);
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    box-shadow: var(--glow-sm) rgba(255, 255, 255, 0.1);
   }
 
   .cell-content {
@@ -392,20 +402,23 @@
   }
 
   .cell-number {
-    font-size: 0.7rem;
-    font-weight: bold;
-    color: #333;
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: var(--text-muted);
     margin-bottom: 0.1rem;
   }
 
   .cell-icon {
-    font-size: 1rem;
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
     margin-bottom: 0.1rem;
   }
 
   .cell-effect {
-    font-size: 0.5rem;
-    color: #666;
+    font-size: 0.45rem;
+    color: var(--text-muted);
     line-height: 1;
     max-width: 100%;
     overflow: hidden;
@@ -413,64 +426,44 @@
     white-space: nowrap;
   }
 
-  /* 格子类型样式 */
+  /* Type-specific: colored left border + tinted icon */
   .cell-punishment {
-    background: linear-gradient(135deg, #ff6b6b, #ee5a52);
-    border-color: #ff4757;
-    color: white;
+    border-left: 3px solid var(--color-punishment);
   }
-
-  .cell-punishment .cell-number,
-  .cell-punishment .cell-effect {
-    color: white;
+  .cell-punishment .cell-icon {
+    color: var(--color-punishment);
   }
 
   .cell-bonus {
-    background: linear-gradient(135deg, #2ed573, #1e90ff);
-    border-color: #2ed573;
-    color: white;
+    border-left: 3px solid var(--color-bonus);
   }
-
-  .cell-bonus .cell-number,
-  .cell-bonus .cell-effect {
-    color: white;
+  .cell-bonus .cell-icon {
+    color: var(--color-bonus);
   }
 
   .cell-special {
-    background: linear-gradient(135deg, #ffa726, #ff9800);
-    border-color: #ff7043;
-    color: white;
+    border-left: 3px solid var(--color-special);
   }
-
-  .cell-special .cell-number,
-  .cell-special .cell-effect {
-    color: white;
+  .cell-special .cell-icon {
+    color: var(--color-special);
   }
 
   .cell-restart {
-    background: linear-gradient(135deg, #ab47bc, #8e44ad);
-    border-color: #9b59b6;
-    color: white;
+    border-left: 3px solid var(--color-restart);
   }
-
-  .cell-restart .cell-number,
-  .cell-restart .cell-effect {
-    color: white;
+  .cell-restart .cell-icon {
+    color: var(--color-restart);
   }
 
   .cell-trap {
-    background: linear-gradient(135deg, #8b0000, #dc143c);
-    border-color: #b22222;
-    color: white;
+    border-left: 3px solid var(--color-trap);
   }
-
-  .cell-trap .cell-number,
-  .cell-trap .cell-effect {
-    color: white;
+  .cell-trap .cell-icon {
+    color: var(--color-trap);
   }
 
   .cell-occupied {
-    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.8);
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.3);
   }
 
   /* 玩家标记 */
@@ -479,25 +472,26 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 24px;
-    height: 24px;
+    width: 26px;
+    height: 26px;
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     color: white;
-    font-weight: bold;
-    font-size: 12px;
-    border: 2px solid rgba(255, 255, 255, 0.8);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-    transition: all 0.3s ease;
+    font-weight: 700;
+    font-size: 11px;
+    border: 2px solid rgba(255, 255, 255, 0.6);
+    box-shadow: var(--glow-md) currentColor;
+    transition: all var(--transition-normal);
     z-index: 10;
+    text-transform: uppercase;
   }
 
   .player-marker.current-player {
-    border-color: #ffd700;
-    box-shadow: 0 0 12px rgba(255, 215, 0, 0.6);
-    animation: pulse 2s infinite;
+    border-color: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 0 12px rgba(255, 215, 0, 0.6), 0 0 24px rgba(255, 215, 0, 0.3);
+    animation: pulseGlow 2s ease-in-out infinite;
   }
 
   .player-marker.player-moving {
@@ -505,13 +499,13 @@
     transform: translate(-50%, -50%) scale(1.2);
   }
 
-  @keyframes pulse {
+  @keyframes pulseGlow {
     0%,
     100% {
-      box-shadow: 0 0 12px rgba(255, 215, 0, 0.6);
+      box-shadow: 0 0 12px rgba(255, 215, 0, 0.6), 0 0 24px rgba(255, 215, 0, 0.3);
     }
     50% {
-      box-shadow: 0 0 20px rgba(255, 215, 0, 0.8);
+      box-shadow: 0 0 20px rgba(255, 215, 0, 0.8), 0 0 40px rgba(255, 215, 0, 0.4);
     }
   }
 
@@ -539,15 +533,15 @@
   .start-cell {
     width: 80px;
     height: 80px;
-    border-radius: 12px;
-    background: linear-gradient(135deg, #667eea, #764ba2);
-    border: 3px solid #5a67d8;
+    border-radius: var(--radius-md);
+    background: var(--bg-glass);
+    border: 2px solid var(--color-accent);
     display: flex;
     align-items: center;
     justify-content: center;
-    color: white;
+    color: var(--text-primary);
     font-weight: bold;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    box-shadow: var(--glow-md) rgba(102, 126, 234, 0.3);
   }
 
   .start-cell .cell-content {
@@ -556,45 +550,12 @@
 
   .start-cell .cell-number {
     font-size: 0.8rem;
-    color: white;
+    color: var(--color-accent-light);
     margin-bottom: 0.2rem;
   }
 
   .start-cell .cell-icon {
-    font-size: 1.5rem;
-  }
-
-  /* 蛇形路径指示器 */
-  .board-grid::before {
-    content: '';
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 100%;
-    height: 100%;
-    background:
-      linear-gradient(
-        90deg,
-        transparent 0%,
-        transparent 10%,
-        rgba(78, 205, 196, 0.1) 10%,
-        rgba(78, 205, 196, 0.1) 90%,
-        transparent 90%,
-        transparent 100%
-      ),
-      linear-gradient(
-        0deg,
-        transparent 0%,
-        transparent 10%,
-        rgba(78, 205, 196, 0.1) 10%,
-        rgba(78, 205, 196, 0.1) 90%,
-        transparent 90%,
-        transparent 100%
-      );
-    pointer-events: none;
-    z-index: -1;
-    border-radius: 16px;
+    color: var(--color-accent);
   }
 
   /* 效果显示 */
@@ -603,11 +564,13 @@
     top: 20px;
     left: 50%;
     transform: translateX(-50%);
-    background: linear-gradient(135deg, #667eea, #764ba2);
-    color: white;
-    padding: 1rem 2rem;
-    border-radius: 8px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    background: rgba(20, 20, 40, 0.9);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    color: var(--text-primary);
+    padding: 0.75rem 1.5rem;
+    border-radius: var(--radius-md);
+    box-shadow: var(--glass-shadow);
     z-index: 1000;
     animation: slideDown 0.5s ease-out;
   }
@@ -619,7 +582,9 @@
   }
 
   .effect-icon {
-    font-size: 1.2rem;
+    display: flex;
+    align-items: center;
+    color: var(--color-accent-light);
   }
 
   .effect-text {
@@ -672,7 +637,7 @@
       width: clamp(1.5rem, 4vw, 2rem);
       height: clamp(1.5rem, 4vw, 2rem);
       font-size: clamp(0.8rem, 2vw, 1rem);
-      border: 1px solid white;
+      border: 1px solid rgba(255, 255, 255, 0.5);
     }
     .start-cell {
       width: clamp(65px, 16vw, 80px);
@@ -707,7 +672,6 @@
       width: clamp(38px, 10vw, 48px);
       height: clamp(38px, 10vw, 48px);
       border-radius: 8px;
-      border-width: 1px;
       touch-action: manipulation;
       -webkit-tap-highlight-color: transparent;
     }
@@ -731,6 +695,7 @@
       height: clamp(1.2rem, 3vw, 1.5rem);
       font-size: clamp(0.7rem, 1.8vw, 0.9rem);
       border-width: 1px;
+      border-color: rgba(255, 255, 255, 0.5);
     }
     .start-cell {
       width: clamp(55px, 14vw, 65px);
@@ -852,12 +817,11 @@
   .cell-tooltip {
     position: fixed;
     z-index: 10000;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.9));
-    backdrop-filter: blur(15px);
-    border: 2px solid rgba(255, 255, 255, 0.3);
-    border-radius: 12px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-    padding: 0;
+    background: rgba(20, 20, 40, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--glass-shadow-lg);
     max-width: 280px;
     min-width: 200px;
     pointer-events: none;
@@ -874,19 +838,19 @@
     align-items: center;
     margin-bottom: 0.75rem;
     padding-bottom: 0.5rem;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   }
 
   .tooltip-number {
     font-size: 1.2rem;
     font-weight: bold;
-    color: #333;
+    color: var(--text-primary);
   }
 
   .tooltip-type {
     font-size: 0.8rem;
-    color: #666;
-    background: rgba(0, 0, 0, 0.1);
+    color: var(--text-muted);
+    background: var(--bg-glass);
     padding: 0.2rem 0.5rem;
     border-radius: 12px;
   }
@@ -896,13 +860,13 @@
   }
 
   .tooltip-effect {
-    color: #333;
+    color: var(--text-primary);
   }
 
   .effect-title {
     font-weight: bold;
     margin-bottom: 0.5rem;
-    color: #2c3e50;
+    color: var(--text-primary);
   }
 
   .punishment-details,
@@ -911,8 +875,8 @@
   .reverse-details,
   .restart-details,
   .trap-details {
-    background: rgba(0, 0, 0, 0.05);
-    border-radius: 8px;
+    background: var(--bg-glass);
+    border-radius: var(--radius-sm);
     padding: 0.75rem;
     margin-top: 0.5rem;
   }
@@ -930,24 +894,25 @@
 
   .detail-label {
     font-weight: 500;
-    color: #555;
+    color: var(--text-muted);
     min-width: 40px;
   }
 
   .detail-value {
     font-weight: bold;
-    color: #2c3e50;
+    color: var(--text-primary);
     text-align: right;
   }
 
   .tooltip-normal {
     text-align: center;
-    color: #666;
+    color: var(--text-muted);
     font-style: italic;
   }
 
   .normal-text {
     padding: 0.5rem;
+    color: var(--text-muted);
   }
 
   /* 浮窗动画 */

--- a/src/components/GameControls.vue
+++ b/src/components/GameControls.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import { computed } from 'vue'
+  import { Gamepad2, Trophy } from '@lucide/vue'
   import type { Player } from '../types/game'
 
   interface Props {
@@ -72,9 +73,12 @@
 </script>
 
 <template>
-  <div class="game-controls">
+  <div class="game-controls glass-card">
     <div class="control-buttons">
-      <button v-if="!gameStarted" class="btn btn-primary" @click="startGame">🎮 开始游戏</button>
+      <button v-if="!gameStarted" class="btn btn-primary" @click="startGame">
+        <Gamepad2 :size="20" />
+        开始游戏
+      </button>
     </div>
 
     <div v-if="gameStarted" class="game-status">
@@ -96,54 +100,29 @@
     </div>
 
     <div v-if="gameFinished" class="game-over">
-      <h3>🎉 游戏结束！</h3>
+      <h3>
+        <Trophy :size="24" />
+        游戏结束！
+      </h3>
       <p v-if="winner">{{ winner.name }} 获胜！</p>
-      <button class="btn btn-primary" @click="resetGame">🎮 再来一局</button>
+      <button class="btn btn-primary" @click="resetGame">
+        <Gamepad2 :size="20" />
+        再来一局
+      </button>
     </div>
   </div>
 </template>
 
 <style scoped>
   .game-controls {
-    background: white;
-    border-radius: 8px;
-    padding: 1.5rem;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     margin-bottom: 1rem;
+    padding: 1.5rem;
   }
 
-  .btn {
-    padding: clamp(0.6rem, 2vw, 0.75rem) clamp(1.2rem, 3vw, 1.5rem);
-    border: none;
-    border-radius: clamp(4px, 1vw, 6px);
-    font-size: clamp(0.9rem, 2.5vw, 1rem);
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s ease;
+  .control-buttons {
     display: flex;
-    align-items: center;
-    gap: clamp(0.4rem, 1vw, 0.5rem);
-    min-height: clamp(36px, 8vw, 44px);
-  }
-
-  .btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-  }
-
-  .btn-primary {
-    background: linear-gradient(135deg, #4ecdc4, #44a08d);
-    color: white;
-  }
-
-  .btn-secondary {
-    background: linear-gradient(135deg, #ff6b6b, #ee5a52);
-    color: white;
-  }
-
-  .btn-danger {
-    background: linear-gradient(135deg, #ffa726, #ff9800);
-    color: white;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
   }
 
   .game-status {
@@ -151,8 +130,9 @@
     justify-content: space-around;
     gap: clamp(1rem, 4vw, 2rem);
     padding: clamp(0.8rem, 2.5vw, 1rem);
-    background: #f8f9fa;
-    border-radius: clamp(4px, 1vw, 6px);
+    background: var(--bg-surface);
+    border: var(--glass-border);
+    border-radius: var(--radius-sm);
   }
 
   .status-item {
@@ -164,42 +144,42 @@
 
   .label {
     font-size: clamp(0.8rem, 2.5vw, 0.9rem);
-    color: #666;
+    color: var(--text-muted);
   }
 
   .value {
     font-weight: bold;
     font-size: clamp(1rem, 3vw, 1.1rem);
+    color: var(--text-primary);
   }
 
   .status-waiting {
-    color: #4ecdc4;
+    color: var(--player-2);
   }
 
   .status-rolling {
-    color: #ff6b6b;
+    color: var(--player-1);
     animation: pulse 1s infinite;
   }
 
   .status-moving {
-    color: #45b7d1;
+    color: var(--player-3);
   }
 
   .status-showing_effect {
-    color: #ab47bc;
+    color: var(--color-restart);
     animation: pulse 1s infinite;
   }
 
   .status-finished {
-    color: #96ceb4;
+    color: var(--player-8);
   }
 
-  /* 当前玩家信息样式 */
   .current-player-info {
-    background: linear-gradient(135deg, rgba(78, 205, 196, 0.1), rgba(69, 183, 209, 0.1));
-    border-radius: clamp(4px, 1vw, 6px);
+    background: rgba(102, 126, 234, 0.1);
+    border-radius: var(--radius-sm);
     padding: clamp(0.5rem, 1.5vw, 0.8rem);
-    border: 1px solid rgba(78, 205, 196, 0.3);
+    border: 1px solid rgba(102, 126, 234, 0.25);
   }
 
   .player-info {
@@ -212,33 +192,38 @@
     width: clamp(20px, 5vw, 24px);
     height: clamp(20px, 5vw, 24px);
     border-radius: 50%;
-    border: 2px solid rgba(255, 255, 255, 0.8);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   }
 
   .player-name {
     font-weight: bold;
     font-size: clamp(0.9rem, 2.5vw, 1rem);
-    color: #333;
+    color: var(--text-primary);
   }
 
   .game-over {
     text-align: center;
     padding: clamp(1.5rem, 4vw, 2rem);
-    background: linear-gradient(135deg, #fff8e1, #fffde7);
-    border-radius: clamp(6px, 1.5vw, 8px);
-    border: 2px solid #ffd700;
+    background: rgba(245, 158, 11, 0.08);
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(245, 158, 11, 0.25);
+    margin-top: 1rem;
   }
 
   .game-over h3 {
     margin: 0 0 0.5rem 0;
-    color: #333;
+    color: var(--color-warning);
     font-size: clamp(1.2rem, 3.5vw, 1.5rem);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
   }
 
   .game-over p {
     margin: 0 0 1rem 0;
-    color: #666;
+    color: var(--text-secondary);
     font-size: clamp(0.9rem, 2.5vw, 1rem);
   }
 
@@ -257,7 +242,6 @@
     .game-controls {
       padding: 0.75rem;
       margin-bottom: 0.75rem;
-      border-radius: 6px;
     }
 
     .control-buttons {
@@ -265,35 +249,13 @@
       margin-bottom: 0.75rem;
     }
 
-    .btn {
-      padding: clamp(0.5rem, 2vw, 0.6rem) clamp(1rem, 3vw, 1.2rem);
-      font-size: clamp(0.8rem, 2.2vw, 0.9rem);
-      border-radius: 4px;
-      min-height: clamp(36px, 8vw, 40px);
-      gap: clamp(0.3rem, 1vw, 0.4rem);
-    }
-
     .game-status {
       gap: clamp(0.5rem, 2vw, 1rem);
       padding: clamp(0.5rem, 2vw, 0.8rem);
-      border-radius: 4px;
-    }
-
-    .status-item {
-      gap: clamp(0.15rem, 0.5vw, 0.2rem);
-    }
-
-    .label {
-      font-size: clamp(0.7rem, 2vw, 0.8rem);
-    }
-
-    .value {
-      font-size: clamp(0.9rem, 2.5vw, 1rem);
     }
 
     .game-over {
       padding: clamp(1rem, 3vw, 1.5rem);
-      border-radius: 6px;
     }
 
     .game-over h3 {
@@ -307,7 +269,6 @@
     }
   }
 
-  /* 小屏手机优化 */
   @media (max-width: 480px) {
     .game-controls {
       padding: 0.5rem;
@@ -319,143 +280,41 @@
       margin-bottom: 0.5rem;
     }
 
-    .btn {
-      padding: clamp(0.4rem, 1.8vw, 0.5rem) clamp(0.8rem, 2.5vw, 1rem);
-      font-size: clamp(0.75rem, 2vw, 0.8rem);
-      min-height: clamp(32px, 7vw, 36px);
-      gap: clamp(0.25rem, 0.8vw, 0.3rem);
-    }
-
     .game-status {
       gap: clamp(0.4rem, 1.5vw, 0.5rem);
       padding: clamp(0.4rem, 1.5vw, 0.5rem);
     }
 
-    .status-item {
-      gap: clamp(0.1rem, 0.4vw, 0.15rem);
-    }
-
-    .label {
-      font-size: clamp(0.65rem, 1.8vw, 0.7rem);
-    }
-
-    .value {
-      font-size: clamp(0.8rem, 2.2vw, 0.9rem);
-    }
-
     .game-over {
       padding: clamp(0.75rem, 2.5vw, 1rem);
     }
-
-    .game-over h3 {
-      font-size: clamp(0.9rem, 2.5vw, 1rem);
-      margin-bottom: 0.3rem;
-    }
-
-    .game-over p {
-      font-size: clamp(0.75rem, 2vw, 0.8rem);
-      margin-bottom: 0.5rem;
-    }
   }
 
-  /* 超小屏手机优化 */
   @media (max-width: 360px) {
     .game-controls {
       padding: 0.4rem;
       margin-bottom: 0.4rem;
     }
 
-    .control-buttons {
-      gap: 0.3rem;
-      margin-bottom: 0.4rem;
-    }
-
-    .btn {
-      padding: clamp(0.35rem, 1.5vw, 0.4rem) clamp(0.7rem, 2vw, 0.8rem);
-      font-size: clamp(0.7rem, 1.8vw, 0.75rem);
-      min-height: clamp(28px, 6vw, 32px);
-      gap: clamp(0.2rem, 0.6vw, 0.25rem);
-    }
-
     .game-status {
       gap: clamp(0.3rem, 1.2vw, 0.4rem);
       padding: clamp(0.3rem, 1.2vw, 0.4rem);
     }
-
-    .status-item {
-      gap: clamp(0.08rem, 0.3vw, 0.1rem);
-    }
-
-    .label {
-      font-size: clamp(0.6rem, 1.5vw, 0.65rem);
-    }
-
-    .value {
-      font-size: clamp(0.75rem, 2vw, 0.8rem);
-    }
-
-    .game-over {
-      padding: clamp(0.6rem, 2vw, 0.75rem);
-    }
-
-    .game-over h3 {
-      font-size: clamp(0.8rem, 2.2vw, 0.9rem);
-      margin-bottom: 0.25rem;
-    }
-
-    .game-over p {
-      font-size: clamp(0.7rem, 1.8vw, 0.75rem);
-      margin-bottom: 0.4rem;
-    }
   }
 
-  /* 横屏模式优化 */
   @media (max-width: 767px) and (orientation: landscape) {
     .game-controls {
       padding: 0.4rem;
       margin-bottom: 0.4rem;
     }
 
-    .control-buttons {
-      gap: 0.3rem;
-      margin-bottom: 0.4rem;
-    }
-
-    .btn {
-      padding: clamp(0.35rem, 1.5vw, 0.4rem) clamp(0.7rem, 2vw, 0.8rem);
-      font-size: clamp(0.7rem, 1.8vw, 0.75rem);
-      min-height: clamp(28px, 6vw, 32px);
-    }
-
     .game-status {
       gap: clamp(0.3rem, 1.2vw, 0.4rem);
       padding: clamp(0.3rem, 1.2vw, 0.4rem);
     }
 
-    .status-item {
-      gap: clamp(0.08rem, 0.3vw, 0.1rem);
-    }
-
-    .label {
-      font-size: clamp(0.6rem, 1.5vw, 0.65rem);
-    }
-
-    .value {
-      font-size: clamp(0.75rem, 2vw, 0.8rem);
-    }
-
     .game-over {
       padding: clamp(0.6rem, 2vw, 0.75rem);
-    }
-
-    .game-over h3 {
-      font-size: clamp(0.8rem, 2.2vw, 0.9rem);
-      margin-bottom: 0.25rem;
-    }
-
-    .game-over p {
-      font-size: clamp(0.7rem, 1.8vw, 0.75rem);
-      margin-bottom: 0.4rem;
     }
   }
 </style>

--- a/src/components/IntroPage.vue
+++ b/src/components/IntroPage.vue
@@ -1,5 +1,21 @@
 <script setup lang="ts">
   import { ref, onMounted, onUnmounted, watch } from 'vue'
+  import {
+    Dices,
+    Star,
+    Gem,
+    Code2,
+    ExternalLink,
+    Users,
+    User,
+    Minus,
+    Plus,
+    Rocket,
+    Clock,
+    Target,
+    Eraser,
+    Check,
+  } from '@lucide/vue'
   import { savePlayerSettings, loadPlayerSettings, clearAllLocalGameData } from '../utils/cache'
   import { SecureRandom } from '../utils/secureRandom'
   import { devLog } from '../utils/logger'
@@ -198,14 +214,15 @@
       <div class="intro-header">
         <div class="title-container">
           <h1 class="game-title">
-            <span class="title-main">🎲 惩罚飞行棋</span>
+            <Dices :size="48" class="title-icon" />
+            <span class="title-main">惩罚飞行棋</span>
             <div class="title-glow"></div>
           </h1>
           <div class="title-decoration">
             <div class="decoration-line left"></div>
             <div class="decoration-center">
-              <span class="decoration-star">⭐</span>
-              <span class="decoration-diamond">💎</span>
+              <Star :size="24" class="decoration-star" />
+              <Gem :size="24" class="decoration-diamond" />
             </div>
             <div class="decoration-line right"></div>
           </div>
@@ -218,7 +235,7 @@
 
         <div class="developer-info">
           <div class="dev-card">
-            <div class="dev-avatar">👨‍💻</div>
+            <div class="dev-avatar"><Code2 :size="28" /></div>
             <div class="dev-details">
               <span class="dev-name">开发者：阿汤</span>
               <!-- 论坛宣传链接 -->
@@ -229,7 +246,7 @@
                 class="dev-link"
               >
                 <span class="dev-id">论坛: atang-sp.run.place</span>
-                <span class="link-icon">🔗</span>
+                <ExternalLink :size="14" class="link-icon" />
               </a>
               <a
                 href="https://x.com/sp_with_py"
@@ -238,7 +255,7 @@
                 class="dev-link"
               >
                 <span class="dev-id">@sp_with_py</span>
-                <span class="link-icon">🔗</span>
+                <ExternalLink :size="14" class="link-icon" />
               </a>
             </div>
           </div>
@@ -248,7 +265,10 @@
       <!-- 玩家设置区域 -->
       <div class="player-settings">
         <div class="settings-header">
-          <h2 class="settings-title">👥 玩家设置</h2>
+          <h2 class="settings-title">
+            <Users :size="22" class="settings-icon" />
+            <span class="settings-title-text">玩家设置</span>
+          </h2>
           <div class="settings-underline"></div>
         </div>
 
@@ -256,23 +276,23 @@
         <div class="player-count-section">
           <div class="setting-item">
             <label class="setting-label">
-              <span class="label-icon">👤</span>
+              <User :size="20" class="label-icon" />
               <span class="label-text">玩家人数</span>
             </label>
             <div class="count-controls">
               <button
-                class="count-btn minus"
+                class="btn btn-secondary count-btn minus"
                 :disabled="playerCount <= 1"
                 @click="onPlayerCountChange(Math.max(1, playerCount - 1))"
               >
-                <span class="btn-icon">➖</span>
+                <Minus :size="18" />
               </button>
               <div class="count-display">
                 <span class="count-number">{{ playerCount }}</span>
                 <span class="count-unit">人</span>
               </div>
-              <button class="count-btn plus" @click="onPlayerCountChange(playerCount + 1)">
-                <span class="btn-icon">➕</span>
+              <button class="btn btn-secondary count-btn plus" @click="onPlayerCountChange(playerCount + 1)">
+                <Plus :size="18" />
               </button>
             </div>
           </div>
@@ -303,22 +323,18 @@
 
       <!-- 操作区域 -->
       <div class="intro-actions">
-        <button class="start-btn" @click="startGame">
-          <div class="btn-content">
-            <span class="btn-icon">🚀</span>
-            <span class="btn-text">开始游戏</span>
-          </div>
-          <div class="btn-glow"></div>
-          <div class="btn-particles"></div>
+        <button class="btn btn-primary start-btn" @click="startGame">
+          <Rocket :size="22" />
+          <span class="btn-text">开始游戏</span>
         </button>
 
         <div class="game-info">
           <div class="info-item">
-            <span class="info-icon">⏱️</span>
+            <Clock :size="16" class="info-icon" />
             <span class="info-text">游戏时长：约10-20分钟</span>
           </div>
           <div class="info-item">
-            <span class="info-icon">🎯</span>
+            <Target :size="16" class="info-icon" />
             <span class="info-text">适合年龄：18岁以上</span>
           </div>
         </div>
@@ -326,11 +342,11 @@
         <!-- 清空缓存选项 -->
         <div class="cache-controls">
           <button
-            class="clear-cache-btn"
+            class="btn btn-danger clear-cache-btn"
             title="清除保存在此设备上的游戏配置、玩家设置和引导偏好"
             @click="clearCache"
           >
-            <span class="btn-icon">🧹</span>
+            <Eraser :size="16" />
             <span class="btn-text">清除本地游戏数据</span>
           </button>
           <p class="cache-hint">清除后刷新页面即可从默认配置重新开始</p>
@@ -338,7 +354,7 @@
 
         <!-- 清空成功提示 -->
         <div v-if="showClearSuccess" class="clear-success-toast">
-          <span class="toast-icon">✅</span>
+          <Check :size="18" class="toast-icon" />
           <span class="toast-text">本地游戏数据已清除</span>
         </div>
       </div>
@@ -346,8 +362,12 @@
 
     <!-- 背景装饰 -->
     <div class="background-decoration">
-      <div v-for="i in 8" :key="i" class="floating-dice" :style="getDiceStyle(i)">🎲</div>
-      <div v-for="i in 12" :key="i" class="floating-star" :style="getStarStyle(i)">⭐</div>
+      <div v-for="i in 8" :key="i" class="floating-dice" :style="getDiceStyle(i)">
+        <Dices :size="28" />
+      </div>
+      <div v-for="i in 12" :key="i" class="floating-star" :style="getStarStyle(i)">
+        <Star :size="24" />
+      </div>
       <div class="geometric-shapes">
         <div class="shape shape-1"></div>
         <div class="shape shape-2"></div>
@@ -412,7 +432,7 @@
   /* 主内容 */
   .intro-content {
     text-align: center;
-    color: white;
+    color: var(--text-primary);
     z-index: 10;
     max-width: min(900px, 95vw);
     padding: clamp(1rem, 4vw, 2rem);
@@ -430,12 +450,19 @@
   }
 
   .game-title {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: clamp(0.5rem, 2vw, 1rem);
     font-size: clamp(2.5rem, 10vw, 5rem);
     font-weight: 900;
     margin: 0;
     position: relative;
     z-index: 2;
-    background: linear-gradient(135deg, #ff6b6b, #4ecdc4, #45b7d1, #96ceb4, #feca57);
+  }
+
+  .title-main {
+    background: linear-gradient(135deg, var(--player-1), var(--player-2), var(--player-3), var(--player-4), var(--color-accent));
     background-size: 300% 300%;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -445,13 +472,19 @@
       titleFloat 4s ease-in-out infinite;
   }
 
+  .title-icon {
+    flex-shrink: 0;
+    color: var(--color-accent-light);
+    animation: titleFloat 4s ease-in-out infinite;
+  }
+
   .title-glow {
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    background: linear-gradient(135deg, #ff6b6b, #4ecdc4, #45b7d1, #96ceb4, #feca57);
+    background: linear-gradient(135deg, var(--player-1), var(--player-2), var(--player-3), var(--player-4), var(--color-accent));
     background-size: 300% 300%;
     filter: blur(20px);
     opacity: 0.3;
@@ -481,7 +514,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: linear-gradient(90deg, transparent, #ff6b6b, transparent);
+    background: linear-gradient(90deg, transparent, var(--player-1), transparent);
     animation: lineGlow 2s ease-in-out infinite;
   }
 
@@ -492,7 +525,7 @@
 
   .decoration-star,
   .decoration-diamond {
-    font-size: clamp(1.5rem, 4vw, 2rem);
+    color: var(--color-accent-light);
     animation: starTwinkle 2s ease-in-out infinite;
   }
 
@@ -512,6 +545,7 @@
     z-index: 2;
     font-weight: 300;
     letter-spacing: 1px;
+    color: var(--text-secondary);
   }
 
   .subtitle-underline {
@@ -520,7 +554,7 @@
     left: 0;
     right: 0;
     height: 2px;
-    background: linear-gradient(90deg, transparent, #ff6b6b, transparent);
+    background: linear-gradient(90deg, transparent, var(--player-1), transparent);
     animation: underlineGlow 2s ease-in-out infinite;
   }
 
@@ -534,21 +568,24 @@
     align-items: center;
     gap: clamp(0.8rem, 2vw, 1rem);
     padding: clamp(0.8rem, 2vw, 1.2rem) clamp(1.5rem, 4vw, 2rem);
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: clamp(15px, 4vw, 25px);
-    backdrop-filter: blur(15px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    transition: all 0.3s ease;
+    background: var(--bg-glass);
+    border-radius: var(--radius-xl);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    transition: all var(--transition-normal);
   }
 
   .dev-card:hover {
     transform: translateY(-3px);
-    background: rgba(255, 255, 255, 0.15);
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    background: var(--bg-glass-hover);
+    box-shadow: var(--glass-shadow);
   }
 
   .dev-avatar {
-    font-size: clamp(1.5rem, 4vw, 2rem);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-accent-light);
     animation: avatarFloat 3s ease-in-out infinite;
   }
 
@@ -561,36 +598,37 @@
   .dev-name {
     font-size: clamp(0.9rem, 2.5vw, 1rem);
     font-weight: 500;
+    color: var(--text-primary);
   }
 
   .dev-link {
     font-size: clamp(0.7rem, 2vw, 0.8rem);
     opacity: 0.8;
     font-weight: bold;
-    color: #4ecdc4;
+    color: var(--player-2);
     text-decoration: none;
     display: flex;
     align-items: center;
     gap: 0.3rem;
-    transition: all 0.3s ease;
+    transition: all var(--transition-normal);
     padding: 0.2rem 0.5rem;
-    border-radius: 0.5rem;
-    background: rgba(78, 205, 196, 0.1);
-    border: 1px solid rgba(78, 205, 196, 0.2);
+    border-radius: var(--radius-sm);
+    background: rgba(var(--player-2-rgb), 0.1);
+    border: 1px solid rgba(var(--player-2-rgb), 0.2);
   }
 
   .dev-link:hover {
     opacity: 1;
-    color: #fff;
-    background: rgba(78, 205, 196, 0.2);
-    border-color: rgba(78, 205, 196, 0.4);
+    color: var(--text-primary);
+    background: rgba(var(--player-2-rgb), 0.2);
+    border-color: rgba(var(--player-2-rgb), 0.4);
     transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(78, 205, 196, 0.3);
+    box-shadow: var(--glow-sm) rgba(var(--player-2-rgb), 0.3);
   }
 
   .link-icon {
-    font-size: clamp(0.8rem, 2.2vw, 0.9rem);
-    transition: transform 0.3s ease;
+    flex-shrink: 0;
+    transition: transform var(--transition-normal);
   }
 
   .dev-link:hover .link-icon {
@@ -601,11 +639,11 @@
   .player-settings {
     margin: clamp(2rem, 6vw, 3rem) 0;
     padding: clamp(1.5rem, 4vw, 2rem);
-    background: rgba(255, 255, 255, 0.08);
-    border-radius: clamp(20px, 5vw, 30px);
-    backdrop-filter: blur(20px);
-    border: 1px solid rgba(255, 255, 255, 0.15);
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+    background: var(--bg-glass);
+    border-radius: var(--radius-xl);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
   }
 
   .settings-header {
@@ -614,10 +652,21 @@
   }
 
   .settings-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
     font-size: clamp(1.3rem, 4vw, 1.6rem);
     font-weight: 700;
     margin: 0 0 clamp(0.5rem, 1.5vw, 0.8rem) 0;
-    background: linear-gradient(135deg, #4ecdc4, #45b7d1);
+  }
+
+  .settings-icon {
+    color: var(--player-2);
+    flex-shrink: 0;
+  }
+
+  .settings-title-text {
+    background: linear-gradient(135deg, var(--player-2), var(--player-3));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -626,7 +675,7 @@
   .settings-underline {
     width: clamp(60px, 15vw, 100px);
     height: 3px;
-    background: linear-gradient(90deg, #4ecdc4, #45b7d1);
+    background: linear-gradient(90deg, var(--player-2), var(--player-3));
     margin: 0 auto;
     border-radius: 2px;
     animation: underlineGlow 2s ease-in-out infinite;
@@ -643,14 +692,14 @@
     justify-content: space-between;
     gap: clamp(1rem, 3vw, 1.5rem);
     padding: clamp(1rem, 3vw, 1.5rem);
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: clamp(15px, 4vw, 20px);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    transition: all 0.3s ease;
+    background: var(--bg-surface);
+    border-radius: var(--radius-lg);
+    border: var(--glass-border);
+    transition: all var(--transition-normal);
   }
 
   .setting-item:hover {
-    background: rgba(255, 255, 255, 0.08);
+    background: var(--bg-glass);
     border-color: rgba(255, 255, 255, 0.2);
   }
 
@@ -660,12 +709,13 @@
     gap: clamp(0.5rem, 1.5vw, 0.8rem);
     font-size: clamp(1rem, 3vw, 1.1rem);
     font-weight: 600;
-    color: #fff;
+    color: var(--text-primary);
     cursor: pointer;
   }
 
   .label-icon {
-    font-size: clamp(1.2rem, 3.5vw, 1.4rem);
+    color: var(--color-accent-light);
+    flex-shrink: 0;
   }
 
   .count-controls {
@@ -675,35 +725,12 @@
   }
 
   .count-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
     width: clamp(40px, 10vw, 50px);
     height: clamp(40px, 10vw, 50px);
-    background: linear-gradient(135deg, #ff6b6b, #ee5a52);
-    border: none;
-    border-radius: 50%;
-    color: white;
-    font-size: clamp(1.2rem, 3vw, 1.4rem);
-    cursor: pointer;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 12px rgba(255, 107, 107, 0.3);
-  }
-
-  .count-btn:hover:not(:disabled) {
-    transform: translateY(-2px) scale(1.1);
-    box-shadow: 0 6px 20px rgba(255, 107, 107, 0.4);
-  }
-
-  .count-btn:active:not(:disabled) {
-    transform: translateY(0) scale(1.05);
-  }
-
-  .count-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-    transform: none;
-    box-shadow: none;
+    min-width: clamp(40px, 10vw, 50px);
+    min-height: clamp(40px, 10vw, 50px);
+    padding: 0;
+    border-radius: var(--radius-full);
   }
 
   .count-display {
@@ -711,9 +738,9 @@
     align-items: center;
     gap: clamp(0.3rem, 1vw, 0.5rem);
     padding: clamp(0.5rem, 1.5vw, 0.8rem) clamp(1rem, 3vw, 1.5rem);
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: clamp(10px, 3vw, 15px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: var(--bg-glass);
+    border-radius: var(--radius-md);
+    border: var(--glass-border);
     min-width: clamp(80px, 20vw, 100px);
     justify-content: center;
   }
@@ -721,12 +748,12 @@
   .count-number {
     font-size: clamp(1.2rem, 3.5vw, 1.4rem);
     font-weight: 700;
-    color: #4ecdc4;
+    color: var(--player-2);
   }
 
   .count-unit {
     font-size: clamp(0.9rem, 2.5vw, 1rem);
-    color: rgba(255, 255, 255, 0.8);
+    color: var(--text-secondary);
   }
 
   /* 玩家名称设置 */
@@ -742,7 +769,7 @@
   .names-title {
     font-size: clamp(1rem, 3vw, 1.1rem);
     font-weight: 600;
-    color: rgba(255, 255, 255, 0.9);
+    color: var(--text-primary);
   }
 
   .names-list {
@@ -764,30 +791,30 @@
   .name-input {
     width: 100%;
     padding: clamp(0.8rem, 2vw, 1rem) clamp(1rem, 3vw, 1.2rem);
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: clamp(10px, 3vw, 15px);
-    color: #fff;
+    background: rgba(10, 10, 26, 0.6);
+    border: var(--glass-border);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
     font-size: clamp(0.9rem, 2.5vw, 1rem);
     font-weight: 500;
-    transition: all 0.3s ease;
-    backdrop-filter: blur(10px);
+    transition: all var(--transition-normal);
+    backdrop-filter: blur(var(--glass-blur));
   }
 
   .name-input::placeholder {
-    color: rgba(255, 255, 255, 0.5);
+    color: var(--text-muted);
   }
 
   .name-input:focus {
     outline: none;
-    border-color: #4ecdc4;
-    background: rgba(255, 255, 255, 0.15);
-    box-shadow: 0 0 0 3px rgba(78, 205, 196, 0.2);
+    border-color: var(--color-accent);
+    background: var(--bg-glass-hover);
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
   }
 
   .name-input:hover {
-    border-color: rgba(255, 255, 255, 0.3);
-    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.2);
+    background: var(--bg-glass);
   }
 
   .input-glow {
@@ -796,10 +823,10 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: linear-gradient(135deg, rgba(78, 205, 196, 0.1), rgba(69, 183, 209, 0.1));
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.1), rgba(139, 156, 247, 0.1));
     border-radius: inherit;
     opacity: 0;
-    transition: opacity 0.3s ease;
+    transition: opacity var(--transition-normal);
     pointer-events: none;
   }
 
@@ -816,78 +843,11 @@
   }
 
   .start-btn {
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: clamp(1rem, 3vw, 1.5rem);
     padding: clamp(1.2rem, 4vw, 1.8rem) clamp(3rem, 8vw, 4rem);
     font-size: clamp(1.1rem, 3.5vw, 1.4rem);
-    font-weight: 700;
-    background: linear-gradient(135deg, #ff6b6b, #ee5a52, #ff4757);
-    color: white;
-    border: none;
-    border-radius: clamp(30px, 10vw, 60px);
-    cursor: pointer;
-    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-    overflow: hidden;
+    border-radius: var(--radius-full);
     min-height: clamp(50px, 12vw, 70px);
     min-width: clamp(200px, 60vw, 300px);
-  }
-
-  .btn-content {
-    display: flex;
-    align-items: center;
-    gap: clamp(0.8rem, 2vw, 1rem);
-    position: relative;
-    z-index: 2;
-  }
-
-  .btn-glow {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: linear-gradient(135deg, #ff6b6b, #ee5a52, #ff4757);
-    filter: blur(20px);
-    opacity: 0;
-    transition: opacity 0.3s ease;
-  }
-
-  .btn-particles {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: radial-gradient(circle at center, rgba(255, 255, 255, 0.3) 0%, transparent 70%);
-    opacity: 0;
-    transition: opacity 0.3s ease;
-  }
-
-  .start-btn:hover {
-    transform: translateY(-5px) scale(1.05);
-    box-shadow:
-      0 20px 40px rgba(255, 107, 107, 0.4),
-      0 0 0 1px rgba(255, 255, 255, 0.2);
-  }
-
-  .start-btn:hover .btn-glow {
-    opacity: 0.6;
-  }
-
-  .start-btn:hover .btn-particles {
-    opacity: 1;
-  }
-
-  .start-btn:active {
-    transform: translateY(-2px) scale(1.02);
-  }
-
-  .btn-icon {
-    font-size: clamp(1.5rem, 4vw, 1.8rem);
-    animation: rocketBounce 2s ease-in-out infinite;
   }
 
   .game-info {
@@ -900,12 +860,15 @@
   .info-item {
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: clamp(0.5rem, 1.5vw, 0.8rem);
     font-size: clamp(0.8rem, 2.5vw, 0.9rem);
+    color: var(--text-secondary);
   }
 
   .info-icon {
-    font-size: clamp(0.9rem, 2.5vw, 1rem);
+    color: var(--color-accent-light);
+    flex-shrink: 0;
   }
 
   /* 背景装饰 */
@@ -922,7 +885,10 @@
   .floating-dice,
   .floating-star {
     position: absolute;
-    font-size: clamp(1.5rem, 4vw, 2rem);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-accent-light);
     opacity: 0.2;
     filter: blur(0.5px);
   }
@@ -1068,16 +1034,6 @@
     }
     50% {
       transform: translateY(-5px);
-    }
-  }
-
-  @keyframes rocketBounce {
-    0%,
-    100% {
-      transform: translateY(0px);
-    }
-    50% {
-      transform: translateY(-3px);
     }
   }
 
@@ -1227,16 +1183,8 @@
 
     .start-btn {
       padding: clamp(0.8rem, 3vw, 1rem) clamp(1.5rem, 5vw, 2rem);
-      border-radius: 12px;
+      border-radius: var(--radius-md);
       min-height: clamp(48px, 12vw, 56px);
-    }
-
-    .btn-content {
-      gap: 0.5rem;
-    }
-
-    .btn-icon {
-      font-size: clamp(1.2rem, 3.5vw, 1.5rem);
     }
 
     .btn-text {
@@ -1328,10 +1276,6 @@
     .start-btn {
       padding: clamp(0.7rem, 2.5vw, 0.8rem) clamp(1.2rem, 4vw, 1.5rem);
       min-height: clamp(44px, 11vw, 48px);
-    }
-
-    .btn-icon {
-      font-size: clamp(1rem, 3vw, 1.2rem);
     }
 
     .btn-text {
@@ -1444,10 +1388,6 @@
       min-height: clamp(40px, 10vw, 44px);
     }
 
-    .btn-icon {
-      font-size: clamp(0.9rem, 2.5vw, 1rem);
-    }
-
     .btn-text {
       font-size: clamp(0.8rem, 2.2vw, 0.9rem);
     }
@@ -1531,10 +1471,6 @@
       min-height: clamp(44px, 11vw, 48px);
     }
 
-    .btn-icon {
-      font-size: clamp(1rem, 3vw, 1.2rem);
-    }
-
     .btn-text {
       font-size: clamp(0.9rem, 2.5vw, 1rem);
     }
@@ -1563,41 +1499,13 @@
   }
 
   .clear-cache-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.6rem 1.2rem;
-    background: linear-gradient(135deg, #ff6b6b, #ee5a5a);
-    color: white;
-    border: none;
-    border-radius: 8px;
     font-size: 0.85rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 12px rgba(255, 107, 107, 0.3);
-  }
-
-  .clear-cache-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 16px rgba(255, 107, 107, 0.4);
-    background: linear-gradient(135deg, #ee5a5a, #dd4a4a);
-  }
-
-  .clear-cache-btn:active {
-    transform: translateY(0);
-    box-shadow: 0 2px 8px rgba(255, 107, 107, 0.3);
-  }
-
-  .clear-cache-btn .btn-icon {
-    font-size: 1rem;
   }
 
   .cache-hint {
     margin-top: 0.5rem;
     font-size: 0.75rem;
-    color: rgba(255, 255, 255, 0.7);
-    opacity: 0.8;
+    color: var(--text-muted);
   }
 
   /* 清空成功提示样式 */
@@ -1610,19 +1518,20 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.8rem 1.5rem;
-    background: rgba(46, 160, 67, 0.95);
-    color: white;
-    border-radius: 8px;
+    background: rgba(34, 197, 94, 0.95);
+    color: var(--text-primary);
+    border-radius: var(--radius-sm);
     font-size: 0.9rem;
     font-weight: 500;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
-    backdrop-filter: blur(10px);
+    box-shadow: var(--glass-shadow);
+    backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid rgba(34, 197, 94, 0.3);
     z-index: 1000;
     animation: toastSlideIn 0.3s ease-out;
   }
 
   .toast-icon {
-    font-size: 1.1rem;
+    flex-shrink: 0;
   }
 
   @keyframes toastSlideIn {

--- a/src/components/PlayerPanel.vue
+++ b/src/components/PlayerPanel.vue
@@ -313,7 +313,7 @@
           }"
         >
           <div class="player-header">
-            <div class="player-color" :style="{ backgroundColor: player.color }"></div>
+            <div class="player-color" :style="{ backgroundColor: player.color, '--player-glow-color': player.color }"></div>
             <span class="player-name">{{ player.name }}</span>
             <div v-if="player.isWinner" class="winner-badge">🏆</div>
           </div>
@@ -331,32 +331,28 @@
 
 <style scoped>
   .player-panel {
-    background: white;
-    border-radius: clamp(6px, 1.5vw, 8px);
+    background: transparent;
+    border-radius: var(--radius-sm);
     padding: clamp(0.8rem, 2.5vw, 1rem);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     margin-bottom: clamp(0.8rem, 2.5vw, 1rem);
   }
 
   .player-panel h3 {
     margin: 0 0 clamp(0.8rem, 2.5vw, 1rem) 0;
-    color: #333;
+    color: var(--text-primary);
     text-align: center;
     font-size: clamp(1.1rem, 3vw, 1.3rem);
   }
 
   .players-container {
     max-height: 60vh;
-    min-height: 200px; /* 确保容器有最小高度 */
+    min-height: 200px;
     overflow-y: auto;
     overflow-x: hidden;
     scroll-behavior: smooth;
-    /* 确保在移动设备上滚动流畅 */
     -webkit-overflow-scrolling: touch;
-    /* 自定义滚动条样式 */
     scrollbar-width: thin;
-    scrollbar-color: #4ecdc4 #f0f0f0;
-    /* 确保容器有明确的定位上下文 */
+    scrollbar-color: rgba(255, 255, 255, 0.15) rgba(255, 255, 255, 0.05);
     position: relative;
   }
 
@@ -365,17 +361,17 @@
   }
 
   .players-container::-webkit-scrollbar-track {
-    background: #f0f0f0;
+    background: rgba(255, 255, 255, 0.05);
     border-radius: 3px;
   }
 
   .players-container::-webkit-scrollbar-thumb {
-    background: #4ecdc4;
+    background: rgba(255, 255, 255, 0.15);
     border-radius: 3px;
   }
 
   .players-container::-webkit-scrollbar-thumb:hover {
-    background: #45b7b8;
+    background: rgba(255, 255, 255, 0.25);
   }
 
   .players-grid {
@@ -386,24 +382,25 @@
   }
 
   .player-card {
-    border: 2px solid #e0e0e0;
-    border-radius: clamp(6px, 1.5vw, 8px);
+    border: var(--glass-border);
+    border-radius: var(--radius-md);
     padding: clamp(0.8rem, 2.5vw, 1rem);
-    transition: all 0.3s ease;
-    background: #fafafa;
+    transition: all var(--transition-normal);
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
   }
 
   .player-card.current {
-    border-color: #4ecdc4;
-    background: linear-gradient(135deg, #e8f5e8, #f0f8f0);
-    box-shadow: 0 4px 12px rgba(78, 205, 196, 0.3);
+    border-color: rgba(102, 126, 234, 0.5);
+    background: var(--bg-glass-hover);
+    box-shadow: var(--glow-sm) rgba(102, 126, 234, 0.3);
     transform: translateY(-2px);
   }
 
   .player-card.winner {
-    border-color: #ffd700;
-    background: linear-gradient(135deg, #fff8e1, #fffde7);
-    box-shadow: 0 4px 12px rgba(255, 215, 0, 0.3);
+    border-color: rgba(254, 202, 87, 0.5);
+    background: var(--bg-glass-hover);
+    box-shadow: var(--glow-sm) rgba(254, 202, 87, 0.3);
   }
 
   .player-header {
@@ -417,13 +414,13 @@
     width: clamp(16px, 4vw, 20px);
     height: clamp(16px, 4vw, 20px);
     border-radius: 50%;
-    border: 2px solid white;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    box-shadow: var(--glow-sm) var(--player-glow-color, rgba(255, 255, 255, 0.3));
   }
 
   .player-name {
     font-weight: bold;
-    color: #333;
+    color: var(--text-primary);
     flex: 1;
     font-size: clamp(0.9rem, 2.5vw, 1rem);
   }
@@ -447,13 +444,13 @@
 
   .label {
     font-size: clamp(0.8rem, 2.5vw, 0.9rem);
-    color: #666;
+    color: var(--text-muted);
     min-width: clamp(35px, 8vw, 40px);
   }
 
   .value {
     font-weight: bold;
-    color: #333;
+    color: var(--text-secondary);
     font-size: clamp(0.8rem, 2.5vw, 0.9rem);
   }
 

--- a/src/components/PunishmentConfig.vue
+++ b/src/components/PunishmentConfig.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
   import { ref, watch, nextTick } from 'vue'
+  import {
+    Settings,
+    Target,
+    ChevronRight,
+    X,
+    Minus,
+    Plus,
+    RotateCcw,
+  } from '@lucide/vue'
   import type {
     PunishmentConfig,
     PunishmentTool,
@@ -611,16 +620,22 @@
 </script>
 
 <template>
-  <div class="punishment-config">
+  <div class="punishment-config glass-card">
     <div class="config-header">
-      <h3>⚙️ 惩罚设置</h3>
+      <h3>
+        <Settings :size="22" />
+        惩罚设置
+      </h3>
     </div>
 
     <div class="config-sections">
       <!-- 工具设置 -->
       <div class="config-section">
         <div class="section-header">
-          <h4>🛠️ 工具设置</h4>
+          <h4>
+            <Settings :size="18" />
+            工具设置
+          </h4>
           <div class="section-summary">{{ Object.keys(localConfig.tools).length }}个工具</div>
         </div>
 
@@ -632,7 +647,9 @@
           >
             <div class="item-header">
               <span class="item-name">{{ tool.name }}</span>
-              <button class="btn-remove" @click="removeTool(tool.name)">×</button>
+              <button class="btn-remove" @click="removeTool(tool.name)">
+                <X :size="14" />
+              </button>
             </div>
 
             <div class="item-stats">
@@ -644,7 +661,7 @@
                     class="btn-stat"
                     @click="updateToolIntensity(tool.name, tool.intensity - 1)"
                   >
-                    -
+                    <Minus :size="14" />
                   </button>
                   <span class="stat-value">{{ tool.intensity }}/10</span>
                   <button
@@ -652,7 +669,7 @@
                     class="btn-stat"
                     @click="updateToolIntensity(tool.name, tool.intensity + 1)"
                   >
-                    +
+                    <Plus :size="14" />
                   </button>
                 </div>
               </div>
@@ -686,7 +703,8 @@
             />
           </div>
           <button :disabled="!newToolName.trim()" class="btn-add" @click="addTool">
-            + 添加工具
+            <Plus :size="16" />
+            添加工具
           </button>
         </div>
       </div>
@@ -694,7 +712,10 @@
       <!-- 部位设置 -->
       <div class="config-section">
         <div class="section-header">
-          <h4>🎯 部位设置</h4>
+          <h4>
+            <Target :size="18" />
+            部位设置
+          </h4>
           <div class="section-summary">{{ Object.keys(localConfig.bodyParts).length }}个部位</div>
         </div>
 
@@ -706,7 +727,9 @@
           >
             <div class="item-header">
               <span class="item-name">{{ bodyPart.name }}</span>
-              <button class="btn-remove" @click="removeBodyPart(bodyPart.name)">×</button>
+              <button class="btn-remove" @click="removeBodyPart(bodyPart.name)">
+                <X :size="14" />
+              </button>
             </div>
 
             <div class="item-stats">
@@ -718,7 +741,7 @@
                     class="btn-stat"
                     @click="updateBodyPartSensitivity(bodyPart.name, bodyPart.sensitivity - 1)"
                   >
-                    -
+                    <Minus :size="14" />
                   </button>
                   <span class="stat-value">{{ bodyPart.sensitivity }}/10</span>
                   <button
@@ -726,7 +749,7 @@
                     class="btn-stat"
                     @click="updateBodyPartSensitivity(bodyPart.name, bodyPart.sensitivity + 1)"
                   >
-                    +
+                    <Plus :size="14" />
                   </button>
                 </div>
               </div>
@@ -760,7 +783,8 @@
             />
           </div>
           <button :disabled="!newBodyPartName.trim()" class="btn-add" @click="addBodyPart">
-            + 添加部位
+            <Plus :size="16" />
+            添加部位
           </button>
         </div>
       </div>
@@ -768,7 +792,10 @@
       <!-- 姿势设置 -->
       <div class="config-section">
         <div class="section-header">
-          <h4>🧘 姿势设置</h4>
+          <h4>
+            <ChevronRight :size="18" />
+            姿势设置
+          </h4>
           <div class="section-summary">{{ Object.keys(localConfig.positions).length }}个姿势</div>
         </div>
 
@@ -780,7 +807,9 @@
           >
             <div class="item-header">
               <span class="item-name">{{ position.name }}</span>
-              <button class="btn-remove" @click="removePosition(position.name)">×</button>
+              <button class="btn-remove" @click="removePosition(position.name)">
+                <X :size="14" />
+              </button>
             </div>
 
             <div class="item-stats">
@@ -824,7 +853,8 @@
             <input v-model="newPositionName" placeholder="新姿势名称" class="input-field" />
           </div>
           <button :disabled="!newPositionName.trim()" class="btn-add" @click="addPosition">
-            + 添加姿势
+            <Plus :size="16" />
+            添加姿势
           </button>
         </div>
       </div>
@@ -832,7 +862,10 @@
       <!-- 惩罚数量设置 -->
       <div class="config-section">
         <div class="section-header">
-          <h4>🔢 惩罚数量设置</h4>
+          <h4>
+            <Settings :size="18" />
+            惩罚数量设置
+          </h4>
         </div>
 
         <div class="strikes-config">
@@ -844,7 +877,7 @@
                 class="btn-stat"
                 @click="updateMinStrikes(localConfig.minStrikes - 5)"
               >
-                -
+                <Minus :size="14" />
               </button>
               <span class="strikes-value">{{ localConfig.minStrikes }}</span>
               <button
@@ -852,7 +885,7 @@
                 class="btn-stat"
                 @click="updateMinStrikes(localConfig.minStrikes + 5)"
               >
-                +
+                <Plus :size="14" />
               </button>
             </div>
           </div>
@@ -865,7 +898,7 @@
                 class="btn-stat"
                 @click="updateMaxStrikes(localConfig.maxStrikes - 5)"
               >
-                -
+                <Minus :size="14" />
               </button>
               <span class="strikes-value">{{ localConfig.maxStrikes }}</span>
               <button
@@ -873,7 +906,7 @@
                 class="btn-stat"
                 @click="updateMaxStrikes(localConfig.maxStrikes + 5)"
               >
-                +
+                <Plus :size="14" />
               </button>
             </div>
           </div>
@@ -886,7 +919,7 @@
                 class="btn-stat"
                 @click="updateMaxTakeoffFailures(localConfig.maxTakeoffFailures - 1)"
               >
-                -
+                <Minus :size="14" />
               </button>
               <span class="strikes-value">{{ localConfig.maxTakeoffFailures }}</span>
               <button
@@ -894,7 +927,7 @@
                 class="btn-stat"
                 @click="updateMaxTakeoffFailures(localConfig.maxTakeoffFailures + 1)"
               >
-                +
+                <Plus :size="14" />
               </button>
             </div>
           </div>
@@ -907,8 +940,8 @@
     </div>
 
     <div class="config-actions">
-      <button class="btn-secondary" @click="resetToDefault">
-        <span class="btn-icon">🔄</span>
+      <button class="btn btn-secondary" @click="resetToDefault">
+        <RotateCcw :size="16" />
         <span class="btn-text">重置默认</span>
       </button>
     </div>
@@ -925,11 +958,11 @@
 
 <style scoped>
   .punishment-config {
-    background: white;
-    border-radius: 8px;
-    padding: 1rem;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     margin-bottom: 1rem;
+  }
+
+  .punishment-config:hover {
+    border-color: rgba(255, 255, 255, 0.1);
   }
 
   .config-header {
@@ -939,9 +972,13 @@
 
   .config-header h3 {
     margin: 0;
-    color: #333;
+    color: var(--text-primary);
     font-size: 1.3rem;
     font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
   }
 
   .config-sections {
@@ -952,10 +989,10 @@
   }
 
   .config-section {
-    border: 1px solid #e0e0e0;
-    border-radius: 8px;
+    border: var(--glass-border);
+    border-radius: var(--radius-md);
     padding: 1rem;
-    background: #fafafa;
+    background: var(--bg-surface);
   }
 
   .section-header {
@@ -964,22 +1001,26 @@
     align-items: center;
     margin-bottom: 1rem;
     padding-bottom: 0.5rem;
-    border-bottom: 1px solid #e0e0e0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   }
 
   .section-header h4 {
     margin: 0;
-    color: #333;
+    color: var(--text-primary);
     font-size: 1.1rem;
     font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
   }
 
   .section-summary {
     font-size: 0.8rem;
-    color: #666;
-    background: #e0e0e0;
+    color: var(--text-secondary);
+    background: var(--bg-glass);
     padding: 0.2rem 0.5rem;
-    border-radius: 12px;
+    border-radius: var(--radius-full);
+    border: var(--glass-border);
   }
 
   .items-grid {
@@ -989,11 +1030,11 @@
   }
 
   .item-card {
-    background: white;
-    border: 1px solid #ddd;
-    border-radius: 6px;
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    border-radius: var(--radius-sm);
     padding: 0.8rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   }
 
   .item-header {
@@ -1005,27 +1046,26 @@
 
   .item-name {
     font-weight: 600;
-    color: #333;
+    color: var(--text-primary);
     font-size: 1rem;
   }
 
   .btn-remove {
     width: 24px;
     height: 24px;
-    border: 1px solid #ff6b6b;
-    background: #ff6b6b;
-    color: white;
-    border-radius: 4px;
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    background: rgba(239, 68, 68, 0.15);
+    color: var(--color-danger);
+    border-radius: var(--radius-sm);
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 0.9rem;
-    font-weight: bold;
+    transition: all var(--transition-fast);
   }
 
   .btn-remove:hover {
-    background: #ff4757;
+    background: rgba(239, 68, 68, 0.25);
   }
 
   .item-stats {
@@ -1043,7 +1083,7 @@
 
   .stat-label {
     font-size: 0.85rem;
-    color: #666;
+    color: var(--text-secondary);
     min-width: 60px;
   }
 
@@ -1064,13 +1104,13 @@
     align-items: center;
     gap: 0.25rem;
     padding: 0.2rem 0.5rem;
-    border: 1px solid #ddd;
-    border-radius: 12px;
+    border: var(--glass-border);
+    border-radius: var(--radius-full);
     font-size: 0.8rem;
     cursor: pointer;
-    background: #f5f5f5;
-    color: #666;
-    transition: all 0.2s ease;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    transition: all var(--transition-fast);
     user-select: none;
   }
 
@@ -1079,13 +1119,14 @@
   }
 
   .chip-label.active {
-    background: #4ecdc4;
-    color: white;
-    border-color: #44a08d;
+    background: rgba(102, 126, 234, 0.25);
+    color: var(--color-accent-light);
+    border-color: rgba(102, 126, 234, 0.4);
   }
 
   .chip-label:hover {
-    border-color: #4ecdc4;
+    border-color: rgba(102, 126, 234, 0.3);
+    background: var(--bg-glass-hover);
   }
 
   .stat-controls {
@@ -1097,23 +1138,24 @@
   .btn-stat {
     width: 24px;
     height: 24px;
-    border: 1px solid #ddd;
-    background: white;
-    border-radius: 4px;
+    border: var(--glass-border);
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border-radius: var(--radius-sm);
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 0.8rem;
-    font-weight: bold;
+    transition: all var(--transition-fast);
   }
 
   .btn-stat:hover:not(:disabled) {
-    background: #f0f0f0;
+    background: var(--bg-glass-hover);
+    border-color: rgba(255, 255, 255, 0.2);
   }
 
   .btn-stat:disabled {
-    opacity: 0.5;
+    opacity: 0.4;
     cursor: not-allowed;
   }
 
@@ -1122,14 +1164,14 @@
     text-align: center;
     font-weight: 600;
     font-size: 0.9rem;
-    color: #333;
+    color: var(--text-primary);
   }
 
   .ratio-slider {
     flex: 1;
     height: 4px;
     border-radius: 2px;
-    background: #ddd;
+    background: var(--bg-secondary);
     outline: none;
     -webkit-appearance: none;
   }
@@ -1140,21 +1182,23 @@
     width: 16px;
     height: 16px;
     border-radius: 50%;
-    background: #4ecdc4;
+    background: var(--color-accent);
     cursor: pointer;
+    box-shadow: 0 0 8px rgba(102, 126, 234, 0.4);
   }
 
   .ratio-slider::-moz-range-thumb {
     width: 16px;
     height: 16px;
     border-radius: 50%;
-    background: #4ecdc4;
+    background: var(--color-accent);
     cursor: pointer;
     border: none;
+    box-shadow: 0 0 8px rgba(102, 126, 234, 0.4);
   }
 
   .add-item-form {
-    border-top: 1px solid #e0e0e0;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
     padding-top: 0.8rem;
   }
 
@@ -1164,19 +1208,37 @@
     margin-bottom: 0.5rem;
   }
 
+  .input-field,
+  .input-mini {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: var(--text-primary);
+    outline: none;
+    transition: border-color var(--transition-normal);
+    font-family: inherit;
+  }
+
+  .input-field::placeholder,
+  .input-mini::placeholder {
+    color: var(--text-muted);
+  }
+
+  .input-field:focus,
+  .input-mini:focus {
+    border-color: var(--color-accent);
+  }
+
   .input-field {
     flex: 1;
     padding: 0.5rem;
-    border: 1px solid #ddd;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     font-size: 0.9rem;
   }
 
   .input-mini {
     width: 60px;
     padding: 0.5rem;
-    border: 1px solid #ddd;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     font-size: 0.9rem;
     text-align: center;
   }
@@ -1184,21 +1246,27 @@
   .btn-add {
     width: 100%;
     padding: 0.6rem;
-    border: 1px solid #4ecdc4;
-    background: #4ecdc4;
-    color: white;
-    border-radius: 4px;
+    border: 1px solid rgba(102, 126, 234, 0.4);
+    background: rgba(102, 126, 234, 0.2);
+    color: var(--color-accent-light);
+    border-radius: var(--radius-sm);
     cursor: pointer;
     font-size: 0.9rem;
     font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    transition: all var(--transition-normal);
   }
 
   .btn-add:hover:not(:disabled) {
-    background: #44a08d;
+    background: rgba(102, 126, 234, 0.3);
+    border-color: rgba(102, 126, 234, 0.5);
   }
 
   .btn-add:disabled {
-    opacity: 0.5;
+    opacity: 0.4;
     cursor: not-allowed;
   }
 
@@ -1213,14 +1281,14 @@
     justify-content: space-between;
     align-items: center;
     padding: 0.8rem;
-    background: white;
-    border: 1px solid #ddd;
-    border-radius: 6px;
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    border-radius: var(--radius-sm);
   }
 
   .strikes-label {
     font-weight: 600;
-    color: #333;
+    color: var(--text-primary);
     font-size: 0.95rem;
   }
 
@@ -1235,17 +1303,17 @@
     text-align: center;
     font-weight: 600;
     font-size: 1rem;
-    color: #ffa726;
+    color: var(--color-warning);
   }
 
   .strikes-description {
     text-align: center;
     padding: 0.6rem;
-    background: #fff3e0;
-    border-radius: 6px;
-    color: #e65100;
+    background: rgba(245, 158, 11, 0.1);
+    border-radius: var(--radius-sm);
+    color: var(--color-warning);
     font-size: 0.85rem;
-    border: 1px solid #ffcc80;
+    border: 1px solid rgba(245, 158, 11, 0.25);
     font-weight: 600;
   }
 
@@ -1255,64 +1323,11 @@
     justify-content: center;
   }
 
-  .btn-primary,
-  .btn-secondary {
-    padding: clamp(0.4rem, 1.5vw, 0.6rem) clamp(0.8rem, 2.5vw, 1.2rem);
-    border: none;
-    border-radius: clamp(4px, 1vw, 6px);
-    font-size: clamp(0.8rem, 2.2vw, 0.9rem);
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    display: flex;
-    align-items: center;
-    gap: clamp(0.3rem, 1vw, 0.4rem);
-    min-height: clamp(32px, 7vw, 36px);
-    min-width: 120px;
-  }
-
-  .btn-primary {
-    background: linear-gradient(135deg, #4ecdc4, #44a08d);
-    color: white;
-  }
-
-  .btn-primary:hover:not(:disabled) {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(78, 205, 196, 0.3);
-  }
-
-  .btn-primary:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-    transform: none;
-    box-shadow: none;
-  }
-
-  .btn-secondary {
-    background: linear-gradient(135deg, #ff6b6b, #ee5a52);
-    color: white;
-  }
-
-  .btn-secondary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(255, 107, 107, 0.3);
-  }
-
-  .btn-icon {
-    font-size: 1rem;
-  }
-
   .btn-text {
     font-weight: 600;
   }
 
-  /* 移动端优化 */
   @media (max-width: 768px) {
-    .punishment-config {
-      padding: 0.8rem;
-      margin: 0.5rem;
-    }
-
     .config-header h3 {
       font-size: 1.2rem;
     }
@@ -1349,7 +1364,6 @@
     .btn-remove {
       width: 22px;
       height: 22px;
-      font-size: 0.8rem;
     }
 
     .stat-item {
@@ -1364,7 +1378,6 @@
     .btn-stat {
       width: 22px;
       height: 22px;
-      font-size: 0.75rem;
     }
 
     .stat-value {
@@ -1424,27 +1437,14 @@
       gap: 0.8rem;
     }
 
-    .btn-primary,
-    .btn-secondary {
+    .config-actions .btn {
       width: 100%;
       max-width: min(300px, 80vw);
       justify-content: center;
-      padding: clamp(0.35rem, 1.5vw, 0.4rem) clamp(0.7rem, 2vw, 0.8rem);
-      font-size: clamp(0.7rem, 1.8vw, 0.75rem);
-      border-radius: 4px;
-      min-height: clamp(28px, 6vw, 32px);
-      gap: clamp(0.2rem, 0.6vw, 0.25rem);
-      min-width: auto;
     }
   }
 
-  /* 超小屏幕优化 */
   @media (max-width: 480px) {
-    .punishment-config {
-      padding: 0.6rem;
-      margin: 0.3rem;
-    }
-
     .config-header h3 {
       font-size: 1.1rem;
     }
@@ -1489,7 +1489,6 @@
     .btn-remove {
       width: 20px;
       height: 20px;
-      font-size: 0.75rem;
     }
 
     .item-stats {
@@ -1508,7 +1507,6 @@
     .btn-stat {
       width: 20px;
       height: 20px;
-      font-size: 0.7rem;
     }
 
     .stat-value {
@@ -1569,19 +1567,6 @@
 
     .config-actions {
       gap: 0.6rem;
-    }
-
-    .btn-primary,
-    .btn-secondary {
-      width: 100%;
-      max-width: min(300px, 80vw);
-      justify-content: center;
-      padding: clamp(0.3rem, 1.2vw, 0.35rem) clamp(0.6rem, 1.8vw, 0.7rem);
-      font-size: clamp(0.65rem, 1.6vw, 0.7rem);
-      border-radius: 4px;
-      min-height: clamp(24px, 5vw, 28px);
-      gap: clamp(0.15rem, 0.5vw, 0.2rem);
-      min-width: auto;
     }
   }
 </style>

--- a/src/components/PunishmentConfirmation.vue
+++ b/src/components/PunishmentConfirmation.vue
@@ -1,5 +1,13 @@
 <script setup lang="ts">
   import { ref } from 'vue'
+  import {
+    Target,
+    Info,
+    Trash2,
+    RotateCcw,
+    ArrowLeft,
+    Check,
+  } from '@lucide/vue'
   import type { PunishmentCombination } from '../types/game'
 
   interface Props {
@@ -45,12 +53,18 @@
 
 <template>
   <div v-if="show" class="punishment-confirmation">
-    <div class="confirmation-overlay" @click="handleOverlayClick">
+    <div class="modal-overlay confirmation-overlay" @click="handleOverlayClick">
       <div class="confirmation-modal" @click.stop>
         <div class="modal-header">
-          <h3>🎯 惩罚组合确认</h3>
+          <h3>
+            <Target :size="22" />
+            惩罚组合确认
+          </h3>
           <p>请检查以下惩罚组合，可以删除不合适的组合</p>
-          <p class="duplicate-notice">💡 相同工具+部位+姿势的组合已自动去重</p>
+          <p class="duplicate-notice">
+            <Info :size="16" />
+            相同工具+部位+姿势的组合已自动去重
+          </p>
         </div>
 
         <div class="combinations-list">
@@ -90,7 +104,7 @@
                 title="删除此组合"
                 @click="removeCombination(index)"
               >
-                🗑️
+                <Trash2 :size="18" />
               </button>
               <button
                 v-else
@@ -98,7 +112,7 @@
                 title="恢复此组合"
                 @click="restoreCombination(index)"
               >
-                🔄
+                <RotateCcw :size="18" />
               </button>
             </div>
           </div>
@@ -120,16 +134,21 @@
         </div>
 
         <div class="modal-actions">
-          <button class="btn-secondary" @click="regenerateCombinations">🔄 重新生成</button>
-          <button class="btn-secondary" @click="() => emit('back-to-settings')">
-            ⬅️ 返回惩罚设置
+          <button class="btn btn-secondary" @click="regenerateCombinations">
+            <RotateCcw :size="18" />
+            重新生成
+          </button>
+          <button class="btn btn-secondary" @click="() => emit('back-to-settings')">
+            <ArrowLeft :size="18" />
+            返回惩罚设置
           </button>
           <button
-            class="btn-primary"
+            class="btn btn-primary"
             :disabled="removedCombinations.size >= combinations.length"
             @click="confirmCombinations"
           >
-            ✅ 确认组合 ({{ combinations.length - removedCombinations.size }}个)
+            <Check :size="18" />
+            确认组合 ({{ combinations.length - removedCombinations.size }}个)
           </button>
         </div>
       </div>
@@ -140,37 +159,32 @@
 <style scoped>
   .punishment-confirmation {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    inset: 0;
     z-index: 1000;
   }
 
   .confirmation-overlay {
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.7);
-    display: flex;
-    align-items: center;
-    justify-content: center;
     padding: 1rem;
   }
 
   .confirmation-modal {
-    background: white;
-    border-radius: 16px;
+    background: rgba(20, 20, 40, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    border-radius: var(--radius-xl);
     max-width: 800px;
     width: 100%;
     max-height: 90vh;
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    box-shadow: var(--glass-shadow-lg);
+    padding: 0;
+    animation: modalSlideIn 0.3s ease;
   }
 
   .modal-header {
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: linear-gradient(135deg, var(--color-accent) 0%, #764ba2 100%);
     color: white;
     padding: 1.5rem;
     text-align: center;
@@ -180,20 +194,29 @@
     margin: 0 0 0.5rem 0;
     font-size: 1.5rem;
     font-weight: bold;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
   }
 
   .modal-header p {
     margin: 0;
     font-size: 1rem;
     opacity: 0.9;
+    color: rgba(255, 255, 255, 0.9);
   }
 
   .duplicate-notice {
     margin-top: 0.5rem !important;
     font-size: 0.9rem !important;
-    opacity: 0.8 !important;
-    color: #4ecdc4 !important;
+    opacity: 0.9 !important;
+    color: var(--color-bonus) !important;
     font-weight: 500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
   }
 
   .combinations-list {
@@ -208,22 +231,24 @@
     align-items: center;
     gap: 1rem;
     padding: 1rem;
-    border: 2px solid #e9ecef;
-    border-radius: 12px;
+    border: var(--glass-border);
+    border-radius: var(--radius-md);
     margin-bottom: 1rem;
-    transition: all 0.3s ease;
-    background: white;
+    transition: all var(--transition-normal);
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
   }
 
   .combination-item:hover {
-    border-color: #667eea;
+    border-color: rgba(102, 126, 234, 0.4);
+    background: var(--bg-glass-hover);
     box-shadow: 0 4px 12px rgba(102, 126, 234, 0.15);
   }
 
   .combination-item.removed {
     opacity: 0.5;
-    background: #f8f9fa;
-    border-color: #dee2e6;
+    background: var(--bg-surface);
+    border-color: rgba(255, 255, 255, 0.06);
   }
 
   .combination-content {
@@ -235,7 +260,7 @@
 
   .combination-number {
     font-weight: bold;
-    color: #667eea;
+    color: var(--color-accent-light);
     font-size: 0.9rem;
   }
 
@@ -256,21 +281,21 @@
 
   .label {
     font-weight: bold;
-    color: #666;
+    color: var(--text-secondary);
     min-width: 40px;
   }
 
   .value {
-    color: #333;
+    color: var(--text-primary);
     font-weight: 500;
   }
 
   .intensity,
   .sensitivity {
-    background: #667eea;
+    background: var(--color-accent);
     color: white;
     padding: 0.2rem 0.4rem;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     font-size: 0.7rem;
     font-weight: bold;
   }
@@ -278,14 +303,14 @@
   .combination-summary {
     margin-top: 0.5rem;
     padding: 0.5rem;
-    background: #f8f9fa;
-    border-radius: 6px;
-    border-left: 3px solid #667eea;
+    background: var(--bg-surface);
+    border-radius: var(--radius-sm);
+    border-left: 3px solid var(--color-accent);
   }
 
   .summary-text {
     font-size: 0.9rem;
-    color: #333;
+    color: var(--text-primary);
     font-weight: 500;
   }
 
@@ -299,33 +324,32 @@
   .btn-restore {
     width: 40px;
     height: 40px;
-    border: none;
-    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-sm);
     cursor: pointer;
-    font-size: 1.2rem;
-    transition: all 0.3s ease;
+    transition: all var(--transition-normal);
     display: flex;
     align-items: center;
     justify-content: center;
   }
 
   .btn-remove {
-    background: #ff6b6b;
-    color: white;
+    background: rgba(239, 68, 68, 0.2);
+    color: var(--color-danger);
   }
 
   .btn-remove:hover {
-    background: #ff5252;
+    background: rgba(239, 68, 68, 0.35);
     transform: scale(1.05);
   }
 
   .btn-restore {
-    background: #2ed573;
-    color: white;
+    background: rgba(34, 197, 94, 0.2);
+    color: var(--color-success);
   }
 
   .btn-restore:hover {
-    background: #26d0ce;
+    background: rgba(34, 197, 94, 0.35);
     transform: scale(1.05);
   }
 
@@ -333,8 +357,8 @@
     display: flex;
     justify-content: space-around;
     padding: 1rem;
-    background: #f8f9fa;
-    border-top: 1px solid #e9ecef;
+    background: var(--bg-surface);
+    border-top: var(--glass-border);
   }
 
   .stat-item {
@@ -346,67 +370,27 @@
 
   .stat-label {
     font-size: 0.8rem;
-    color: #666;
+    color: var(--text-secondary);
   }
 
   .stat-value {
     font-size: 1.2rem;
     font-weight: bold;
-    color: #667eea;
+    color: var(--color-accent-light);
   }
 
   .modal-actions {
     display: flex;
     gap: 1rem;
     padding: 1.5rem;
-    background: #f8f9fa;
-    border-top: 1px solid #e9ecef;
+    background: var(--bg-surface);
+    border-top: var(--glass-border);
   }
 
-  .btn-primary,
-  .btn-secondary {
+  .modal-actions .btn {
     flex: 1;
-    padding: 1rem 1.5rem;
-    border: none;
-    border-radius: 8px;
-    font-size: 1rem;
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
   }
 
-  .btn-primary {
-    background: linear-gradient(135deg, #667eea, #764ba2);
-    color: white;
-  }
-
-  .btn-primary:hover:not(:disabled) {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
-  }
-
-  .btn-primary:disabled {
-    background: #ccc;
-    cursor: not-allowed;
-    transform: none;
-    box-shadow: none;
-  }
-
-  .btn-secondary {
-    background: #6c757d;
-    color: white;
-  }
-
-  .btn-secondary:hover {
-    background: #5a6268;
-    transform: translateY(-2px);
-  }
-
-  /* 响应式设计 */
   @media (max-width: 768px) {
     .confirmation-overlay {
       padding: 0.5rem;
@@ -415,8 +399,7 @@
     .confirmation-modal {
       max-width: 100%;
       max-height: 95vh;
-      margin: 0;
-      border-radius: 12px;
+      border-radius: var(--radius-md);
     }
 
     .modal-header {
@@ -460,7 +443,6 @@
     .btn-restore {
       width: 35px;
       height: 35px;
-      font-size: 1rem;
     }
 
     .combination-stats {
@@ -479,12 +461,6 @@
       padding: 1rem;
       gap: 0.75rem;
     }
-
-    .btn-primary,
-    .btn-secondary {
-      padding: 0.75rem 1rem;
-      font-size: 0.9rem;
-    }
   }
 
   @media (max-width: 480px) {
@@ -494,7 +470,7 @@
 
     .confirmation-modal {
       max-height: 98vh;
-      border-radius: 8px;
+      border-radius: var(--radius-sm);
     }
 
     .modal-header {
@@ -517,27 +493,15 @@
 
     .combination-number {
       font-size: 0.8rem;
-      min-width: 25px;
     }
 
     .combination-details {
       font-size: 0.75rem;
     }
 
-    .combination-summary {
-      font-size: 0.75rem;
-    }
-
     .modal-actions {
       padding: 0.75rem;
-    }
-
-    .btn-primary,
-    .btn-secondary {
-      padding: 0.6rem 0.8rem;
-      font-size: 0.85rem;
+      flex-wrap: wrap;
     }
   }
-
-  /* 响应式设计 */
 </style>

--- a/src/components/PunishmentDisplay.vue
+++ b/src/components/PunishmentDisplay.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+  import { Zap, Check, SkipForward } from '@lucide/vue'
   import type { PunishmentAction, Player } from '../types/game'
 
   interface Props {
@@ -24,51 +25,62 @@
 </script>
 
 <template>
-  <div v-if="punishment" class="punishment-display">
-    <div class="punishment-header">
-      <h3>⚡ 惩罚时间</h3>
-      <p>你踩到了惩罚格子！</p>
-    </div>
-
-    <div class="punishment-content">
-      <!-- 执行惩罚的玩家信息 -->
-      <div v-if="executorPlayer" class="executor-info">
-        <div class="executor-header">
-          <span class="executor-label">执行惩罚的玩家:</span>
-        </div>
-        <div class="executor-player">
-          <div class="executor-avatar" :style="{ backgroundColor: executorPlayer.color }"></div>
-          <span class="executor-name">{{ executorPlayer.name }}</span>
-        </div>
+  <div v-if="punishment" class="modal-overlay">
+    <div class="modal-content punishment-display">
+      <div class="punishment-header">
+        <h3>
+          <Zap :size="20" />
+          惩罚时间
+        </h3>
+        <p>你踩到了惩罚格子！</p>
       </div>
 
-      <div class="punishment-details">
-        <div class="punishment-item">
-          <span class="label">工具:</span>
-          <span class="value tool">{{ punishment.tool.name }}</span>
-          <span class="intensity">强度: {{ punishment.tool.intensity }}/10</span>
+      <div class="punishment-content">
+        <!-- 执行惩罚的玩家信息 -->
+        <div v-if="executorPlayer" class="executor-info">
+          <div class="executor-header">
+            <span class="executor-label">执行惩罚的玩家:</span>
+          </div>
+          <div class="executor-player">
+            <div class="executor-avatar" :style="{ backgroundColor: executorPlayer.color }"></div>
+            <span class="executor-name">{{ executorPlayer.name }}</span>
+          </div>
         </div>
 
-        <div class="punishment-item">
-          <span class="label">部位:</span>
-          <span class="value body-part">{{ punishment.bodyPart.name }}</span>
-          <span class="sensitivity">耐受度: {{ punishment.bodyPart.sensitivity }}/10</span>
+        <div class="punishment-details">
+          <div class="punishment-item">
+            <span class="label">工具:</span>
+            <span class="value tool">{{ punishment.tool.name }}</span>
+            <span class="intensity">强度: {{ punishment.tool.intensity }}/10</span>
+          </div>
+
+          <div class="punishment-item">
+            <span class="label">部位:</span>
+            <span class="value body-part">{{ punishment.bodyPart.name }}</span>
+            <span class="sensitivity">耐受度: {{ punishment.bodyPart.sensitivity }}/10</span>
+          </div>
+
+          <div class="punishment-item">
+            <span class="label">姿势:</span>
+            <span class="value position">{{ punishment.position.name }}</span>
+          </div>
         </div>
 
-        <div class="punishment-item">
-          <span class="label">姿势:</span>
-          <span class="value position">{{ punishment.position.name }}</span>
+        <div class="punishment-summary">
+          <h4>执行内容:</h4>
+          <p class="summary-text">{{ punishment.description }}</p>
         </div>
-      </div>
 
-      <div class="punishment-summary">
-        <h4>执行内容:</h4>
-        <p class="summary-text">{{ punishment.description }}</p>
-      </div>
-
-      <div class="punishment-actions">
-        <button class="btn-confirm" @click="confirmPunishment">✅ 确认执行</button>
-        <button class="btn-skip" @click="skipPunishment">⏭️ 跳过惩罚</button>
+        <div class="punishment-actions">
+          <button class="btn btn-success" @click="confirmPunishment">
+            <Check :size="18" />
+            确认执行
+          </button>
+          <button class="btn btn-secondary" @click="skipPunishment">
+            <SkipForward :size="18" />
+            跳过惩罚
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -76,20 +88,8 @@
 
 <style scoped>
   .punishment-display {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background: white;
-    border-radius: 12px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-    padding: 2rem;
+    border: 1px solid rgba(255, 71, 87, 0.3);
     max-width: 500px;
-    width: 90%;
-    z-index: 1000;
-    border: 3px solid #ff6b6b;
-    max-height: 90vh;
-    overflow-y: auto;
   }
 
   .punishment-header {
@@ -98,14 +98,18 @@
   }
 
   .punishment-header h3 {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
     margin: 0 0 0.5rem 0;
-    color: #ff6b6b;
+    color: var(--color-punishment);
     font-size: 1.5rem;
   }
 
   .punishment-header p {
     margin: 0;
-    color: #666;
+    color: var(--text-secondary);
     font-size: 1.1rem;
   }
 
@@ -115,12 +119,12 @@
     gap: 1.5rem;
   }
 
-  /* 执行惩罚的玩家信息样式 */
   .executor-info {
-    background: linear-gradient(135deg, #f8f9fa, #e9ecef);
-    border-radius: 8px;
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border-radius: var(--radius-sm);
     padding: 1rem;
-    border: 2px solid #4ecdc4;
+    border: 1px solid var(--player-2);
   }
 
   .executor-header {
@@ -129,7 +133,7 @@
 
   .executor-label {
     font-weight: bold;
-    color: #333;
+    color: var(--text-secondary);
     font-size: 1rem;
   }
 
@@ -143,14 +147,14 @@
     width: 32px;
     height: 32px;
     border-radius: 50%;
-    border: 2px solid rgba(255, 255, 255, 0.8);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    box-shadow: var(--glass-shadow);
   }
 
   .executor-name {
     font-weight: bold;
     font-size: 1.1rem;
-    color: #333;
+    color: var(--text-primary);
   }
 
   .punishment-details {
@@ -164,14 +168,14 @@
     align-items: center;
     gap: 1rem;
     padding: 1rem;
-    background: #f8f9fa;
-    border-radius: 8px;
-    border-left: 4px solid #ff6b6b;
+    background: var(--bg-glass);
+    border-radius: var(--radius-sm);
+    border-left: 4px solid var(--color-punishment);
   }
 
   .label {
     font-weight: bold;
-    color: #333;
+    color: var(--text-secondary);
     min-width: 60px;
   }
 
@@ -179,39 +183,37 @@
     font-weight: bold;
     font-size: 1.1rem;
     flex: 1;
+    color: var(--text-primary);
   }
 
   .tool {
-    color: #e74c3c;
+    color: var(--color-punishment);
   }
 
   .body-part {
-    color: #9b59b6;
+    color: var(--color-restart);
   }
 
   .position {
-    color: #f39c12;
-  }
-
-  .strikes {
-    color: #e67e22;
+    color: var(--color-special);
   }
 
   .intensity,
   .sensitivity {
     font-size: 0.8rem;
-    color: #666;
-    background: #e0e0e0;
+    color: var(--text-muted);
+    background: var(--bg-glass-hover);
     padding: 0.25rem 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
   }
 
   .punishment-summary {
     text-align: center;
     padding: 1rem;
-    background: linear-gradient(135deg, #ff6b6b, #ee5a52);
-    border-radius: 8px;
-    color: white;
+    background: linear-gradient(135deg, #c0392b, #922b21);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    box-shadow: var(--glow-sm) rgba(255, 71, 87, 0.3);
   }
 
   .punishment-summary h4 {
@@ -232,48 +234,12 @@
     margin-top: 1rem;
   }
 
-  .btn-confirm,
-  .btn-skip {
-    padding: 0.75rem 1.5rem;
-    border: none;
-    border-radius: 6px;
-    font-size: 1rem;
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    min-height: 44px;
-  }
-
-  .btn-confirm {
-    background: linear-gradient(135deg, #2ed573, #1e90ff);
-    color: white;
-  }
-
-  .btn-confirm:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(46, 213, 115, 0.3);
-  }
-
-  .btn-skip {
-    background: linear-gradient(135deg, #ffa726, #ff9800);
-    color: white;
-  }
-
-  .btn-skip:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(255, 167, 38, 0.3);
-  }
-
   /* 移动端适配 */
   @media (max-width: 768px) {
     .punishment-display {
       padding: 1rem;
       width: 95%;
       max-height: 95vh;
-      margin: 1rem;
     }
 
     .punishment-header h3 {
@@ -324,8 +290,7 @@
       margin-top: 1.5rem;
     }
 
-    .btn-confirm,
-    .btn-skip {
+    .punishment-actions .btn {
       width: 100%;
       justify-content: center;
       padding: 1rem 1.5rem;
@@ -394,8 +359,7 @@
       margin-top: 1rem;
     }
 
-    .btn-confirm,
-    .btn-skip {
+    .punishment-actions .btn {
       padding: 0.9rem 1rem;
       font-size: 1rem;
       min-height: 48px;
@@ -428,8 +392,7 @@
       font-size: 0.9rem;
     }
 
-    .btn-confirm,
-    .btn-skip {
+    .punishment-actions .btn {
       padding: 0.8rem 0.8rem;
       font-size: 0.95rem;
       min-height: 44px;

--- a/src/components/PunishmentStats.vue
+++ b/src/components/PunishmentStats.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import { computed } from 'vue'
+  import { Target, RotateCcw, Rocket } from '@lucide/vue'
   import type { PunishmentCombination } from '../types/game'
 
   interface Props {
@@ -86,10 +87,13 @@
 
 <template>
   <div v-if="show" class="punishment-stats">
-    <div class="stats-overlay" @click="handleOverlayClick">
+    <div class="modal-overlay stats-overlay" @click="handleOverlayClick">
       <div class="stats-modal" @click.stop>
         <div class="modal-header">
-          <h3>📊 惩罚组合统计</h3>
+          <h3>
+            <Target :size="22" />
+            惩罚组合统计
+          </h3>
           <p>以下是确认的惩罚组合的分布情况</p>
         </div>
 
@@ -152,8 +156,14 @@
         </div>
 
         <div class="modal-actions">
-          <button class="btn-secondary" @click="handleRegenerate">🔄 重新生成</button>
-          <button class="btn-primary" @click="handleConfirm">✅ 开始游戏</button>
+          <button class="btn btn-secondary" @click="handleRegenerate">
+            <RotateCcw :size="18" />
+            重新生成
+          </button>
+          <button class="btn btn-primary" @click="handleConfirm">
+            <Rocket :size="18" />
+            开始游戏
+          </button>
         </div>
       </div>
     </div>
@@ -163,37 +173,32 @@
 <style scoped>
   .punishment-stats {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    inset: 0;
     z-index: 1000;
   }
 
   .stats-overlay {
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.7);
-    display: flex;
-    align-items: center;
-    justify-content: center;
     padding: 1rem;
   }
 
   .stats-modal {
-    background: white;
-    border-radius: 16px;
+    background: rgba(20, 20, 40, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    border-radius: var(--radius-xl);
     max-width: 900px;
     width: 100%;
     max-height: 90vh;
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    box-shadow: var(--glass-shadow-lg);
+    padding: 0;
+    animation: modalSlideIn 0.3s ease;
   }
 
   .modal-header {
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: linear-gradient(135deg, var(--color-accent) 0%, #764ba2 100%);
     color: white;
     padding: 1.5rem;
     text-align: center;
@@ -203,12 +208,17 @@
     margin: 0 0 0.5rem 0;
     font-size: 1.5rem;
     font-weight: bold;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
   }
 
   .modal-header p {
     margin: 0;
     font-size: 1rem;
     opacity: 0.9;
+    color: rgba(255, 255, 255, 0.9);
   }
 
   .stats-content {
@@ -225,15 +235,16 @@
   }
 
   .stats-item {
-    background: #f8f9fa;
-    border-radius: 12px;
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border-radius: var(--radius-md);
     padding: 1.5rem;
-    border: 1px solid #e9ecef;
+    border: var(--glass-border);
   }
 
   .stats-label {
     font-weight: bold;
-    color: #495057;
+    color: var(--text-primary);
     margin-bottom: 1rem;
     font-size: 1.1rem;
     text-align: center;
@@ -254,38 +265,39 @@
 
   .stat-name {
     min-width: 80px;
-    color: #495057;
+    color: var(--text-secondary);
     font-weight: 500;
   }
 
   .stat-bar-container {
     flex: 1;
     height: 10px;
-    background: #e9ecef;
+    background: var(--bg-secondary);
     border-radius: 5px;
     overflow: hidden;
   }
 
   .stat-bar-fill {
     height: 100%;
-    background: linear-gradient(90deg, #667eea, #764ba2);
+    background: linear-gradient(90deg, var(--color-accent), #764ba2);
     border-radius: 5px;
-    transition: width 0.3s ease;
+    transition: width var(--transition-normal);
   }
 
   .stat-value {
     min-width: 80px;
     text-align: right;
-    color: #6c757d;
+    color: var(--text-muted);
     font-weight: bold;
     font-size: 0.85rem;
   }
 
   .stats-summary {
-    background: linear-gradient(135deg, #f8f9fa, #e9ecef);
-    border-radius: 12px;
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border-radius: var(--radius-md);
     padding: 1.5rem;
-    border: 1px solid #dee2e6;
+    border: var(--glass-border);
   }
 
   .summary-item {
@@ -293,7 +305,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 0.5rem 0;
-    border-bottom: 1px solid #e9ecef;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   }
 
   .summary-item:last-child {
@@ -302,12 +314,12 @@
 
   .summary-label {
     font-weight: bold;
-    color: #495057;
+    color: var(--text-secondary);
     font-size: 1rem;
   }
 
   .summary-value {
-    color: #667eea;
+    color: var(--color-accent-light);
     font-weight: bold;
     font-size: 1.1rem;
   }
@@ -317,49 +329,11 @@
     justify-content: center;
     gap: 1rem;
     padding: 1.5rem;
-    background: #f8f9fa;
-    border-top: 1px solid #e9ecef;
+    background: var(--bg-surface);
+    border-top: var(--glass-border);
     flex-wrap: wrap;
   }
 
-  .btn-primary {
-    background: linear-gradient(135deg, #667eea, #764ba2);
-    color: white;
-    border: none;
-    border-radius: 8px;
-    padding: 1rem 2rem;
-    font-size: 1.1rem;
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
-  }
-
-  .btn-secondary {
-    background: #6c757d;
-    color: white;
-    border: none;
-    border-radius: 8px;
-    padding: 0.75rem 1.5rem;
-    font-size: 1rem;
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s ease;
-  }
-
-  .btn-secondary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(108, 117, 125, 0.3);
-  }
-
-  /* 响应式设计 */
   @media (max-width: 768px) {
     .stats-overlay {
       padding: 0.5rem;
@@ -368,8 +342,7 @@
     .stats-modal {
       max-width: 100%;
       max-height: 95vh;
-      margin: 0;
-      border-radius: 12px;
+      border-radius: var(--radius-md);
     }
 
     .modal-header {
@@ -436,16 +409,6 @@
     .modal-actions {
       padding: 1rem;
     }
-
-    .btn-primary {
-      padding: 0.8rem 1.5rem;
-      font-size: 1rem;
-    }
-
-    .btn-secondary {
-      padding: 0.75rem 1.2rem;
-      font-size: 0.9rem;
-    }
   }
 
   @media (max-width: 480px) {
@@ -455,7 +418,7 @@
 
     .stats-modal {
       max-height: 98vh;
-      border-radius: 8px;
+      border-radius: var(--radius-sm);
     }
 
     .modal-header {
@@ -516,16 +479,6 @@
 
     .modal-actions {
       padding: 0.75rem;
-    }
-
-    .btn-primary {
-      padding: 0.7rem 1.2rem;
-      font-size: 0.9rem;
-    }
-
-    .btn-secondary {
-      padding: 0.7rem 1.2rem;
-      font-size: 0.9rem;
     }
   }
 </style>

--- a/src/components/TakeoffPunishmentDisplay.vue
+++ b/src/components/TakeoffPunishmentDisplay.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+  import { Plane, Info } from '@lucide/vue'
   import type { PunishmentAction } from '../types/game'
 
   interface Props {
@@ -24,7 +25,9 @@
   <div v-if="visible" class="takeoff-punishment-overlay">
     <div class="takeoff-punishment-modal">
       <div class="punishment-header">
-        <div class="punishment-icon">✈️</div>
+        <div class="punishment-icon">
+          <Plane :size="48" />
+        </div>
         <div class="punishment-title">未起飞惩罚</div>
       </div>
 
@@ -53,7 +56,9 @@
         </div>
 
         <div class="punishment-note">
-          <div class="note-icon">💡</div>
+          <div class="note-icon">
+            <Info :size="20" />
+          </div>
           <div class="note-text">只有掷到6点才能起飞。下次掷到6点前，每次掷骰子都会受到惩罚。</div>
         </div>
       </div>
@@ -68,27 +73,27 @@
 <style scoped>
   .takeoff-punishment-overlay {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.8);
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
-    animation: fadeIn 0.3s ease;
+    z-index: 2000;
+    animation: fadeIn var(--transition-normal);
   }
 
   .takeoff-punishment-modal {
-    background: white;
-    border-radius: 16px;
+    background: rgba(20, 20, 40, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    border-radius: var(--radius-xl);
     padding: 2rem;
     max-width: 500px;
     width: 90%;
     text-align: center;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
-    animation: slideIn 0.3s ease;
+    box-shadow: var(--glass-shadow-lg);
+    animation: slideIn var(--transition-normal);
   }
 
   .punishment-header {
@@ -96,14 +101,16 @@
   }
 
   .punishment-icon {
-    font-size: 3rem;
+    display: flex;
+    justify-content: center;
     margin-bottom: 0.5rem;
+    color: var(--color-punishment);
   }
 
   .punishment-title {
     font-size: 1.5rem;
     font-weight: bold;
-    color: #ff6b6b;
+    color: var(--color-punishment);
   }
 
   .punishment-content {
@@ -112,17 +119,17 @@
 
   .punishment-description {
     font-size: 1.1rem;
-    color: #666;
+    color: var(--text-secondary);
     margin-bottom: 1.5rem;
     line-height: 1.5;
   }
 
   .punishment-details {
-    background: linear-gradient(135deg, #f8f9fa, #e9ecef);
-    border-radius: 8px;
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    border-radius: var(--radius-sm);
     padding: 1rem;
     margin-bottom: 1.5rem;
-    border: 1px solid #dee2e6;
   }
 
   .detail-item {
@@ -130,7 +137,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 0.5rem 0;
-    border-bottom: 1px solid #dee2e6;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   }
 
   .detail-item:last-child {
@@ -139,32 +146,34 @@
 
   .detail-label {
     font-weight: bold;
-    color: #666;
+    color: var(--text-muted);
   }
 
   .detail-value {
-    color: #333;
+    color: var(--text-primary);
     font-weight: bold;
   }
 
   .punishment-note {
-    background: linear-gradient(135deg, #fff3cd, #ffeaa7);
-    border-radius: 8px;
+    background: rgba(245, 158, 11, 0.1);
+    border-radius: var(--radius-sm);
     padding: 1rem;
-    border: 1px solid #ffc107;
+    border: 1px solid var(--color-warning);
     display: flex;
     align-items: flex-start;
     gap: 0.5rem;
   }
 
   .note-icon {
-    font-size: 1.2rem;
+    display: flex;
+    flex-shrink: 0;
     margin-top: 0.1rem;
+    color: var(--color-warning);
   }
 
   .note-text {
     font-size: 0.9rem;
-    color: #856404;
+    color: var(--color-warning);
     line-height: 1.4;
     text-align: left;
   }
@@ -175,20 +184,20 @@
   }
 
   .confirm-btn {
-    background: linear-gradient(135deg, #ff6b6b, #ee5a52);
+    background: linear-gradient(135deg, var(--color-punishment), #c0392b);
     color: white;
     border: none;
-    border-radius: 8px;
+    border-radius: var(--radius-sm);
     padding: 0.75rem 2rem;
     font-size: 1.1rem;
     font-weight: bold;
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: all var(--transition-normal);
   }
 
   .confirm-btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(255, 107, 107, 0.3);
+    box-shadow: 0 4px 12px rgba(255, 71, 87, 0.4);
   }
 
   @keyframes fadeIn {
@@ -218,8 +227,9 @@
       margin: 1rem;
     }
 
-    .punishment-icon {
-      font-size: 2.5rem;
+    .punishment-icon :deep(svg) {
+      width: 40px;
+      height: 40px;
     }
 
     .punishment-title {

--- a/src/components/TakeoffReliefDisplay.vue
+++ b/src/components/TakeoffReliefDisplay.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import { Frown } from '@lucide/vue'
+
   interface Props {
     visible: boolean
     failedCount: number
@@ -20,7 +22,9 @@
   <div v-if="visible" class="relief-overlay">
     <div class="relief-modal">
       <div class="relief-header">
-        <div class="relief-icon">🤯</div>
+        <div class="relief-icon">
+          <Frown :size="48" />
+        </div>
         <div class="relief-title">运气太差！</div>
       </div>
 
@@ -40,27 +44,27 @@
 <style scoped>
   .relief-overlay {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.8);
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
-    animation: fadeIn 0.3s ease;
+    z-index: 2000;
+    animation: fadeIn var(--transition-normal);
   }
 
   .relief-modal {
-    background: white;
-    border-radius: 16px;
+    background: rgba(20, 20, 40, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    border-radius: var(--radius-xl);
     padding: 2rem;
     max-width: 480px;
     width: 90%;
     text-align: center;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
-    animation: slideIn 0.3s ease;
+    box-shadow: var(--glass-shadow-lg);
+    animation: slideIn var(--transition-normal);
   }
 
   .relief-header {
@@ -68,14 +72,16 @@
   }
 
   .relief-icon {
-    font-size: 3rem;
+    display: flex;
+    justify-content: center;
     margin-bottom: 0.5rem;
+    color: var(--color-punishment);
   }
 
   .relief-title {
     font-size: 1.5rem;
     font-weight: bold;
-    color: #ff6b6b;
+    color: var(--color-punishment);
   }
 
   .relief-content {
@@ -84,7 +90,7 @@
 
   .relief-text {
     font-size: 1.1rem;
-    color: #666;
+    color: var(--text-secondary);
     line-height: 1.5;
   }
 
@@ -94,20 +100,20 @@
   }
 
   .confirm-btn {
-    background: linear-gradient(135deg, #ff6b6b, #ee5a52);
+    background: linear-gradient(135deg, var(--color-accent), #764ba2);
     color: white;
     border: none;
-    border-radius: 8px;
+    border-radius: var(--radius-sm);
     padding: 0.75rem 2rem;
     font-size: 1.1rem;
     font-weight: bold;
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: all var(--transition-normal);
   }
 
   .confirm-btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(255, 107, 107, 0.3);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
   }
 
   @keyframes fadeIn {

--- a/src/components/TrapConfig.vue
+++ b/src/components/TrapConfig.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-  import { ref, computed } from 'vue'
+  import { ref, computed, watch } from 'vue'
+  import { Skull, Trash2, Plus, Check, X, Info, RotateCcw } from '@lucide/vue'
   import type { TrapAction } from '../types/game'
   import { GAME_CONFIG } from '../config/gameConfig'
   import { GameService } from '../services/gameService'
@@ -17,6 +18,14 @@
 
   // 本地机关状态
   const localTraps = ref<TrapAction[]>([...props.traps])
+
+  watch(
+    () => props.traps,
+    (newTraps) => {
+      localTraps.value = [...newTraps]
+    },
+    { deep: true }
+  )
 
   // 添加新机关
   const addTrap = () => {
@@ -55,9 +64,12 @@
 </script>
 
 <template>
-  <div class="trap-config">
+  <div class="trap-config glass-card">
     <div class="config-section">
-      <h3>💀 机关格子配置</h3>
+      <h3>
+        <Skull :size="20" />
+        机关格子配置
+      </h3>
       <p class="section-description">
         自定义机关格子的内容。每次踩到机关格子时，会从所有机关中随机选择一个触发。
       </p>
@@ -72,7 +84,7 @@
               :disabled="localTraps.length <= 1"
               @click="removeTrap(index)"
             >
-              🗑️
+              <Trash2 :size="16" />
             </button>
           </div>
 
@@ -105,8 +117,8 @@
 
       <!-- 添加机关按钮 -->
       <div class="add-trap-section">
-        <button class="btn-primary" @click="addTrap">
-          <span class="btn-icon">➕</span>
+        <button class="btn btn-primary" @click="addTrap">
+          <Plus :size="18" />
           添加机关
         </button>
       </div>
@@ -117,19 +129,22 @@
           class="status-item"
           :class="{ 'status-error': !isConfigValid, 'status-success': isConfigValid }"
         >
-          <span class="status-icon">{{ isConfigValid ? '✅' : '❌' }}</span>
+          <span class="status-icon">
+            <Check v-if="isConfigValid" :size="16" />
+            <X v-else :size="16" />
+          </span>
           <span class="status-text">配置状态：{{ isConfigValid ? '有效' : '无效' }}</span>
         </div>
         <div class="status-item status-info">
-          <span class="status-icon">ℹ️</span>
+          <span class="status-icon"><Info :size="16" /></span>
           <span class="status-text">机关数量：{{ localTraps.length }} 个（等概率出现）</span>
         </div>
       </div>
 
       <!-- 快捷操作 -->
       <div class="quick-actions">
-        <button class="btn-secondary" @click="resetToDefault">
-          <span class="btn-icon">🔄</span>
+        <button class="btn btn-secondary" @click="resetToDefault">
+          <RotateCcw :size="16" />
           重置默认
         </button>
       </div>
@@ -139,23 +154,25 @@
 
 <style scoped>
   .trap-config {
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 12px;
-    padding: 20px;
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
     margin-bottom: 20px;
   }
 
+  .trap-config:hover {
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+
   .config-section h3 {
-    color: white;
+    color: var(--text-primary);
     margin: 0 0 10px 0;
     font-size: 1.2rem;
     font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
   }
 
   .section-description {
-    color: rgba(255, 255, 255, 0.8);
+    color: var(--text-secondary);
     margin: 0 0 20px 0;
     font-size: 0.9rem;
   }
@@ -168,10 +185,10 @@
   }
 
   .trap-item {
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: 8px;
+    background: var(--bg-surface);
+    border-radius: var(--radius-sm);
     padding: 15px;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: var(--glass-border);
   }
 
   .trap-header {
@@ -182,27 +199,30 @@
   }
 
   .trap-header h4 {
-    color: white;
+    color: var(--text-primary);
     margin: 0;
     font-size: 1rem;
   }
 
   .btn-remove {
-    background: rgba(244, 67, 54, 0.2);
-    border: 1px solid rgba(244, 67, 54, 0.3);
-    border-radius: 4px;
-    padding: 4px 8px;
-    color: white;
+    background: rgba(239, 68, 68, 0.15);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: var(--radius-sm);
+    padding: 6px 8px;
+    color: var(--color-danger);
     cursor: pointer;
-    transition: all 0.3s;
+    transition: all var(--transition-normal);
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .btn-remove:hover:not(:disabled) {
-    background: rgba(244, 67, 54, 0.3);
+    background: rgba(239, 68, 68, 0.25);
   }
 
   .btn-remove:disabled {
-    opacity: 0.5;
+    opacity: 0.4;
     cursor: not-allowed;
   }
 
@@ -219,39 +239,37 @@
   }
 
   .input-label {
-    color: white;
+    color: var(--text-secondary);
     font-size: 0.9rem;
     font-weight: 500;
   }
 
-  .config-input {
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    border-radius: 6px;
+  .config-input,
+  .config-textarea {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: var(--radius-sm);
     padding: 8px 12px;
-    color: white;
+    color: var(--text-primary);
     font-size: 0.9rem;
     outline: none;
-    transition: border-color 0.3s;
+    transition: border-color var(--transition-normal);
+    font-family: inherit;
   }
 
-  .config-input:focus {
-    border-color: #4caf50;
+  .config-input::placeholder,
+  .config-textarea::placeholder {
+    color: var(--text-muted);
+  }
+
+  .config-input:focus,
+  .config-textarea:focus {
+    border-color: var(--color-accent);
   }
 
   .config-textarea {
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    border-radius: 6px;
-    padding: 8px 12px;
-    color: white;
-    font-size: 0.9rem;
-    outline: none;
-    transition: border-color 0.3s;
-  }
-
-  .config-textarea:focus {
-    border-color: #4caf50;
+    min-height: 80px;
+    resize: vertical;
   }
 
   .add-trap-section {
@@ -260,33 +278,12 @@
     margin-bottom: 20px;
   }
 
-  .btn-primary {
-    background: linear-gradient(135deg, #4caf50, #45a049);
-    border: none;
-    border-radius: 6px;
-    padding: 10px 20px;
-    color: white;
-    cursor: pointer;
-    transition: all 0.3s;
-    display: flex;
-    align-items: center;
-    font-size: 0.9rem;
-  }
-
-  .btn-primary:hover {
-    background: linear-gradient(135deg, #45a049, #4caf50);
-    transform: translateY(-1px);
-  }
-
-  .btn-icon {
-    margin-right: 6px;
-  }
-
   .status-section {
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: 8px;
+    background: var(--bg-surface);
+    border-radius: var(--radius-sm);
     padding: 15px;
     margin-bottom: 20px;
+    border: var(--glass-border);
   }
 
   .status-item {
@@ -294,8 +291,8 @@
     align-items: center;
     margin-bottom: 8px;
     padding: 8px;
-    border-radius: 6px;
-    transition: background-color 0.3s;
+    border-radius: var(--radius-sm);
+    transition: background-color var(--transition-normal);
   }
 
   .status-item:last-child {
@@ -303,27 +300,40 @@
   }
 
   .status-success {
-    background: rgba(76, 175, 80, 0.2);
-    border: 1px solid rgba(76, 175, 80, 0.3);
+    background: rgba(34, 197, 94, 0.12);
+    border: 1px solid rgba(34, 197, 94, 0.25);
   }
 
   .status-error {
-    background: rgba(244, 67, 54, 0.2);
-    border: 1px solid rgba(244, 67, 54, 0.3);
+    background: rgba(239, 68, 68, 0.12);
+    border: 1px solid rgba(239, 68, 68, 0.25);
   }
 
   .status-info {
-    background: rgba(33, 150, 243, 0.2);
-    border: 1px solid rgba(33, 150, 243, 0.3);
+    background: rgba(59, 130, 246, 0.12);
+    border: 1px solid rgba(59, 130, 246, 0.25);
   }
 
   .status-icon {
     margin-right: 8px;
-    font-size: 1rem;
+    display: flex;
+    align-items: center;
+  }
+
+  .status-success .status-icon {
+    color: var(--color-success);
+  }
+
+  .status-error .status-icon {
+    color: var(--color-danger);
+  }
+
+  .status-info .status-icon {
+    color: var(--color-info);
   }
 
   .status-text {
-    color: white;
+    color: var(--text-primary);
     font-size: 0.9rem;
   }
 
@@ -331,24 +341,6 @@
     display: flex;
     gap: 10px;
     justify-content: center;
-  }
-
-  .btn-secondary {
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    border-radius: 6px;
-    padding: 8px 16px;
-    color: white;
-    cursor: pointer;
-    transition: all 0.3s;
-    display: flex;
-    align-items: center;
-    font-size: 0.85rem;
-  }
-
-  .btn-secondary:hover {
-    background: rgba(255, 255, 255, 0.2);
-    border-color: rgba(255, 255, 255, 0.5);
   }
 
   @media (max-width: 768px) {

--- a/src/components/TrapDisplay.vue
+++ b/src/components/TrapDisplay.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import { Skull, AlertTriangle } from '@lucide/vue'
+
   interface Props {
     show: boolean
     trapDescription?: string
@@ -8,7 +10,7 @@
     (e: 'confirm'): void
   }
 
-  const props = defineProps<Props>()
+  defineProps<Props>()
   const emit = defineEmits<Emits>()
 
   const handleConfirm = () => {
@@ -21,10 +23,12 @@
 </script>
 
 <template>
-  <div v-if="show" class="trap-display-overlay" @click="handleOverlayClick">
+  <div v-if="show" class="modal-overlay trap-display-overlay" @click="handleOverlayClick">
     <div class="trap-display-modal" @click.stop>
       <div class="trap-header">
-        <div class="trap-icon">💀</div>
+        <div class="trap-icon">
+          <Skull :size="48" />
+        </div>
         <h2 class="trap-title">机关陷阱触发！</h2>
       </div>
 
@@ -34,13 +38,18 @@
         </div>
 
         <div class="trap-warning">
-          <p>⚠️ 机关陷阱已触发，请按照描述执行！</p>
+          <p>
+            <AlertTriangle :size="18" />
+            机关陷阱已触发，请按照描述执行！
+          </p>
         </div>
       </div>
 
       <div class="trap-actions">
-        <button class="btn-primary" @click="handleConfirm">
-          <span class="btn-icon">😰</span>
+        <button class="btn trap-confirm-btn" @click="handleConfirm">
+          <span class="btn-icon">
+            <AlertTriangle :size="18" />
+          </span>
           <span class="btn-text">确认执行</span>
         </button>
       </div>
@@ -50,29 +59,20 @@
 
 <style scoped>
   .trap-display-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.8);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-    animation: fadeIn 0.3s ease-out;
+    background: rgba(0, 0, 0, 0.85);
   }
 
   .trap-display-modal {
-    background: linear-gradient(135deg, #2c1810, #4a1c1c);
-    border: 3px solid #8b0000;
-    border-radius: 20px;
+    background: rgba(20, 10, 10, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid rgba(220, 38, 38, 0.4);
+    border-radius: var(--radius-xl);
     padding: 30px;
     max-width: 500px;
     width: 90%;
     text-align: center;
-    box-shadow: 0 10px 30px rgba(139, 0, 0, 0.5);
-    animation: slideIn 0.3s ease-out;
+    box-shadow: var(--glass-shadow-lg), var(--glow-md) rgba(220, 38, 38, 0.2);
+    animation: slideIn var(--transition-normal) ease-out;
   }
 
   .trap-header {
@@ -80,16 +80,18 @@
   }
 
   .trap-icon {
-    font-size: 4em;
+    display: flex;
+    justify-content: center;
     margin-bottom: 10px;
+    color: var(--color-trap);
     animation: pulse 2s infinite;
   }
 
   .trap-title {
-    color: #ff6b6b;
+    color: var(--color-trap);
     font-size: 1.8em;
     margin: 0;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+    text-shadow: var(--glow-sm) rgba(220, 38, 38, 0.5);
     font-weight: bold;
   }
 
@@ -102,22 +104,25 @@
   }
 
   .trap-description {
-    color: #ffd700;
+    color: var(--color-special);
     font-size: 1.2em;
     font-weight: bold;
     margin: 0;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.7);
   }
 
   .trap-warning {
-    background: rgba(255, 107, 107, 0.2);
-    border: 2px solid #ff6b6b;
-    border-radius: 10px;
+    background: rgba(220, 38, 38, 0.15);
+    border: 1px solid rgba(220, 38, 38, 0.4);
+    border-radius: var(--radius-md);
     padding: 15px;
   }
 
   .trap-warning p {
-    color: #ff6b6b;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    color: var(--color-trap);
     font-weight: bold;
     margin: 0;
     font-size: 0.9em;
@@ -128,48 +133,25 @@
     justify-content: center;
   }
 
-  .btn-primary {
-    background: linear-gradient(135deg, #8b0000, #dc143c);
+  .trap-confirm-btn {
+    background: linear-gradient(135deg, #7f1d1d, var(--color-trap));
     color: white;
-    border: none;
-    border-radius: 25px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-full);
     padding: 12px 30px;
     font-size: 1.1em;
     font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    box-shadow: 0 4px 15px rgba(139, 0, 0, 0.4);
+    box-shadow: 0 4px 15px rgba(220, 38, 38, 0.4);
   }
 
-  .btn-primary:hover {
-    background: linear-gradient(135deg, #dc143c, #ff0000);
+  .trap-confirm-btn:not(:disabled):hover {
+    background: linear-gradient(135deg, var(--color-trap), #ef4444);
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(139, 0, 0, 0.6);
+    box-shadow: 0 6px 20px rgba(220, 38, 38, 0.6);
   }
 
-  .btn-primary:active {
+  .trap-confirm-btn:active {
     transform: translateY(0);
-  }
-
-  .btn-icon {
-    font-size: 1.2em;
-  }
-
-  .btn-text {
-    font-weight: bold;
-  }
-
-  /* 动画效果 */
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
   }
 
   @keyframes slideIn {
@@ -200,8 +182,9 @@
       margin: 20px;
     }
 
-    .trap-icon {
-      font-size: 3em;
+    .trap-icon :deep(svg) {
+      width: 40px;
+      height: 40px;
     }
 
     .trap-title {
@@ -212,7 +195,7 @@
       font-size: 1.1em;
     }
 
-    .btn-primary {
+    .trap-confirm-btn {
       padding: 10px 25px;
       font-size: 1em;
     }

--- a/src/components/VersionDisplay.vue
+++ b/src/components/VersionDisplay.vue
@@ -25,46 +25,52 @@
     position: fixed;
     top: 16px;
     right: 16px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
+    background: var(--bg-glass);
+    color: var(--text-primary);
     padding: 8px 16px;
-    border-radius: 20px;
+    border-radius: var(--radius-full);
     font-size: 16px;
     font-weight: bold;
     font-family: 'Courier New', monospace;
     z-index: 1000;
     display: flex;
     align-items: center;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(10px);
-    border: 2px solid rgba(255, 255, 255, 0.2);
-    transition: all 0.3s ease;
+    box-shadow: var(--glass-shadow);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    transition: all var(--transition-normal);
   }
 
   .version-display:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+    background: var(--bg-glass-hover);
+    box-shadow: var(--glass-shadow-lg);
+    border-color: rgba(102, 126, 234, 0.3);
   }
 
   .version-text {
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+    color: var(--color-accent-light);
     letter-spacing: 0.5px;
   }
 
   .dev-mode {
-    background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
+    border-color: rgba(255, 107, 107, 0.4);
     animation: pulse 2s infinite;
+  }
+
+  .dev-mode .version-text {
+    color: var(--player-1);
   }
 
   @keyframes pulse {
     0% {
-      box-shadow: 0 4px 15px rgba(255, 107, 107, 0.4);
+      box-shadow: var(--glow-sm) rgba(255, 107, 107, 0.4);
     }
     50% {
-      box-shadow: 0 4px 15px rgba(255, 107, 107, 0.8);
+      box-shadow: var(--glow-md) rgba(255, 107, 107, 0.6);
     }
     100% {
-      box-shadow: 0 4px 15px rgba(255, 107, 107, 0.4);
+      box-shadow: var(--glow-sm) rgba(255, 107, 107, 0.4);
     }
   }
 </style>

--- a/src/components/VictoryScreen.vue
+++ b/src/components/VictoryScreen.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import { computed } from 'vue'
+  import { Trophy, Gamepad2 } from '@lucide/vue'
   import type { Player } from '../types/game'
 
   interface Props {
@@ -29,7 +30,10 @@
   <div v-if="show && winner" class="victory-screen-overlay">
     <div class="victory-screen">
       <div class="victory-header">
-        <h1 class="victory-title">🎉 游戏胜利！</h1>
+        <h1 class="victory-title">
+          <Trophy :size="32" />
+          游戏胜利！
+        </h1>
         <div class="winner-info">
           <div class="winner-avatar" :style="{ backgroundColor: winner.color }"></div>
           <span class="winner-name">{{ winner.name }}</span>
@@ -38,7 +42,10 @@
 
       <div class="victory-content">
         <div class="reward-section">
-          <h2 class="reward-title">🏆 胜利奖励</h2>
+          <h2 class="reward-title">
+            <Trophy :size="24" />
+            胜利奖励
+          </h2>
           <div class="reward-description">
             <p>恭喜 {{ winner.name }} 获得胜利！</p>
             <p class="reward-action">
@@ -60,7 +67,10 @@
       </div>
 
       <div class="victory-actions">
-        <button class="btn btn-primary" @click="handlePlayAgain">🎮 再来一局</button>
+        <button class="btn btn-primary" @click="handlePlayAgain">
+          <Gamepad2 :size="18" />
+          再来一局
+        </button>
       </div>
     </div>
   </div>
@@ -69,27 +79,25 @@
 <style scoped>
   .victory-screen-overlay {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.8);
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
-    backdrop-filter: blur(10px);
+    z-index: 2000;
+    backdrop-filter: blur(4px);
   }
 
   .victory-screen {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    border-radius: 20px;
+    background: rgba(20, 20, 40, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    border-radius: var(--radius-xl);
     padding: 2rem;
     max-width: 90vw;
     width: 500px;
     text-align: center;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
-    border: 2px solid rgba(255, 255, 255, 0.2);
+    box-shadow: var(--glass-shadow-lg), var(--glow-md) rgba(102, 126, 234, 0.3);
     animation: victorySlideIn 0.5s ease-out;
   }
 
@@ -109,11 +117,20 @@
   }
 
   .victory-title {
-    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    color: var(--text-primary);
     font-size: 2rem;
     font-weight: bold;
     margin: 0 0 1rem 0;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  }
+
+  .victory-title :deep(svg) {
+    color: var(--color-accent);
+    flex-shrink: 0;
   }
 
   .winner-info {
@@ -128,15 +145,14 @@
     width: 60px;
     height: 60px;
     border-radius: 50%;
-    border: 3px solid white;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    border: 3px solid rgba(255, 255, 255, 0.2);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
   }
 
   .winner-name {
-    color: white;
+    color: var(--text-primary);
     font-size: 1.5rem;
     font-weight: bold;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
   }
 
   .victory-content {
@@ -144,21 +160,29 @@
   }
 
   .reward-section {
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 15px;
+    background: var(--bg-glass);
+    border: var(--glass-border);
+    border-radius: var(--radius-md);
     padding: 1.5rem;
-    border: 1px solid rgba(255, 255, 255, 0.2);
   }
 
   .reward-title {
-    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    color: var(--text-primary);
     font-size: 1.3rem;
     margin: 0 0 1rem 0;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
+  }
+
+  .reward-title :deep(svg) {
+    color: var(--color-accent);
+    flex-shrink: 0;
   }
 
   .reward-description {
-    color: white;
+    color: var(--text-secondary);
     margin-bottom: 1.5rem;
   }
 
@@ -169,15 +193,13 @@
 
   .reward-action {
     font-weight: bold;
-    color: #ffd700;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
+    color: var(--color-warning);
   }
 
   .other-players-list h3 {
-    color: white;
+    color: var(--text-secondary);
     margin: 0 0 1rem 0;
     font-size: 1.1rem;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
   }
 
   .players-grid {
@@ -188,34 +210,33 @@
   }
 
   .player-item {
-    background: rgba(255, 255, 255, 0.15);
-    border-radius: 10px;
+    background: var(--bg-glass);
+    border-radius: var(--radius-sm);
     padding: 1rem;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 0.5rem;
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    transition: transform 0.2s ease;
+    border: var(--glass-border);
+    transition: transform var(--transition-fast), background var(--transition-fast);
   }
 
   .player-item:hover {
     transform: translateY(-2px);
-    background: rgba(255, 255, 255, 0.2);
+    background: var(--bg-glass-hover);
   }
 
   .player-avatar {
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    border: 2px solid white;
+    border: 2px solid rgba(255, 255, 255, 0.2);
   }
 
   .player-name {
-    color: white;
+    color: var(--text-primary);
     font-weight: bold;
     font-size: 0.9rem;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
   }
 
   .punishment-count {
@@ -225,7 +246,7 @@
     border-radius: 15px;
     font-size: 0.8rem;
     font-weight: bold;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.2);
   }
 
   .victory-actions {
@@ -240,7 +261,7 @@
     font-size: 1rem;
     font-weight: bold;
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: all var(--transition-normal);
     text-decoration: none;
     display: inline-flex;
     align-items: center;
@@ -250,14 +271,14 @@
   }
 
   .btn-primary {
-    background: linear-gradient(45deg, #ff6b6b, #ee5a24);
+    background: linear-gradient(135deg, var(--color-accent), #764ba2);
     color: white;
-    box-shadow: 0 4px 15px rgba(255, 107, 107, 0.4);
+    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4), var(--glow-sm) rgba(102, 126, 234, 0.3);
   }
 
   .btn-primary:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(255, 107, 107, 0.6);
+    box-shadow: 0 6px 20px rgba(102, 126, 234, 0.5), var(--glow-md) rgba(102, 126, 234, 0.4);
   }
 
   .btn-primary:active {

--- a/src/config/gameConfig.ts
+++ b/src/config/gameConfig.ts
@@ -189,8 +189,20 @@ export const GAME_CONFIG = {
   },
 }
 
-// 格子类型图标映射
-export const CELL_ICONS = {
+// Lucide icon component name mapping for cell types
+export const CELL_ICON_NAMES: Record<string, string> = {
+  punishment: 'Zap',
+  bonus: 'Gift',
+  reverse: 'Undo2',
+  rest: 'Moon',
+  restart: 'RotateCcw',
+  trap: 'Skull',
+  start: 'Rocket',
+  normal: 'Circle',
+}
+
+// Legacy emoji mapping (kept for fallback/compatibility)
+export const CELL_ICONS: Record<string, string> = {
   punishment: '⚡',
   bonus: '🎁',
   special: '⬅️',
@@ -198,26 +210,26 @@ export const CELL_ICONS = {
   trap: '💀',
 }
 
-// 格子类型颜色映射
+// Cell type color tokens (dark theme)
 export const CELL_COLORS = {
   punishment: {
-    background: 'linear-gradient(135deg, #ff6b6b, #ee5a52)',
-    border: '#ff4757',
+    color: 'var(--color-punishment)',
+    border: 'var(--color-punishment)',
   },
   bonus: {
-    background: 'linear-gradient(135deg, #2ed573, #1e90ff)',
-    border: '#00d2d3',
+    color: 'var(--color-bonus)',
+    border: 'var(--color-bonus)',
   },
   special: {
-    background: 'linear-gradient(135deg, #ffa726, #ff9800)',
-    border: '#ff7043',
+    color: 'var(--color-special)',
+    border: 'var(--color-special)',
   },
   restart: {
-    background: 'linear-gradient(135deg, #ab47bc, #8e44ad)',
-    border: '#9b59b6',
+    color: 'var(--color-restart)',
+    border: 'var(--color-restart)',
   },
   trap: {
-    background: 'linear-gradient(135deg, #8b0000, #dc143c)',
-    border: '#b22222',
+    color: 'var(--color-trap)',
+    border: 'var(--color-trap)',
   },
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ app.use(PrimeVue, {
     preset: Aura,
     options: {
       prefix: 'p',
-      darkModeSelector: 'system',
+      darkModeSelector: '.dark-mode',
       cssLayer: false,
     },
   },

--- a/src/services/audioService.ts
+++ b/src/services/audioService.ts
@@ -1,0 +1,228 @@
+type SoundName = 'diceRoll' | 'pieceStep' | 'punishment' | 'bonus' | 'trap' | 'victory'
+
+class AudioService {
+  private context: AudioContext | null = null
+  private _enabled: boolean = true
+  private _volume: number = 0.5
+
+  get enabled(): boolean {
+    return this._enabled
+  }
+
+  private getContext(): AudioContext {
+    if (!this.context) {
+      this.context = new AudioContext()
+    }
+    if (this.context.state === 'suspended') {
+      this.context.resume()
+    }
+    return this.context
+  }
+
+  init(): void {
+    const stored = localStorage.getItem('audio_enabled')
+    if (stored !== null) {
+      this._enabled = stored === 'true'
+    }
+    const vol = localStorage.getItem('audio_volume')
+    if (vol !== null) {
+      this._volume = parseFloat(vol) || 0.5
+    }
+  }
+
+  toggle(): boolean {
+    this._enabled = !this._enabled
+    localStorage.setItem('audio_enabled', String(this._enabled))
+    return this._enabled
+  }
+
+  setVolume(vol: number): void {
+    this._volume = Math.max(0, Math.min(1, vol))
+    localStorage.setItem('audio_volume', String(this._volume))
+  }
+
+  play(name: SoundName): void {
+    if (!this._enabled) return
+    try {
+      const ctx = this.getContext()
+      switch (name) {
+        case 'diceRoll':
+          this.playDiceRoll(ctx)
+          break
+        case 'pieceStep':
+          this.playPieceStep(ctx)
+          break
+        case 'punishment':
+          this.playPunishment(ctx)
+          break
+        case 'bonus':
+          this.playBonus(ctx)
+          break
+        case 'trap':
+          this.playTrap(ctx)
+          break
+        case 'victory':
+          this.playVictory(ctx)
+          break
+      }
+    } catch {
+      // Silently fail on audio issues (user may not have interacted yet)
+    }
+  }
+
+  private createGain(ctx: AudioContext, volume: number = this._volume): GainNode {
+    const gain = ctx.createGain()
+    gain.gain.value = volume
+    gain.connect(ctx.destination)
+    return gain
+  }
+
+  private playDiceRoll(ctx: AudioContext): void {
+    const now = ctx.currentTime
+    const gain = this.createGain(ctx, this._volume * 0.4)
+
+    // Short noise bursts simulating dice rattling
+    for (let i = 0; i < 8; i++) {
+      const bufferSize = 1200
+      const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate)
+      const data = buffer.getChannelData(0)
+      for (let j = 0; j < bufferSize; j++) {
+        data[j] = (Math.random() * 2 - 1) * (1 - j / bufferSize)
+      }
+      const noise = ctx.createBufferSource()
+      noise.buffer = buffer
+      const filter = ctx.createBiquadFilter()
+      filter.type = 'bandpass'
+      filter.frequency.value = 2000 + Math.random() * 3000
+      filter.Q.value = 2
+      noise.connect(filter)
+      filter.connect(gain)
+      noise.start(now + i * 0.08)
+      noise.stop(now + i * 0.08 + 0.06)
+    }
+  }
+
+  private playPieceStep(ctx: AudioContext): void {
+    const now = ctx.currentTime
+    const gain = this.createGain(ctx, this._volume * 0.3)
+
+    const osc = ctx.createOscillator()
+    osc.type = 'sine'
+    osc.frequency.setValueAtTime(800, now)
+    osc.frequency.exponentialRampToValueAtTime(1200, now + 0.05)
+    osc.frequency.exponentialRampToValueAtTime(600, now + 0.1)
+
+    gain.gain.setValueAtTime(this._volume * 0.3, now)
+    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.12)
+
+    osc.connect(gain)
+    osc.start(now)
+    osc.stop(now + 0.12)
+  }
+
+  private playPunishment(ctx: AudioContext): void {
+    const now = ctx.currentTime
+    const gain = this.createGain(ctx, this._volume * 0.5)
+
+    // Descending warning tone
+    const osc = ctx.createOscillator()
+    osc.type = 'sawtooth'
+    osc.frequency.setValueAtTime(600, now)
+    osc.frequency.exponentialRampToValueAtTime(200, now + 0.4)
+
+    gain.gain.setValueAtTime(this._volume * 0.5, now)
+    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.5)
+
+    osc.connect(gain)
+    osc.start(now)
+    osc.stop(now + 0.5)
+
+    // Second tone
+    const osc2 = ctx.createOscillator()
+    osc2.type = 'square'
+    osc2.frequency.setValueAtTime(300, now + 0.15)
+    osc2.frequency.exponentialRampToValueAtTime(150, now + 0.5)
+
+    const gain2 = this.createGain(ctx, this._volume * 0.2)
+    gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.5)
+
+    osc2.connect(gain2)
+    osc2.start(now + 0.15)
+    osc2.stop(now + 0.5)
+  }
+
+  private playBonus(ctx: AudioContext): void {
+    const now = ctx.currentTime
+
+    // Ascending cheerful notes
+    const notes = [523, 659, 784, 1047] // C5, E5, G5, C6
+    notes.forEach((freq, i) => {
+      const osc = ctx.createOscillator()
+      osc.type = 'sine'
+      osc.frequency.value = freq
+
+      const gain = this.createGain(ctx, this._volume * 0.3)
+      gain.gain.setValueAtTime(this._volume * 0.3, now + i * 0.1)
+      gain.gain.exponentialRampToValueAtTime(0.001, now + i * 0.1 + 0.2)
+
+      osc.connect(gain)
+      osc.start(now + i * 0.1)
+      osc.stop(now + i * 0.1 + 0.2)
+    })
+  }
+
+  private playTrap(ctx: AudioContext): void {
+    const now = ctx.currentTime
+    const gain = this.createGain(ctx, this._volume * 0.4)
+
+    // Low rumble
+    const osc = ctx.createOscillator()
+    osc.type = 'sawtooth'
+    osc.frequency.setValueAtTime(80, now)
+    osc.frequency.exponentialRampToValueAtTime(40, now + 0.6)
+
+    gain.gain.setValueAtTime(this._volume * 0.4, now)
+    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.6)
+
+    osc.connect(gain)
+    osc.start(now)
+    osc.stop(now + 0.6)
+
+    // High stinger
+    const osc2 = ctx.createOscillator()
+    osc2.type = 'square'
+    osc2.frequency.setValueAtTime(400, now)
+    osc2.frequency.exponentialRampToValueAtTime(100, now + 0.3)
+
+    const gain2 = this.createGain(ctx, this._volume * 0.25)
+    gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.35)
+
+    osc2.connect(gain2)
+    osc2.start(now)
+    osc2.stop(now + 0.35)
+  }
+
+  private playVictory(ctx: AudioContext): void {
+    const now = ctx.currentTime
+
+    // Fanfare: ascending arpeggiated chord
+    const notes = [523, 659, 784, 1047, 1319, 1568] // C major ascending
+    notes.forEach((freq, i) => {
+      const osc = ctx.createOscillator()
+      osc.type = i < 4 ? 'sine' : 'triangle'
+      osc.frequency.value = freq
+
+      const gain = this.createGain(ctx, this._volume * 0.25)
+      const start = now + i * 0.12
+      gain.gain.setValueAtTime(this._volume * 0.25, start)
+      gain.gain.setValueAtTime(this._volume * 0.2, start + 0.3)
+      gain.gain.exponentialRampToValueAtTime(0.001, start + 0.8)
+
+      osc.connect(gain)
+      osc.start(start)
+      osc.stop(start + 0.8)
+    })
+  }
+}
+
+export const audioService = new AudioService()


### PR DESCRIPTION
## Summary

- Complete dark theme visual redesign (8 phases): CSS token system, Lucide icons, dark glass modals, board/dice/player redesign, tab settings layout, Web Audio synthesis, all components dark-themed
- Bug fixes: EffectDisplay emoji→Lucide, pieceStep audio trigger, config panel prop watch sync

## Changes

- 29 files changed, ~2350 insertions, ~2290 deletions
- New: `src/services/audioService.ts` (Web Audio API, 6 synthesized effects)
- New dep: `@lucide/vue ^1.24.0`
- Version bump: 0.1.0 → 0.2.0

## Test plan

- [ ] Verify dark theme renders correctly on intro/game/settings pages
- [ ] Roll dice and confirm pieceStep sound plays on movement
- [ ] Import config and verify BoardConfig/TrapConfig panels sync
- [ ] Confirm EffectDisplay shows Lucide icons (not emoji) for all effect types
- [ ] Toggle audio on/off, refresh page, verify localStorage persistence
- [ ] Verify tab switching (board/punishment/trap) works in settings


Made with [Cursor](https://cursor.com)