### PR TITLE
feat: 棋盘UI重设计 + 求饶机制 (v1.3.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,7 +29,6 @@
   import IntroPage from './components/IntroPage.vue'
   import GameBoard from './components/GameBoard.vue'
   import PlayerPanel from './components/PlayerPanel.vue'
-  import CoolDice from './components/CoolDice.vue'
   import BoardConfigPanel from './components/BoardConfig.vue'
   import PunishmentConfigPanel from './components/PunishmentConfig.vue'
   import TrapConfigPanel from './components/TrapConfig.vue'
@@ -2047,28 +2046,9 @@
 
       <!-- 主要内容区域 -->
       <main class="game-main">
-        <!-- 左侧骰子区域 -->
+        <!-- 左侧控制区域 -->
         <div class="left-sidebar">
           <div class="sidebar-content">
-            <!-- 骰子区域 -->
-            <Card class="dice-card">
-              <template #title>
-                <div class="card-title">
-                  <i class="pi pi-circle"></i>
-                  <span>投掷骰子</span>
-                </div>
-              </template>
-              <template #content>
-                <div class="dice-section">
-                  <CoolDice
-                    :can-roll="canRollDice"
-                    :value="gameState.diceValue"
-                    @roll="handleDiceRoll"
-                  />
-                </div>
-              </template>
-            </Card>
-
             <!-- 控制按钮 -->
             <div class="control-buttons">
               <PButton
@@ -2093,18 +2073,8 @@
         <div class="game-area">
           <!-- 移动端控制面板 -->
           <div class="mobile-control-panel">
-            <!-- 左侧骰子区域 -->
-            <div class="mobile-dice-section">
-              <CoolDice
-                :can-roll="canRollDice"
-                :value="gameState.diceValue"
-                @roll="handleDiceRoll"
-              />
-            </div>
-
-            <!-- 右侧玩家状态区域 -->
+            <!-- 玩家状态区域 -->
             <div class="mobile-status-section">
-              <!-- 合并的回合数和游戏状态显示 -->
               <div class="mobile-combined-status">
                 <div class="mobile-turn-display">
                   <div class="turn-number">{{ turnCount }}</div>
@@ -2119,7 +2089,7 @@
                 </div>
               </div>
 
-              <!-- 玩家状态面板 (移动端) - 扩展显示区域 -->
+              <!-- 玩家状态面板 (移动端) -->
               <div class="mobile-players-container">
                 <PlayerPanel
                   :players="gameState.players"
@@ -2211,7 +2181,10 @@
               :players="gameState.players"
               :current-player-index="gameState.currentPlayerIndex"
               :last-effect="lastEffect"
+              :can-roll="canRollDice"
+              :dice-value="gameState.diceValue"
               @cell-click="handleCellClick"
+              @roll="handleDiceRoll"
             />
           </div>
         </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -43,6 +43,7 @@
   import BounceDisplay from './components/BounceDisplay.vue'
   import DoublePunishmentReveal from './components/DoublePunishmentReveal.vue'
   import ChainPunishmentRoll from './components/ChainPunishmentRoll.vue'
+  import MercyDecision from './components/MercyDecision.vue'
   import ConfigExport from './components/ConfigExport.vue'
   import { saveConfig, loadConfig, loadPlayerSettings } from './utils/cache'
   import { SecureRandom } from './utils/secureRandom'
@@ -158,8 +159,84 @@
   const isChainPunishment = ref(false)
   const showChainPunishmentRoll = ref(false)
 
+  // 求饶状态
+  const MERCY_MULTIPLIER = 1.5
+  const showMercyDecision = ref(false)
+  const mercyHalvedStrikes = ref(0)
+  const mercySource = ref<'board' | 'takeoff'>('board')
+  const mercyRequested = ref(false)
+  const mercyExecutorPlayer = ref<Player | null>(null)
+  const mercyTargetPlayer = ref<Player | null>(null)
+
   // 胜利结算画面状态
   const showVictoryScreen = ref(false)
+
+  const canRequestBoardMercy = computed(() => !isDoublePunishment.value && !mercyRequested.value)
+  const canRequestTakeoffMercy = computed(() => !mercyRequested.value)
+
+  const rebuildPunishmentDescription = (punishment: PunishmentAction, strikes: number): string => {
+    return `用${punishment.tool.name}打${punishment.bodyPart.name}${strikes}下，姿势：${punishment.position.name}`
+  }
+
+  /** 消耗受罚方 pendingMercyMultiplier，返回可安全修改的惩罚副本 */
+  const preparePunishmentForDisplay = (
+    punishment: PunishmentAction,
+    targetPlayer: Player
+  ): PunishmentAction => {
+    const cloned: PunishmentAction = { ...punishment }
+    const multiplier = targetPlayer.pendingMercyMultiplier
+    if (multiplier && multiplier > 1 && cloned.strikes != null) {
+      const newStrikes = Math.ceil(cloned.strikes * multiplier)
+      cloned.strikes = newStrikes
+      cloned.description = rebuildPunishmentDescription(cloned, newStrikes)
+      targetPlayer.pendingMercyMultiplier = undefined
+    }
+    return cloned
+  }
+
+  const handleMercyRequest = (source: 'board' | 'takeoff') => {
+    const punishment = source === 'board' ? currentPunishment.value : currentTakeoffPunishment.value
+    if (!punishment || punishment.strikes == null) return
+
+    mercySource.value = source
+    mercyHalvedStrikes.value = Math.ceil(punishment.strikes / 2)
+    mercyTargetPlayer.value = gameState.players[gameState.currentPlayerIndex] ?? null
+    if (source === 'board') {
+      mercyExecutorPlayer.value = currentPunishmentExecutor.value
+    } else {
+      const idx = currentTakeoffExecutorIndex.value
+      mercyExecutorPlayer.value =
+        idx >= 0 && idx < gameState.players.length ? gameState.players[idx] : null
+    }
+    showMercyDecision.value = true
+  }
+
+  const handleMercyResult = (accepted: boolean) => {
+    showMercyDecision.value = false
+    mercyRequested.value = true
+
+    if (!accepted) return
+
+    const targetPlayer = gameState.players[gameState.currentPlayerIndex]
+    if (!targetPlayer) return
+
+    const applyHalve = (punishment: PunishmentAction): PunishmentAction => {
+      const halved = Math.ceil((punishment.strikes ?? 0) / 2)
+      return {
+        ...punishment,
+        strikes: halved,
+        description: rebuildPunishmentDescription(punishment, halved),
+      }
+    }
+
+    if (mercySource.value === 'board' && currentPunishment.value) {
+      currentPunishment.value = applyHalve(currentPunishment.value)
+    } else if (mercySource.value === 'takeoff' && currentTakeoffPunishment.value) {
+      currentTakeoffPunishment.value = applyHalve(currentTakeoffPunishment.value)
+    }
+
+    targetPlayer.pendingMercyMultiplier = MERCY_MULTIPLIER
+  }
 
   const resetEffectChainCount = () => {
     effectChainCount.value = 0
@@ -218,9 +295,13 @@
 
     // 当玩家尚未起飞(仍停留在起点)且出现惩罚时，视为未起飞惩罚
     if (resolvedPunishment && !currentPlayer.hasTakenOff) {
-      currentTakeoffPunishment.value = resolvedPunishment
+      currentTakeoffPunishment.value = preparePunishmentForDisplay(
+        resolvedPunishment,
+        currentPlayer
+      )
       currentTakeoffDiceValue.value = diceValue ?? gameState.diceValue ?? 0
       currentTakeoffExecutorIndex.value = executorIndex !== undefined ? executorIndex : -1
+      mercyRequested.value = false
       showTakeoffPunishmentDisplay.value = true
       audioService.play('punishment')
       handleTakeoffPunishmentDisplay()
@@ -228,7 +309,8 @@
     }
 
     if (resolvedPunishment) {
-      currentPunishment.value = resolvedPunishment
+      currentPunishment.value = preparePunishmentForDisplay(resolvedPunishment, currentPlayer)
+      mercyRequested.value = false
       audioService.play('punishment')
       if (
         executorIndex !== undefined &&
@@ -380,6 +462,10 @@
     showDoublePunishmentReveal.value = false
     showChainPunishmentRoll.value = false
     pendingDoublePunishment.value = null
+    showMercyDecision.value = false
+    mercyRequested.value = false
+    mercyExecutorPlayer.value = null
+    mercyTargetPlayer.value = null
     resetEffectChainCount()
 
     devLog('游戏状态已重置')
@@ -405,6 +491,7 @@
       takeoffRelief: showTakeoffReliefDisplay.value,
       doublePunishmentReveal: showDoublePunishmentReveal.value,
       chainPunishmentRoll: showChainPunishmentRoll.value,
+      mercyDecision: showMercyDecision.value,
     }
 
     // 检查是否卡在 moving 状态超过 5 秒
@@ -791,6 +878,12 @@
     showVictoryScreen.value = false
     resetEffectChainCount()
 
+    // 清除求饶状态
+    showMercyDecision.value = false
+    mercyRequested.value = false
+    mercyExecutorPlayer.value = null
+    mercyTargetPlayer.value = null
+
     // 直接跳转到棋盘设置页面
     gameState.gameStatus = 'board_settings'
   }
@@ -1140,6 +1233,7 @@
     isDoublePunishment.value = true
     currentPunishment.value = pendingDoublePunishment.value
     pendingDoublePunishment.value = null
+    mercyRequested.value = true // 翻倍惩罚不可求饶
     gameState.gameStatus = 'configuring'
   }
 
@@ -1148,7 +1242,11 @@
     showChainPunishmentRoll.value = false
     if (continueChain) {
       const newPunishment = GameService.generateRandomPunishment(gameState.punishmentConfig)
-      currentPunishment.value = newPunishment
+      const targetPlayer = gameState.players[gameState.currentPlayerIndex]
+      currentPunishment.value = targetPlayer
+        ? preparePunishmentForDisplay(newPunishment, targetPlayer)
+        : newPunishment
+      mercyRequested.value = false
       gameState.gameStatus = 'configuring'
     } else {
       isChainPunishment.value = false
@@ -2141,6 +2239,17 @@
                   <div class="current-info">
                     <div class="current-name">
                       {{ gameState.players[gameState.currentPlayerIndex].name }}
+                      <span
+                        v-if="
+                          (gameState.players[gameState.currentPlayerIndex].pendingMercyMultiplier ??
+                            0) > 1
+                        "
+                        class="mercy-multiplier-badge"
+                      >
+                        ×{{
+                          gameState.players[gameState.currentPlayerIndex].pendingMercyMultiplier
+                        }}
+                      </span>
                     </div>
                     <div class="current-position">
                       {{
@@ -2194,8 +2303,20 @@
       <PunishmentDisplay
         :punishment="currentPunishment"
         :executor-player="currentPunishmentExecutor"
+        :can-request-mercy="canRequestBoardMercy"
         @confirm="confirmPunishment"
         @skip="skipPunishment"
+        @request-mercy="handleMercyRequest('board')"
+      />
+
+      <!-- 求饶决策弹窗 -->
+      <MercyDecision
+        :visible="showMercyDecision"
+        :punishment="mercySource === 'board' ? currentPunishment : currentTakeoffPunishment"
+        :executor-player="mercyExecutorPlayer"
+        :target-player="mercyTargetPlayer"
+        :halved-strikes="mercyHalvedStrikes"
+        @mercy-result="handleMercyResult"
       />
 
       <!-- 效果显示弹窗 -->
@@ -2235,7 +2356,9 @@
           ? gameState.players[currentTakeoffExecutorIndex]?.name || ''
           : ''
       "
+      :can-request-mercy="canRequestTakeoffMercy"
       @confirm="confirmTakeoffPunishment"
+      @request-mercy="handleMercyRequest('takeoff')"
     />
 
     <!-- 机关陷阱弹窗 -->
@@ -2695,6 +2818,19 @@
     color: var(--text-primary);
     font-size: 0.9rem;
     margin-bottom: 0.1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .mercy-multiplier-badge {
+    font-size: 0.7rem;
+    font-weight: bold;
+    color: #fff;
+    background: linear-gradient(135deg, #f59e0b, #d97706);
+    padding: 0.1rem 0.35rem;
+    border-radius: 999px;
+    box-shadow: 0 0 8px rgba(245, 158, 11, 0.45);
   }
 
   .compact-current-player .current-position {

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -77,6 +77,19 @@
   --glow-sm: 0 0 8px;
   --glow-md: 0 0 16px;
   --glow-lg: 0 0 24px;
+
+  /* Animation timing */
+  --ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+  --move-step-duration: 180ms;
+
+  /* Cell type colors (enhanced saturation for glow) */
+  --color-punishment-glow: rgba(255, 71, 87, 0.4);
+  --color-bonus-glow: rgba(46, 213, 115, 0.4);
+  --color-special-glow: rgba(255, 165, 2, 0.4);
+  --color-restart-glow: rgba(168, 85, 247, 0.4);
+  --color-trap-glow: rgba(220, 38, 38, 0.4);
+  --color-chain-glow: rgba(255, 165, 2, 0.4);
 }
 
 *,

--- a/src/components/GameBoard.vue
+++ b/src/components/GameBoard.vue
@@ -1,18 +1,22 @@
 <script setup lang="ts">
-  import { computed, ref } from 'vue'
+  import { computed, ref, watch, nextTick } from 'vue'
   import type { BoardCell, Player } from '../types/game'
   import { CELL_ICON_NAMES } from '../config/gameConfig'
   import { Zap, Gift, Undo2, Moon, RotateCcw, Skull, Rocket, Sparkles, Link } from '@lucide/vue'
+  import CoolDice from './CoolDice.vue'
 
   interface Props {
     board: BoardCell[]
     players: Player[]
     currentPlayerIndex: number
     lastEffect?: string
+    canRoll?: boolean
+    diceValue?: number | null
   }
 
   interface Emits {
     (e: 'cellClick', cell: BoardCell): void
+    (e: 'roll'): void
   }
 
   const props = defineProps<Props>()
@@ -30,98 +34,68 @@
     Link,
   }
 
-  // 浮窗状态
   const tooltipVisible = ref(false)
   const tooltipCell = ref<BoardCell | null>(null)
-  const tooltipStyle = ref({
-    left: '0px',
-    top: '0px',
-  })
+  const tooltipStyle = ref({ left: '0px', top: '0px' })
 
-  // 螺旋蛇形棋盘生成
-  const spiralBoard = computed(() => {
+  const activatedCell = ref<number | null>(null)
+  const landingCell = ref<number | null>(null)
+
+  // Ring layout: distribute N cells along 4 edges of a rectangle
+  const ringLayout = computed(() => {
     const totalCells = props.board.length
+    if (totalCells === 0) return { top: [], right: [], bottom: [], left: [] }
 
-    // 动态计算网格大小，确保能容纳所有格子
-    // 使用黄金比例来优化布局
-    const aspectRatio = 1.6 // 宽高比
-    const cols = Math.ceil(Math.sqrt(totalCells * aspectRatio))
-    const rows = Math.ceil(totalCells / cols)
+    const ratio = 1.6
+    const adjustedHorizontal = Math.ceil((totalCells * ratio) / (2 * (1 + ratio)))
+    const adjustedVertical = Math.ceil((totalCells - 2 * adjustedHorizontal) / 2)
 
-    const spiral: (number | null)[][] = Array.from({ length: rows }, () => Array(cols).fill(null))
+    const topCount = adjustedHorizontal
+    const rightCount = adjustedVertical
+    const bottomCount = Math.min(adjustedHorizontal, totalCells - topCount - rightCount)
+    const leftCount = totalCells - topCount - rightCount - bottomCount
 
-    let num = 1
-    let left = 0,
-      right = cols - 1,
-      top = 0,
-      bottom = rows - 1
+    let idx = 0
+    const top: number[] = []
+    const right: number[] = []
+    const bottom: number[] = []
+    const left: number[] = []
 
-    while (left <= right && top <= bottom && num <= totalCells) {
-      // 从左到右填充顶部行
-      for (let j = left; j <= right && num <= totalCells; j++) {
-        spiral[top][j] = num++
-      }
-      top++
+    for (let i = 0; i < topCount && idx < totalCells; i++) top.push(props.board[idx++].position)
+    for (let i = 0; i < rightCount && idx < totalCells; i++) right.push(props.board[idx++].position)
+    for (let i = 0; i < bottomCount && idx < totalCells; i++)
+      bottom.push(props.board[idx++].position)
+    for (let i = 0; i < leftCount && idx < totalCells; i++) left.push(props.board[idx++].position)
 
-      // 从上到下填充右列
-      for (let i = top; i <= bottom && num <= totalCells; i++) {
-        spiral[i][right] = num++
-      }
-      right--
-
-      // 从右到左填充底部行（如果还有行）
-      if (top <= bottom) {
-        for (let j = right; j >= left && num <= totalCells; j--) {
-          spiral[bottom][j] = num++
-        }
-        bottom--
-      }
-
-      // 从下到上填充左列（如果还有列）
-      if (left <= right) {
-        for (let i = bottom; i >= top && num <= totalCells; i--) {
-          spiral[i][left] = num++
-        }
-        left++
-      }
-    }
-
-    return spiral
+    return { top, right, bottom: bottom.reverse(), left: left.reverse() }
   })
 
   const getCellByPosition = (position: number): BoardCell => {
     const foundCell = props.board.find(cell => cell.position === position)
-    if (foundCell) {
-      return foundCell
-    }
-
-    // 如果找不到格子，返回一个安全的默认格子
-    console.warn(`位置 ${position} 的格子未找到，使用默认格子`)
+    if (foundCell) return foundCell
     return {
       id: position,
       type: 'bonus',
       position,
-      effect: {
-        type: 'move',
-        value: 0,
-        description: '安全格子',
-      },
+      effect: { type: 'move', value: 0, description: '安全格子' },
     }
   }
 
   const getCellClass = (position: number): string => {
     const cell = getCellByPosition(position)
-    const baseClass = `cell-${cell.type}`
-    const highlightClass = props.players.some(p => p.position === position) ? 'cell-occupied' : ''
-    return `${baseClass} ${highlightClass}`.trim()
+    const classes = [`cell-${cell.type}`]
+    if (props.players.some(p => p.position === position)) classes.push('cell-occupied')
+    if (activatedCell.value === position) classes.push('cell-activated')
+    if (landingCell.value === position) classes.push('cell-landing')
+    if (position === 1) classes.push('cell-start')
+    return classes.join(' ')
   }
 
   const getCellIconComponent = (position: number): string | null => {
     const cell = getCellByPosition(position)
     if (cell.effect?.type === 'rest') return 'Moon'
     if (cell.effect?.type === 'reverse') return 'Undo2'
-    const name = CELL_ICON_NAMES[cell.type]
-    return name || null
+    return CELL_ICON_NAMES[cell.type] || null
   }
 
   const getCellIcon = (position: number) => {
@@ -129,820 +103,817 @@
     return name ? iconComponents[name] : null
   }
 
-  const getCellEffect = (position: number): string => {
-    const cell = getCellByPosition(position)
-    return cell.effect?.description || ''
+  const getCellTypeName = (type: string): string => {
+    const typeNames: Record<string, string> = {
+      punishment: '惩罚格',
+      bonus: '奖励格',
+      special: '特殊格',
+      restart: '回起点',
+      trap: '陷阱格',
+      chain_punishment: '连锁惩罚',
+    }
+    return typeNames[type] || '普通格'
   }
 
-  const getCellTypeName = (type: string): string => {
-    const typeNames = {
-      punishment: '惩罚格子',
-      bonus: '前进格子',
-      special: '后退格子',
-      restart: '回到起点',
-      trap: '机关陷阱',
-    }
+  const getPlayersOnCell = (position: number): Player[] => {
+    return props.players.filter(p => p.position === position)
+  }
 
-    // 特殊处理休息格子
-    if (type === 'special' && tooltipCell.value?.effect?.type === 'rest') {
-      return '休息格子'
-    }
-
-    return typeNames[type as keyof typeof typeNames] || '惩罚格子'
+  const getPlayerOffset = (playerIndex: number, totalOnCell: number): { x: number; y: number } => {
+    if (totalOnCell === 1) return { x: 0, y: 0 }
+    const angle = ((2 * Math.PI) / totalOnCell) * playerIndex - Math.PI / 2
+    const radius = 14
+    return { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius }
   }
 
   const handleCellClick = (cell: BoardCell) => {
     emit('cellClick', cell)
   }
 
-  const showTooltip = (cell: BoardCell, event: MouseEvent) => {
+  const handleDiceRoll = () => {
+    emit('roll')
+  }
+
+  const showTooltip = (cell: BoardCell, event: MouseEvent | TouchEvent) => {
     tooltipCell.value = cell
     tooltipVisible.value = true
 
-    // 计算浮窗位置
-    const rect = (event.target as HTMLElement).getBoundingClientRect()
-    const tooltipWidth = 250 // 预估浮窗宽度
-    const tooltipHeight = 150 // 预估浮窗高度
+    const target = event.target as HTMLElement
+    const rect = target.getBoundingClientRect()
+    const tooltipWidth = 220
+    const tooltipHeight = 120
 
     let left = rect.left + rect.width / 2 - tooltipWidth / 2
-    let top = rect.top - tooltipHeight - 10
+    let top = rect.top - tooltipHeight - 8
 
-    // 确保浮窗不超出屏幕边界
-    if (left < 10) left = 10
-    if (left + tooltipWidth > window.innerWidth - 10) {
-      left = window.innerWidth - tooltipWidth - 10
-    }
-    if (top < 10) {
-      top = rect.bottom + 10
-    }
+    if (left < 8) left = 8
+    if (left + tooltipWidth > window.innerWidth - 8) left = window.innerWidth - tooltipWidth - 8
+    if (top < 8) top = rect.bottom + 8
 
-    tooltipStyle.value = {
-      left: `${left}px`,
-      top: `${top}px`,
-    }
+    tooltipStyle.value = { left: `${left}px`, top: `${top}px` }
   }
 
   const hideTooltip = () => {
     tooltipVisible.value = false
     tooltipCell.value = null
   }
+
+  // Animation: trigger cell activation pulse
+  const triggerCellActivation = (position: number) => {
+    activatedCell.value = position
+    setTimeout(() => {
+      activatedCell.value = null
+    }, 1500)
+  }
+
+  // Animation: trigger landing effect
+  const triggerLanding = (position: number) => {
+    landingCell.value = position
+    setTimeout(() => {
+      landingCell.value = null
+    }, 800)
+  }
+
+  watch(
+    () => props.players.map(p => p.position),
+    (newPositions, oldPositions) => {
+      if (!oldPositions) return
+      for (let i = 0; i < newPositions.length; i++) {
+        if (newPositions[i] !== oldPositions[i]) {
+          nextTick(() => {
+            triggerLanding(newPositions[i])
+            triggerCellActivation(newPositions[i])
+          })
+        }
+      }
+    }
+  )
+
+  const currentPlayer = computed(() => props.players[props.currentPlayerIndex])
+  const playersAtStart = computed(() => props.players.filter(p => p.position === 0))
 </script>
 
 <template>
   <div class="game-board">
-    <!-- 棋盘区域 -->
-    <div class="board-container">
-      <!-- 螺旋蛇形棋盘布局 -->
-      <div class="board-grid">
-        <div v-for="(row, rowIdx) in spiralBoard" :key="'row-' + rowIdx" class="board-row">
-          <div v-for="cellNum in row" :key="'cell-' + cellNum">
-            <template v-if="typeof cellNum === 'number' && cellNum !== null">
-              <div
-                class="board-cell"
-                :class="getCellClass(cellNum)"
-                @click="handleCellClick(getCellByPosition(cellNum))"
-                @mouseenter="showTooltip(getCellByPosition(cellNum), $event)"
-                @mouseleave="hideTooltip"
-              >
-                <div class="cell-content">
-                  <div class="cell-number">{{ cellNum }}</div>
-                  <div class="cell-icon">
-                    <component :is="getCellIcon(cellNum)" v-if="getCellIcon(cellNum)" :size="14" />
-                  </div>
-                  <div class="cell-effect">{{ getCellEffect(cellNum) }}</div>
-                </div>
-                <!-- 玩家标记 -->
-                <div
-                  v-for="(player, index) in players"
-                  v-show="player.position === cellNum"
-                  :key="`player-${player.id}`"
-                  class="player-marker"
-                  :style="{ backgroundColor: player.color }"
-                  :class="{
-                    'current-player': index === currentPlayerIndex,
-                    'player-moving': player.isMoving,
-                  }"
-                >
-                  {{ player.name.charAt(0) }}
-                </div>
-              </div>
-            </template>
-          </div>
-        </div>
-      </div>
-
-      <!-- 起始位置 -->
-      <div class="start-position">
+    <div class="board-ring">
+      <!-- Top edge -->
+      <div class="ring-edge ring-top">
         <div
-          class="start-cell"
-          @mouseenter="showTooltip(getCellByPosition(0), $event)"
+          v-for="pos in ringLayout.top"
+          :key="'t-' + pos"
+          class="board-cell"
+          :class="getCellClass(pos)"
+          @click="handleCellClick(getCellByPosition(pos))"
+          @mouseenter="showTooltip(getCellByPosition(pos), $event)"
           @mouseleave="hideTooltip"
         >
-          <div class="cell-content">
-            <div class="cell-number">START</div>
-            <div class="cell-icon">
-              <Rocket :size="20" />
-            </div>
+          <div class="cell-glow"></div>
+          <div class="cell-icon">
+            <component :is="getCellIcon(pos)" v-if="getCellIcon(pos)" :size="20" />
           </div>
-          <!-- 玩家标记 -->
-          <div
-            v-for="(player, index) in players"
-            v-show="player.position === 0"
-            :key="`player-${player.id}`"
-            class="player-marker"
-            :style="{ backgroundColor: player.color }"
-            :class="{
-              'current-player': index === currentPlayerIndex,
-              'player-moving': player.isMoving,
-            }"
-          >
-            {{ player.name.charAt(0) }}
+          <span class="cell-number">{{ pos }}</span>
+          <!-- Player markers -->
+          <div class="cell-players">
+            <div
+              v-for="(player, pIdx) in getPlayersOnCell(pos)"
+              :key="'p-' + player.id"
+              class="player-marker"
+              :class="{
+                'current-player': player.id === currentPlayer?.id,
+                'player-moving': player.isMoving,
+              }"
+              :style="{
+                backgroundColor: player.color,
+                transform: `translate(${getPlayerOffset(pIdx, getPlayersOnCell(pos).length).x}px, ${getPlayerOffset(pIdx, getPlayersOnCell(pos).length).y}px)`,
+              }"
+            >
+              {{ player.name.charAt(0) }}
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <!-- 效果显示 -->
-    <div v-if="lastEffect" class="effect-display">
-      <div class="effect-content">
-        <span class="effect-icon"><Sparkles :size="16" /></span>
-        <span class="effect-text">{{ lastEffect }}</span>
+      <!-- Right edge -->
+      <div class="ring-edge ring-right">
+        <div
+          v-for="pos in ringLayout.right"
+          :key="'r-' + pos"
+          class="board-cell"
+          :class="getCellClass(pos)"
+          @click="handleCellClick(getCellByPosition(pos))"
+          @mouseenter="showTooltip(getCellByPosition(pos), $event)"
+          @mouseleave="hideTooltip"
+        >
+          <div class="cell-glow"></div>
+          <div class="cell-icon">
+            <component :is="getCellIcon(pos)" v-if="getCellIcon(pos)" :size="20" />
+          </div>
+          <span class="cell-number">{{ pos }}</span>
+          <div class="cell-players">
+            <div
+              v-for="(player, pIdx) in getPlayersOnCell(pos)"
+              :key="'p-' + player.id"
+              class="player-marker"
+              :class="{
+                'current-player': player.id === currentPlayer?.id,
+                'player-moving': player.isMoving,
+              }"
+              :style="{
+                backgroundColor: player.color,
+                transform: `translate(${getPlayerOffset(pIdx, getPlayersOnCell(pos).length).x}px, ${getPlayerOffset(pIdx, getPlayersOnCell(pos).length).y}px)`,
+              }"
+            >
+              {{ player.name.charAt(0) }}
+            </div>
+          </div>
+        </div>
       </div>
+
+      <!-- Center area -->
+      <div class="ring-center">
+        <div class="center-dice">
+          <CoolDice
+            :can-roll="canRoll ?? false"
+            :value="diceValue ?? null"
+            @roll="handleDiceRoll"
+          />
+        </div>
+        <div v-if="currentPlayer" class="center-status">
+          <div class="status-player">
+            <span class="status-avatar" :style="{ backgroundColor: currentPlayer.color }">
+              {{ currentPlayer.name.charAt(0) }}
+            </span>
+            <span class="status-name">{{ currentPlayer.name }}</span>
+          </div>
+          <div class="status-position">
+            {{ currentPlayer.position === 0 ? '等待起飞' : `第 ${currentPlayer.position} 格` }}
+          </div>
+        </div>
+        <!-- Players at position 0 (waiting to take off) -->
+        <div v-if="playersAtStart.length > 0" class="start-zone">
+          <Rocket :size="14" class="start-zone-icon" />
+          <div class="start-zone-players">
+            <div
+              v-for="player in playersAtStart"
+              :key="'start-' + player.id"
+              class="player-marker start-marker"
+              :class="{ 'current-player': player.id === currentPlayer?.id }"
+              :style="{ backgroundColor: player.color }"
+            >
+              {{ player.name.charAt(0) }}
+            </div>
+          </div>
+        </div>
+        <div v-if="lastEffect" class="center-effect">
+          <Sparkles :size="14" />
+          <span>{{ lastEffect }}</span>
+        </div>
+      </div>
+
+      <!-- Bottom edge -->
+      <div class="ring-edge ring-bottom">
+        <div
+          v-for="pos in ringLayout.bottom"
+          :key="'b-' + pos"
+          class="board-cell"
+          :class="getCellClass(pos)"
+          @click="handleCellClick(getCellByPosition(pos))"
+          @mouseenter="showTooltip(getCellByPosition(pos), $event)"
+          @mouseleave="hideTooltip"
+        >
+          <div class="cell-glow"></div>
+          <div class="cell-icon">
+            <component :is="getCellIcon(pos)" v-if="getCellIcon(pos)" :size="20" />
+          </div>
+          <span class="cell-number">{{ pos }}</span>
+          <div class="cell-players">
+            <div
+              v-for="(player, pIdx) in getPlayersOnCell(pos)"
+              :key="'p-' + player.id"
+              class="player-marker"
+              :class="{
+                'current-player': player.id === currentPlayer?.id,
+                'player-moving': player.isMoving,
+              }"
+              :style="{
+                backgroundColor: player.color,
+                transform: `translate(${getPlayerOffset(pIdx, getPlayersOnCell(pos).length).x}px, ${getPlayerOffset(pIdx, getPlayersOnCell(pos).length).y}px)`,
+              }"
+            >
+              {{ player.name.charAt(0) }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Left edge -->
+      <div class="ring-edge ring-left">
+        <div
+          v-for="pos in ringLayout.left"
+          :key="'l-' + pos"
+          class="board-cell"
+          :class="getCellClass(pos)"
+          @click="handleCellClick(getCellByPosition(pos))"
+          @mouseenter="showTooltip(getCellByPosition(pos), $event)"
+          @mouseleave="hideTooltip"
+        >
+          <div class="cell-glow"></div>
+          <div class="cell-icon">
+            <component :is="getCellIcon(pos)" v-if="getCellIcon(pos)" :size="20" />
+          </div>
+          <span class="cell-number">{{ pos }}</span>
+          <div class="cell-players">
+            <div
+              v-for="(player, pIdx) in getPlayersOnCell(pos)"
+              :key="'p-' + player.id"
+              class="player-marker"
+              :class="{
+                'current-player': player.id === currentPlayer?.id,
+                'player-moving': player.isMoving,
+              }"
+              :style="{
+                backgroundColor: player.color,
+                transform: `translate(${getPlayerOffset(pIdx, getPlayersOnCell(pos).length).x}px, ${getPlayerOffset(pIdx, getPlayersOnCell(pos).length).y}px)`,
+              }"
+            >
+              {{ player.name.charAt(0) }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Corner connectors for visual flow -->
+      <div class="corner corner-tr"></div>
+      <div class="corner corner-br"></div>
+      <div class="corner corner-bl"></div>
+      <div class="corner corner-tl"></div>
     </div>
 
-    <!-- 浮窗提示 -->
-    <div v-if="tooltipVisible" class="cell-tooltip" :style="tooltipStyle">
-      <div class="tooltip-content">
+    <!-- Tooltip -->
+    <Teleport to="body">
+      <div v-if="tooltipVisible && tooltipCell" class="cell-tooltip" :style="tooltipStyle">
         <div class="tooltip-header">
-          <span class="tooltip-number">{{ tooltipCell?.position || 0 }}</span>
-          <span class="tooltip-type">{{ getCellTypeName(tooltipCell?.type || 'punishment') }}</span>
+          <span class="tooltip-number">#{{ tooltipCell.position }}</span>
+          <span class="tooltip-type" :class="'type-' + tooltipCell.type">
+            {{ getCellTypeName(tooltipCell.type) }}
+          </span>
         </div>
         <div class="tooltip-body">
-          <div v-if="tooltipCell?.effect" class="tooltip-effect">
-            <div v-if="tooltipCell.effect.type !== 'trap'" class="effect-title">
-              {{ tooltipCell.effect.description }}
-            </div>
+          <template v-if="tooltipCell.effect">
+            <div class="tooltip-desc">{{ tooltipCell.effect.description }}</div>
             <div
               v-if="tooltipCell.effect.type === 'punishment' && tooltipCell.effect.punishment"
-              class="punishment-details"
+              class="tooltip-details"
             >
-              <div class="detail-item">
-                <span class="detail-label">工具：</span>
-                <span class="detail-value">{{ tooltipCell.effect.punishment.tool.name }}</span>
-              </div>
-              <div class="detail-item">
-                <span class="detail-label">部位：</span>
-                <span class="detail-value">{{ tooltipCell.effect.punishment.bodyPart.name }}</span>
-              </div>
-              <div class="detail-item">
-                <span class="detail-label">姿势：</span>
-                <span class="detail-value">{{ tooltipCell.effect.punishment.position.name }}</span>
-              </div>
+              <span>{{ tooltipCell.effect.punishment.tool.name }}</span>
+              <span>{{ tooltipCell.effect.punishment.bodyPart.name }}</span>
+              <span>{{ tooltipCell.effect.punishment.position.name }}</span>
             </div>
-            <div v-else-if="tooltipCell.effect.type === 'move'" class="move-details">
-              <div class="detail-item">
-                <span class="detail-label">移动：</span>
-                <span class="detail-value">
-                  {{ tooltipCell.effect.value > 0 ? '+' : '' }}{{ tooltipCell.effect.value }}步
-                </span>
-              </div>
+            <div v-else-if="tooltipCell.effect.type === 'move'" class="tooltip-details">
+              <span>
+                移动 {{ tooltipCell.effect.value > 0 ? '+' : '' }}{{ tooltipCell.effect.value }} 步
+              </span>
             </div>
-            <div v-else-if="tooltipCell.effect.type === 'rest'" class="rest-details">
-              <div class="detail-item">
-                <span class="detail-label">休息：</span>
-                <span class="detail-value">{{ tooltipCell.effect.value }}回合</span>
-              </div>
+            <div v-else-if="tooltipCell.effect.type === 'rest'" class="tooltip-details">
+              <span>休息 {{ tooltipCell.effect.value }} 回合</span>
             </div>
-            <div v-else-if="tooltipCell.effect.type === 'reverse'" class="reverse-details">
-              <div class="detail-item">
-                <span class="detail-label">后退：</span>
-                <span class="detail-value">{{ tooltipCell.effect.value }}步</span>
-              </div>
+            <div v-else-if="tooltipCell.effect.type === 'reverse'" class="tooltip-details">
+              <span>后退 {{ tooltipCell.effect.value }} 步</span>
             </div>
-            <div v-else-if="tooltipCell.effect.type === 'restart'" class="restart-details">
-              <div class="detail-item">
-                <span class="detail-label">回到起点</span>
-              </div>
+            <div v-else-if="tooltipCell.effect.type === 'restart'" class="tooltip-details">
+              <span>回到起点</span>
             </div>
-            <div v-else-if="tooltipCell.effect.type === 'trap'" class="trap-details">
-              <div class="detail-item">
-                <span class="detail-label">⚠️ 警告：</span>
-                <span class="detail-value">每次惩罚都不一样！</span>
-              </div>
-              <div class="detail-item">
-                <span class="detail-label">💀 特点：</span>
-                <span class="detail-value">随机生成惩罚内容</span>
-              </div>
+            <div v-else-if="tooltipCell.effect.type === 'trap'" class="tooltip-details">
+              <span>随机惩罚</span>
             </div>
-          </div>
-          <div v-else class="tooltip-normal">
-            <div class="normal-text">普通格子，无特殊效果</div>
-          </div>
+          </template>
         </div>
       </div>
-    </div>
+    </Teleport>
+
+    <!-- Full-screen effect flash -->
+    <Transition name="flash">
+      <div
+        v-if="activatedCell !== null"
+        class="effect-flash"
+        :class="'flash-' + getCellByPosition(activatedCell).type"
+      ></div>
+    </Transition>
   </div>
 </template>
 
 <style scoped>
   .game-board {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
-    padding: 1rem;
-  }
-
-  .board-container {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
-  }
-
-  .board-grid {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
-    padding: 1rem;
-    background: var(--bg-surface);
-    border-radius: var(--radius-lg);
-    border: var(--glass-border);
-    box-shadow: var(--glass-shadow);
-  }
-
-  .board-row {
-    display: flex;
-    gap: 0.6rem;
-  }
-
-  .board-cell {
-    position: relative;
-    width: 70px;
-    height: 70px;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all var(--transition-fast);
+    width: 100%;
+    height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--bg-glass);
-    backdrop-filter: blur(8px);
-    border: var(--glass-border);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    padding: 1rem;
+    position: relative;
+  }
+
+  /* === Ring Layout === */
+  .board-ring {
+    display: grid;
+    grid-template-areas:
+      '.    top    .'
+      'left center right'
+      '.    bottom .';
+    grid-template-columns: auto 1fr auto;
+    grid-template-rows: auto 1fr auto;
+    gap: 0;
+    width: 100%;
+    max-width: 800px;
+    aspect-ratio: 1.4 / 1;
+    position: relative;
+  }
+
+  .ring-edge {
+    display: flex;
+    gap: 4px;
+    padding: 2px;
+  }
+
+  .ring-top {
+    grid-area: top;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .ring-right {
+    grid-area: right;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  .ring-bottom {
+    grid-area: bottom;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .ring-left {
+    grid-area: left;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  .ring-center {
+    grid-area: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 1rem;
+    min-height: 200px;
+  }
+
+  /* === Corner Connectors === */
+  .corner {
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(102, 126, 234, 0.4), transparent);
+  }
+  .corner-tr {
+    top: 0;
+    right: 0;
+  }
+  .corner-br {
+    bottom: 0;
+    right: 0;
+  }
+  .corner-bl {
+    bottom: 0;
+    left: 0;
+  }
+  .corner-tl {
+    top: 0;
+    left: 0;
+  }
+
+  /* === Cell Design === */
+  .board-cell {
+    position: relative;
+    width: 56px;
+    height: 56px;
+    border-radius: 12px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: rgba(15, 15, 35, 0.8);
+    border: 2px solid rgba(255, 255, 255, 0.08);
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease,
+      border-color 0.2s ease;
+    flex-shrink: 0;
+    overflow: visible;
   }
 
   .board-cell:hover {
-    background: var(--bg-glass-hover);
-    transform: translateY(-2px);
-    box-shadow: var(--glow-sm) rgba(255, 255, 255, 0.1);
+    transform: scale(1.12);
+    z-index: 5;
   }
 
-  .cell-content {
+  .board-cell .cell-glow {
+    position: absolute;
+    inset: -2px;
+    border-radius: 14px;
+    opacity: 0.4;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+  }
+
+  .board-cell:hover .cell-glow {
+    opacity: 0.8;
+  }
+
+  .board-cell .cell-icon {
     display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
-    width: 100%;
-    height: 100%;
-    padding: 0.25rem;
-    text-align: center;
+    z-index: 2;
   }
 
-  .cell-number {
-    font-size: 0.65rem;
+  .board-cell .cell-number {
+    position: absolute;
+    bottom: 2px;
+    right: 4px;
+    font-size: 0.55rem;
     font-weight: 600;
-    color: var(--text-muted);
-    margin-bottom: 0.1rem;
+    opacity: 0.4;
+    z-index: 2;
   }
 
-  .cell-icon {
-    color: var(--text-secondary);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 0.1rem;
-  }
-
-  .cell-effect {
-    font-size: 0.45rem;
-    color: var(--text-muted);
-    line-height: 1;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  /* Type-specific: colored left border + tinted icon */
+  /* Cell type styles */
   .cell-punishment {
-    border-left: 3px solid var(--color-punishment);
+    border-color: rgba(255, 71, 87, 0.4);
+    box-shadow: 0 0 8px rgba(255, 71, 87, 0.15);
+  }
+  .cell-punishment .cell-glow {
+    background: radial-gradient(circle, rgba(255, 71, 87, 0.3), transparent 70%);
   }
   .cell-punishment .cell-icon {
-    color: var(--color-punishment);
+    color: #ff4757;
   }
-
-  .cell-bonus {
-    border-left: 3px solid var(--color-bonus);
-  }
-  .cell-bonus .cell-icon {
-    color: var(--color-bonus);
-  }
-
-  .cell-special {
-    border-left: 3px solid var(--color-special);
-  }
-  .cell-special .cell-icon {
-    color: var(--color-special);
-  }
-
-  .cell-restart {
-    border-left: 3px solid var(--color-restart);
-  }
-  .cell-restart .cell-icon {
-    color: var(--color-restart);
+  .cell-punishment:hover {
+    border-color: rgba(255, 71, 87, 0.7);
+    box-shadow: 0 0 16px rgba(255, 71, 87, 0.4);
   }
 
   .cell-chain_punishment {
-    border-left: 3px solid var(--color-chain-punishment);
+    border-color: rgba(255, 165, 2, 0.4);
+    box-shadow: 0 0 8px rgba(255, 165, 2, 0.15);
+  }
+  .cell-chain_punishment .cell-glow {
+    background: radial-gradient(circle, rgba(255, 165, 2, 0.3), transparent 70%);
   }
   .cell-chain_punishment .cell-icon {
-    color: var(--color-chain-punishment);
+    color: #ffa502;
+  }
+  .cell-chain_punishment:hover {
+    border-color: rgba(255, 165, 2, 0.7);
+    box-shadow: 0 0 16px rgba(255, 165, 2, 0.4);
+  }
+
+  .cell-bonus {
+    border-color: rgba(46, 213, 115, 0.4);
+    box-shadow: 0 0 8px rgba(46, 213, 115, 0.15);
+  }
+  .cell-bonus .cell-glow {
+    background: radial-gradient(circle, rgba(46, 213, 115, 0.3), transparent 70%);
+  }
+  .cell-bonus .cell-icon {
+    color: #2ed573;
+  }
+  .cell-bonus:hover {
+    border-color: rgba(46, 213, 115, 0.7);
+    box-shadow: 0 0 16px rgba(46, 213, 115, 0.4);
+  }
+
+  .cell-special {
+    border-color: rgba(255, 165, 2, 0.4);
+    box-shadow: 0 0 8px rgba(255, 165, 2, 0.15);
+  }
+  .cell-special .cell-glow {
+    background: radial-gradient(circle, rgba(255, 165, 2, 0.3), transparent 70%);
+  }
+  .cell-special .cell-icon {
+    color: #ffa502;
+  }
+  .cell-special:hover {
+    border-color: rgba(255, 165, 2, 0.7);
+    box-shadow: 0 0 16px rgba(255, 165, 2, 0.4);
+  }
+
+  .cell-restart {
+    border-color: rgba(168, 85, 247, 0.4);
+    box-shadow: 0 0 8px rgba(168, 85, 247, 0.15);
+  }
+  .cell-restart .cell-glow {
+    background: radial-gradient(circle, rgba(168, 85, 247, 0.3), transparent 70%);
+  }
+  .cell-restart .cell-icon {
+    color: #a855f7;
+  }
+  .cell-restart:hover {
+    border-color: rgba(168, 85, 247, 0.7);
+    box-shadow: 0 0 16px rgba(168, 85, 247, 0.4);
   }
 
   .cell-trap {
-    border-left: 3px solid var(--color-trap);
+    border-color: rgba(220, 38, 38, 0.4);
+    box-shadow: 0 0 8px rgba(220, 38, 38, 0.15);
+  }
+  .cell-trap .cell-glow {
+    background: radial-gradient(circle, rgba(220, 38, 38, 0.3), transparent 70%);
   }
   .cell-trap .cell-icon {
-    color: var(--color-trap);
+    color: #dc2626;
+  }
+  .cell-trap:hover {
+    border-color: rgba(220, 38, 38, 0.7);
+    box-shadow: 0 0 16px rgba(220, 38, 38, 0.4);
+  }
+
+  .cell-start {
+    border-color: rgba(102, 126, 234, 0.6);
+    box-shadow: 0 0 12px rgba(102, 126, 234, 0.3);
+    background: rgba(102, 126, 234, 0.1);
   }
 
   .cell-occupied {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.3);
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.2);
   }
 
-  /* 玩家标记 */
-  .player-marker {
+  /* === Cell Animations === */
+  .cell-activated {
+    animation: cellPulse 0.5s ease-out 3;
+  }
+
+  .cell-landing {
+    animation: cellLand 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+
+  @keyframes cellPulse {
+    0%,
+    100% {
+      box-shadow: 0 0 8px currentColor;
+    }
+    50% {
+      box-shadow:
+        0 0 24px currentColor,
+        0 0 48px currentColor;
+    }
+  }
+
+  @keyframes cellLand {
+    0% {
+      transform: scale(1);
+    }
+    40% {
+      transform: scale(1.2);
+    }
+    70% {
+      transform: scale(0.95);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+
+  /* Ripple effect on landing */
+  .cell-landing::after {
+    content: '';
     position: absolute;
-    top: 50%;
+    inset: -4px;
+    border-radius: 16px;
+    border: 2px solid rgba(255, 255, 255, 0.5);
+    animation: ripple 0.8s ease-out forwards;
+    pointer-events: none;
+  }
+
+  @keyframes ripple {
+    0% {
+      transform: scale(1);
+      opacity: 1;
+    }
+    100% {
+      transform: scale(1.6);
+      opacity: 0;
+    }
+  }
+
+  /* === Player Markers === */
+  .cell-players {
+    position: absolute;
+    top: -12px;
     left: 50%;
-    transform: translate(-50%, -50%);
-    width: 26px;
-    height: 26px;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+    pointer-events: none;
+  }
+
+  .player-marker {
+    width: 24px;
+    height: 24px;
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     color: white;
     font-weight: 700;
-    font-size: 11px;
-    border: 2px solid rgba(255, 255, 255, 0.6);
-    box-shadow: var(--glow-md) currentColor;
-    transition: all var(--transition-normal);
-    z-index: 10;
+    font-size: 10px;
+    border: 2px solid rgba(255, 255, 255, 0.7);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
     text-transform: uppercase;
+    position: absolute;
+    transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
   }
 
   .player-marker.current-player {
-    border-color: rgba(255, 255, 255, 0.9);
+    border-color: #ffd700;
     box-shadow:
-      0 0 12px rgba(255, 215, 0, 0.6),
-      0 0 24px rgba(255, 215, 0, 0.3);
-    animation: pulseGlow 2s ease-in-out infinite;
+      0 0 8px rgba(255, 215, 0, 0.6),
+      0 0 20px rgba(255, 215, 0, 0.3);
+    animation: playerPulse 2s ease-in-out infinite;
   }
 
   .player-marker.player-moving {
-    animation: moveAnimation 0.6s ease-in-out;
-    transform: translate(-50%, -50%) scale(1.2);
+    animation: playerBounce 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
   }
 
-  @keyframes pulseGlow {
+  @keyframes playerPulse {
     0%,
     100% {
       box-shadow:
-        0 0 12px rgba(255, 215, 0, 0.6),
-        0 0 24px rgba(255, 215, 0, 0.3);
+        0 0 8px rgba(255, 215, 0, 0.6),
+        0 0 20px rgba(255, 215, 0, 0.3);
+      transform: translateY(-2px);
     }
     50% {
       box-shadow:
-        0 0 20px rgba(255, 215, 0, 0.8),
-        0 0 40px rgba(255, 215, 0, 0.4);
+        0 0 14px rgba(255, 215, 0, 0.8),
+        0 0 32px rgba(255, 215, 0, 0.4);
+      transform: translateY(-5px);
     }
   }
 
-  @keyframes moveAnimation {
+  @keyframes playerBounce {
     0% {
-      transform: translate(-50%, -50%) scale(1);
+      transform: translateY(0) scale(1);
     }
-    50% {
-      transform: translate(-50%, -50%) scale(1.3);
+    30% {
+      transform: translateY(-10px) scale(1.1);
+    }
+    60% {
+      transform: translateY(-3px) scale(0.95);
     }
     100% {
-      transform: translate(-50%, -50%) scale(1);
+      transform: translateY(0) scale(1);
     }
   }
 
-  /* 起始位置 */
-  .start-position {
-    position: absolute;
-    top: -40px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 10;
+  /* === Center Area === */
+  .center-dice {
+    transform: scale(0.75);
+    transform-origin: center;
   }
 
-  .start-cell {
-    width: 80px;
-    height: 80px;
-    border-radius: var(--radius-md);
-    background: var(--bg-glass);
-    border: 2px solid var(--color-accent);
+  .center-status {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
-    color: var(--text-primary);
-    font-weight: bold;
-    box-shadow: var(--glow-md) rgba(102, 126, 234, 0.3);
+    gap: 0.25rem;
+    padding: 0.5rem 1rem;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
   }
 
-  .start-cell .cell-content {
-    text-align: center;
-  }
-
-  .start-cell .cell-number {
-    font-size: 0.8rem;
-    color: var(--color-accent-light);
-    margin-bottom: 0.2rem;
-  }
-
-  .start-cell .cell-icon {
-    color: var(--color-accent);
-  }
-
-  /* 效果显示 */
-  .effect-display {
-    position: fixed;
-    top: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: rgba(20, 20, 40, 0.9);
-    backdrop-filter: blur(var(--glass-blur));
-    border: var(--glass-border);
-    color: var(--text-primary);
-    padding: 0.75rem 1.5rem;
-    border-radius: var(--radius-md);
-    box-shadow: var(--glass-shadow);
-    z-index: 1000;
-    animation: slideDown 0.5s ease-out;
-  }
-
-  .effect-content {
+  .status-player {
     display: flex;
     align-items: center;
     gap: 0.5rem;
   }
 
-  .effect-icon {
+  .status-avatar {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
     display: flex;
     align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: 700;
+    font-size: 9px;
+    text-transform: uppercase;
+  }
+
+  .status-name {
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--text-primary);
+  }
+
+  .status-position {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+  }
+
+  .start-zone {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.8rem;
+    background: rgba(102, 126, 234, 0.08);
+    border: 1px dashed rgba(102, 126, 234, 0.3);
+    border-radius: 8px;
+  }
+
+  .start-zone-icon {
     color: var(--color-accent-light);
+    opacity: 0.6;
   }
 
-  .effect-text {
-    font-weight: bold;
-  }
-
-  /* 动画 */
-  @keyframes slideDown {
-    from {
-      transform: translateX(-50%) translateY(-100%);
-      opacity: 0;
-    }
-    to {
-      transform: translateX(-50%) translateY(0);
-      opacity: 1;
-    }
-  }
-
-  /* 响应式设计 */
-  @media (max-width: 1023px) {
-    .game-board {
-      padding: clamp(0.25rem, 1vw, 0.5rem);
-    }
-    .board-container {
-      max-width: 100%;
-    }
-    .board-grid {
-      gap: clamp(0.25rem, 1vw, 0.5rem);
-      padding: clamp(0.25rem, 1vw, 0.5rem);
-    }
-    .board-row {
-      gap: clamp(0.15rem, 0.5vw, 0.25rem);
-    }
-    .board-cell {
-      width: clamp(48px, 12vw, 60px);
-      height: clamp(48px, 12vw, 60px);
-      font-size: clamp(0.7rem, 2vw, 0.9rem);
-    }
-    .cell-number {
-      font-size: clamp(0.6rem, 1.5vw, 0.7rem);
-      font-weight: bold;
-    }
-    .cell-icon {
-      font-size: clamp(0.9rem, 2.5vw, 1.1rem);
-    }
-    .cell-effect {
-      font-size: clamp(0.5rem, 1.5vw, 0.7rem);
-    }
-    .player-marker {
-      width: clamp(1.5rem, 4vw, 2rem);
-      height: clamp(1.5rem, 4vw, 2rem);
-      font-size: clamp(0.8rem, 2vw, 1rem);
-      border: 1px solid rgba(255, 255, 255, 0.5);
-    }
-    .start-cell {
-      width: clamp(65px, 16vw, 80px);
-      height: clamp(65px, 16vw, 80px);
-    }
-    .start-cell .cell-number {
-      font-size: clamp(0.7rem, 2vw, 0.9rem);
-    }
-    .start-cell .cell-icon {
-      font-size: clamp(1.3rem, 3vw, 1.6rem);
-    }
-  }
-
-  /* 移动端优化 - 更紧凑的布局 */
-  @media (max-width: 767px) {
-    .game-board {
-      padding: 0.25rem;
-      gap: 0.5rem;
-    }
-    .board-container {
-      gap: 0.5rem;
-    }
-    .board-grid {
-      gap: 0.25rem;
-      padding: 0.5rem;
-      border-radius: 12px;
-    }
-    .board-row {
-      gap: 0.15rem;
-    }
-    .board-cell {
-      width: clamp(38px, 10vw, 48px);
-      height: clamp(38px, 10vw, 48px);
-      border-radius: 8px;
-      touch-action: manipulation;
-      -webkit-tap-highlight-color: transparent;
-    }
-    .cell-content {
-      padding: 0.15rem;
-    }
-    .cell-number {
-      font-size: clamp(0.6rem, 1.5vw, 0.7rem);
-      margin-bottom: 0.05rem;
-    }
-    .cell-icon {
-      font-size: clamp(0.9rem, 2.5vw, 1.1rem);
-      margin-bottom: 0.05rem;
-    }
-    .cell-effect {
-      font-size: clamp(0.5rem, 1.5vw, 0.7rem);
-      line-height: 1;
-    }
-    .player-marker {
-      width: clamp(1.2rem, 3vw, 1.5rem);
-      height: clamp(1.2rem, 3vw, 1.5rem);
-      font-size: clamp(0.7rem, 1.8vw, 0.9rem);
-      border-width: 1px;
-      border-color: rgba(255, 255, 255, 0.5);
-    }
-    .start-cell {
-      width: clamp(55px, 14vw, 65px);
-      height: clamp(55px, 14vw, 65px);
-      border-radius: 10px;
-      border-width: 2px;
-    }
-    .start-cell .cell-number {
-      font-size: clamp(0.7rem, 2vw, 0.9rem);
-    }
-    .start-cell .cell-icon {
-      font-size: clamp(1.1rem, 3vw, 1.3rem);
-    }
-    .start-position {
-      top: -30px;
-    }
-  }
-
-  /* 小屏手机优化 */
-  @media (max-width: 480px) {
-    .game-board {
-      padding: 0.15rem;
-      gap: 0.25rem;
-    }
-    .board-grid {
-      gap: 0.15rem;
-      padding: 0.25rem;
-    }
-    .board-row {
-      gap: 0.1rem;
-    }
-    .board-cell {
-      width: clamp(32px, 8vw, 38px);
-      height: clamp(32px, 8vw, 38px);
-      border-radius: 6px;
-    }
-    .cell-content {
-      padding: 0.1rem;
-    }
-    .cell-number {
-      font-size: clamp(0.5rem, 1.2vw, 0.6rem);
-    }
-    .cell-icon {
-      font-size: clamp(0.7rem, 2vw, 0.9rem);
-    }
-    .cell-effect {
-      font-size: clamp(0.4rem, 1vw, 0.5rem);
-    }
-    .player-marker {
-      width: clamp(1rem, 2.5vw, 1.2rem);
-      height: clamp(1rem, 2.5vw, 1.2rem);
-      font-size: clamp(0.6rem, 1.5vw, 0.8rem);
-    }
-    .start-cell {
-      width: clamp(45px, 11vw, 55px);
-      height: clamp(45px, 11vw, 55px);
-    }
-    .start-cell .cell-number {
-      font-size: clamp(0.6rem, 1.5vw, 0.7rem);
-    }
-    .start-cell .cell-icon {
-      font-size: clamp(0.9rem, 2vw, 1.1rem);
-    }
-    .start-position {
-      top: -25px;
-    }
-  }
-
-  /* 超小屏手机优化 */
-  @media (max-width: 360px) {
-    .board-cell {
-      width: clamp(26px, 6vw, 32px);
-      height: clamp(26px, 6vw, 32px);
-    }
-    .cell-number {
-      font-size: clamp(0.4rem, 1vw, 0.5rem);
-    }
-    .cell-icon {
-      font-size: clamp(0.6rem, 1.5vw, 0.7rem);
-    }
-    .cell-effect {
-      font-size: clamp(0.3rem, 0.8vw, 0.4rem);
-    }
-    .player-marker {
-      width: clamp(0.8rem, 2vw, 1rem);
-      height: clamp(0.8rem, 2vw, 1rem);
-      font-size: clamp(0.5rem, 1vw, 0.6rem);
-    }
-    .start-cell {
-      width: clamp(35px, 9vw, 40px);
-      height: clamp(35px, 9vw, 40px);
-    }
-  }
-
-  /* 横屏模式优化 */
-  @media (max-width: 767px) and (orientation: landscape) {
-    .game-board {
-      padding: 0.15rem;
-      gap: 0.25rem;
-    }
-
-    .board-grid {
-      gap: 0.15rem;
-      padding: 0.25rem;
-    }
-
-    .board-cell {
-      width: clamp(22px, 5.5vw, 28px);
-      height: clamp(22px, 5.5vw, 28px);
-    }
-
-    .start-cell {
-      width: clamp(35px, 8vw, 40px);
-      height: clamp(35px, 8vw, 40px);
-    }
-  }
-
-  /* 浮窗样式 */
-  .cell-tooltip {
-    position: fixed;
-    z-index: 10000;
-    background: rgba(20, 20, 40, 0.95);
-    backdrop-filter: blur(var(--glass-blur));
-    border: var(--glass-border);
-    border-radius: var(--radius-md);
-    box-shadow: var(--glass-shadow-lg);
-    max-width: 280px;
-    min-width: 200px;
-    pointer-events: none;
-    animation: tooltipFadeIn 0.2s ease-out;
-  }
-
-  .tooltip-content {
-    padding: 1rem;
-  }
-
-  .tooltip-header {
+  .start-zone-players {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.75rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    gap: 0.3rem;
   }
 
-  .tooltip-number {
-    font-size: 1.2rem;
-    font-weight: bold;
-    color: var(--text-primary);
+  .start-marker {
+    position: static !important;
+    transform: none !important;
   }
 
-  .tooltip-type {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    background: var(--bg-glass);
-    padding: 0.2rem 0.5rem;
-    border-radius: 12px;
-  }
-
-  .tooltip-body {
-    font-size: 0.9rem;
-  }
-
-  .tooltip-effect {
-    color: var(--text-primary);
-  }
-
-  .effect-title {
-    font-weight: bold;
-    margin-bottom: 0.5rem;
-    color: var(--text-primary);
-  }
-
-  .punishment-details,
-  .move-details,
-  .rest-details,
-  .reverse-details,
-  .restart-details,
-  .trap-details {
-    background: var(--bg-glass);
-    border-radius: var(--radius-sm);
-    padding: 0.75rem;
-    margin-top: 0.5rem;
-  }
-
-  .detail-item {
+  .center-effect {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    margin-bottom: 0.25rem;
-  }
-
-  .detail-item:last-child {
-    margin-bottom: 0;
-  }
-
-  .detail-label {
-    font-weight: 500;
-    color: var(--text-muted);
-    min-width: 40px;
-  }
-
-  .detail-value {
-    font-weight: bold;
-    color: var(--text-primary);
-    text-align: right;
-  }
-
-  .tooltip-normal {
+    gap: 0.4rem;
+    padding: 0.4rem 0.8rem;
+    background: rgba(102, 126, 234, 0.15);
+    border: 1px solid rgba(102, 126, 234, 0.3);
+    border-radius: 8px;
+    font-size: 0.75rem;
+    color: var(--color-accent-light);
+    animation: effectSlideIn 0.4s ease-out;
+    max-width: 200px;
     text-align: center;
-    color: var(--text-muted);
-    font-style: italic;
   }
 
-  .normal-text {
-    padding: 0.5rem;
-    color: var(--text-muted);
-  }
-
-  /* 浮窗动画 */
-  @keyframes tooltipFadeIn {
+  @keyframes effectSlideIn {
     from {
       opacity: 0;
-      transform: translateY(-10px) scale(0.95);
+      transform: translateY(8px) scale(0.95);
     }
     to {
       opacity: 1;
@@ -950,298 +921,303 @@
     }
   }
 
-  /* 响应式浮窗 */
-  @media (max-width: 768px) {
-    .cell-tooltip {
-      max-width: 240px;
-      min-width: 180px;
-    }
+  /* === Tooltip === */
+  .cell-tooltip {
+    position: fixed;
+    z-index: 10000;
+    background: rgba(15, 15, 35, 0.95);
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 10px;
+    padding: 0.75rem;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    max-width: 220px;
+    pointer-events: none;
+    animation: tooltipIn 0.15s ease-out;
+  }
 
-    .tooltip-content {
-      padding: 0.75rem;
+  @keyframes tooltipIn {
+    from {
+      opacity: 0;
+      transform: translateY(-4px) scale(0.97);
     }
-
-    .tooltip-header {
-      margin-bottom: 0.5rem;
-    }
-
-    .tooltip-number {
-      font-size: 1rem;
-    }
-
-    .tooltip-type {
-      font-size: 0.7rem;
-    }
-
-    .tooltip-body {
-      font-size: 0.8rem;
-    }
-
-    .punishment-details,
-    .move-details,
-    .rest-details,
-    .reverse-details,
-    .restart-details {
-      padding: 0.5rem;
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
     }
   }
 
-  @media (max-width: 480px) {
-    .cell-tooltip {
-      max-width: 200px;
-      min-width: 160px;
-    }
-
-    .tooltip-content {
-      padding: 0.5rem;
-    }
-
-    .tooltip-number {
-      font-size: 0.9rem;
-    }
-
-    .tooltip-type {
-      font-size: 0.6rem;
-    }
-
-    .tooltip-body {
-      font-size: 0.75rem;
-    }
-
-    .detail-item {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 0.1rem;
-    }
-
-    .detail-label {
-      min-width: auto;
-    }
-
-    .detail-value {
-      text-align: left;
-    }
+  .tooltip-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   }
 
-  /* 移动端浮窗优化 */
-  @media (max-width: 767px) {
-    .cell-tooltip {
-      max-width: 180px;
-      min-width: 140px;
-    }
-
-    .tooltip-content {
-      padding: 0.5rem;
-    }
-
-    .tooltip-header {
-      margin-bottom: 0.4rem;
-      padding-bottom: 0.3rem;
-    }
-
-    .tooltip-number {
-      font-size: 0.85rem;
-    }
-
-    .tooltip-type {
-      font-size: 0.6rem;
-      padding: 0.15rem 0.4rem;
-    }
-
-    .tooltip-body {
-      font-size: 0.7rem;
-    }
-
-    .effect-title {
-      font-size: 0.75rem;
-      margin-bottom: 0.3rem;
-    }
-
-    .punishment-details,
-    .move-details,
-    .rest-details,
-    .reverse-details,
-    .restart-details {
-      padding: 0.4rem;
-      border-radius: 6px;
-      margin-top: 0.3rem;
-    }
-
-    .detail-item {
-      margin-bottom: 0.2rem;
-      gap: 0.2rem;
-    }
-
-    .detail-label {
-      font-size: 0.65rem;
-      min-width: 35px;
-    }
-
-    .detail-value {
-      font-size: 0.7rem;
-    }
+  .tooltip-number {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--text-primary);
   }
 
-  /* 小屏手机浮窗优化 */
-  @media (max-width: 480px) {
-    .cell-tooltip {
-      max-width: 160px;
-      min-width: 120px;
-    }
-
-    .tooltip-content {
-      padding: 0.4rem;
-    }
-
-    .tooltip-header {
-      margin-bottom: 0.3rem;
-      padding-bottom: 0.2rem;
-    }
-
-    .tooltip-number {
-      font-size: 0.8rem;
-    }
-
-    .tooltip-type {
-      font-size: 0.55rem;
-      padding: 0.1rem 0.3rem;
-    }
-
-    .tooltip-body {
-      font-size: 0.65rem;
-    }
-
-    .effect-title {
-      font-size: 0.7rem;
-      margin-bottom: 0.25rem;
-    }
-
-    .punishment-details,
-    .move-details,
-    .rest-details,
-    .reverse-details,
-    .restart-details {
-      padding: 0.3rem;
-      margin-top: 0.25rem;
-    }
-
-    .detail-item {
-      margin-bottom: 0.15rem;
-      gap: 0.15rem;
-    }
-
-    .detail-label {
-      font-size: 0.6rem;
-      min-width: 30px;
-    }
-
-    .detail-value {
-      font-size: 0.65rem;
-    }
+  .tooltip-type {
+    font-size: 0.65rem;
+    font-weight: 600;
+    padding: 0.15rem 0.5rem;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.06);
+  }
+  .tooltip-type.type-punishment {
+    color: #ff4757;
+  }
+  .tooltip-type.type-bonus {
+    color: #2ed573;
+  }
+  .tooltip-type.type-special {
+    color: #ffa502;
+  }
+  .tooltip-type.type-restart {
+    color: #a855f7;
+  }
+  .tooltip-type.type-trap {
+    color: #dc2626;
+  }
+  .tooltip-type.type-chain_punishment {
+    color: #ffa502;
   }
 
-  /* 超小屏手机浮窗优化 */
-  @media (max-width: 360px) {
-    .cell-tooltip {
-      max-width: 140px;
-      min-width: 100px;
-    }
-
-    .tooltip-content {
-      padding: 0.3rem;
-    }
-
-    .tooltip-number {
-      font-size: 0.75rem;
-    }
-
-    .tooltip-type {
-      font-size: 0.5rem;
-      padding: 0.1rem 0.25rem;
-    }
-
-    .tooltip-body {
-      font-size: 0.6rem;
-    }
-
-    .effect-title {
-      font-size: 0.65rem;
-      margin-bottom: 0.2rem;
-    }
-
-    .punishment-details,
-    .move-details,
-    .rest-details,
-    .reverse-details,
-    .restart-details {
-      padding: 0.25rem;
-      margin-top: 0.2rem;
-    }
-
-    .detail-item {
-      margin-bottom: 0.1rem;
-      gap: 0.1rem;
-    }
-
-    .detail-label {
-      font-size: 0.55rem;
-      min-width: 25px;
-    }
-
-    .detail-value {
-      font-size: 0.6rem;
-    }
+  .tooltip-body {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
   }
 
-  /* 横屏模式浮窗优化 */
-  @media (max-width: 767px) and (orientation: landscape) {
-    .cell-tooltip {
-      max-width: 160px;
-      min-width: 120px;
-    }
-
-    .tooltip-content {
-      padding: 0.4rem;
-    }
-
-    .tooltip-header {
-      margin-bottom: 0.3rem;
-    }
-
-    .tooltip-number {
-      font-size: 0.8rem;
-    }
-
-    .tooltip-type {
-      font-size: 0.6rem;
-    }
-
-    .tooltip-body {
-      font-size: 0.7rem;
-    }
+  .tooltip-desc {
+    margin-bottom: 0.4rem;
+    font-weight: 500;
+    color: var(--text-primary);
   }
 
-  /* 玩家移动动画 */
-  @keyframes playerMove {
+  .tooltip-details {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+  }
+
+  .tooltip-details span {
+    padding: 0.1rem 0.4rem;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 4px;
+    font-size: 0.7rem;
+  }
+
+  /* === Full-screen Effect Flash === */
+  .effect-flash {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 100;
+    opacity: 0.15;
+    animation: flashPulse 0.5s ease-out;
+  }
+
+  .flash-punishment,
+  .flash-chain_punishment {
+    background: radial-gradient(circle at center, #ff4757, transparent 70%);
+  }
+  .flash-bonus {
+    background: radial-gradient(circle at center, #2ed573, transparent 70%);
+  }
+  .flash-trap {
+    background: radial-gradient(circle at center, #dc2626, transparent 70%);
+  }
+  .flash-restart {
+    background: radial-gradient(circle at center, #a855f7, transparent 70%);
+  }
+  .flash-special {
+    background: radial-gradient(circle at center, #ffa502, transparent 70%);
+  }
+
+  @keyframes flashPulse {
     0% {
-      transform: scale(1);
-    }
-    50% {
-      transform: scale(1.05);
+      opacity: 0.25;
     }
     100% {
-      transform: scale(1);
+      opacity: 0;
     }
   }
 
-  /* 飞机浮动动画 */
-  @keyframes planeFloat {
-    0%,
-    100% {
-      transform: translateY(0);
+  .flash-enter-active {
+    animation: flashPulse 0.5s ease-out;
+  }
+  .flash-leave-active {
+    animation: flashPulse 0.3s ease-out reverse;
+  }
+
+  /* === Responsive: >= 768px (Desktop/Tablet) === */
+  @media (min-width: 768px) {
+    .board-cell {
+      width: 56px;
+      height: 56px;
     }
-    50% {
-      transform: translateY(-3px);
+    .board-cell .cell-icon :deep(svg) {
+      width: 22px;
+      height: 22px;
+    }
+  }
+
+  /* === Responsive: 480-767px (Small Tablet / Large Phone) === */
+  @media (max-width: 767px) {
+    .game-board {
+      padding: 0.5rem;
+    }
+
+    .board-ring {
+      aspect-ratio: 1.2 / 1;
+    }
+
+    .board-cell {
+      width: 44px;
+      height: 44px;
+      border-radius: 10px;
+    }
+
+    .board-cell .cell-icon :deep(svg) {
+      width: 18px;
+      height: 18px;
+    }
+
+    .cell-number {
+      font-size: 0.5rem;
+    }
+
+    .ring-edge {
+      gap: 3px;
+    }
+
+    .ring-center {
+      padding: 0.5rem;
+      min-height: 140px;
+    }
+
+    .center-dice {
+      transform: scale(0.6);
+    }
+
+    .center-status {
+      padding: 0.3rem 0.6rem;
+    }
+
+    .status-name {
+      font-size: 0.75rem;
+    }
+    .status-position {
+      font-size: 0.65rem;
+    }
+
+    .player-marker {
+      width: 20px;
+      height: 20px;
+      font-size: 8px;
+    }
+  }
+
+  /* === Responsive: < 480px (Phone) === */
+  @media (max-width: 479px) {
+    .game-board {
+      padding: 0.25rem;
+    }
+
+    .board-ring {
+      aspect-ratio: 1.1 / 1;
+    }
+
+    .board-cell {
+      width: 36px;
+      height: 36px;
+      border-radius: 8px;
+      border-width: 1.5px;
+    }
+
+    .board-cell .cell-icon :deep(svg) {
+      width: 15px;
+      height: 15px;
+    }
+
+    .cell-number {
+      font-size: 0.45rem;
+      bottom: 1px;
+      right: 2px;
+    }
+
+    .ring-edge {
+      gap: 2px;
+      padding: 1px;
+    }
+
+    .ring-center {
+      padding: 0.25rem;
+      min-height: 100px;
+      gap: 0.25rem;
+    }
+
+    .center-dice {
+      transform: scale(0.5);
+    }
+
+    .center-status {
+      padding: 0.2rem 0.5rem;
+    }
+
+    .center-effect {
+      font-size: 0.65rem;
+      padding: 0.25rem 0.5rem;
+      max-width: 140px;
+    }
+
+    .status-name {
+      font-size: 0.7rem;
+    }
+    .status-position {
+      font-size: 0.6rem;
+    }
+
+    .player-marker {
+      width: 18px;
+      height: 18px;
+      font-size: 7px;
+      border-width: 1.5px;
+    }
+
+    .cell-players {
+      top: -10px;
+    }
+  }
+
+  /* === Landscape mode === */
+  @media (max-height: 500px) and (orientation: landscape) {
+    .board-ring {
+      aspect-ratio: 2 / 1;
+      max-width: 90vw;
+    }
+
+    .board-cell {
+      width: 32px;
+      height: 32px;
+    }
+
+    .board-cell .cell-icon :deep(svg) {
+      width: 14px;
+      height: 14px;
+    }
+
+    .ring-center {
+      min-height: 80px;
+    }
+
+    .center-dice {
+      transform: scale(0.45);
     }
   }
 </style>

--- a/src/components/MercyDecision.vue
+++ b/src/components/MercyDecision.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+  import { HandHeart, Check, X } from '@lucide/vue'
+  import type { PunishmentAction, Player } from '../types/game'
+
+  interface Props {
+    visible: boolean
+    punishment: PunishmentAction | null
+    executorPlayer: Player | null
+    targetPlayer: Player | null
+    halvedStrikes: number
+  }
+
+  interface Emits {
+    (e: 'mercy-result', accepted: boolean): void
+  }
+
+  defineProps<Props>()
+  const emit = defineEmits<Emits>()
+
+  const accept = () => emit('mercy-result', true)
+  const reject = () => emit('mercy-result', false)
+</script>
+
+<template>
+  <div v-if="visible && punishment" class="modal-overlay mercy-overlay">
+    <div class="modal-content mercy-decision">
+      <div class="mercy-header">
+        <HandHeart :size="28" />
+        <h3>求饶请求</h3>
+      </div>
+
+      <div class="mercy-body">
+        <p class="mercy-intro">
+          <span class="highlight">{{ targetPlayer?.name ?? '受罚方' }}</span>
+          向
+          <span class="highlight">{{ executorPlayer?.name ?? '施罚方' }}</span>
+          求饶
+        </p>
+
+        <div class="mercy-comparison">
+          <div class="comparison-item original">
+            <span class="comparison-label">原惩罚</span>
+            <span class="comparison-value">{{ punishment.strikes ?? 0 }} 下</span>
+          </div>
+          <div class="comparison-arrow">→</div>
+          <div class="comparison-item halved">
+            <span class="comparison-label">求饶后</span>
+            <span class="comparison-value">{{ halvedStrikes }} 下</span>
+          </div>
+        </div>
+
+        <p class="mercy-cost">
+          同意后：本次减半，但
+          <strong>{{ targetPlayer?.name ?? '受罚方' }}</strong>
+          下次被罚自动 ×1.5
+        </p>
+
+        <div class="punishment-brief">
+          {{ punishment.tool.name }} · {{ punishment.bodyPart.name }} ·
+          {{ punishment.position.name }}
+        </div>
+      </div>
+
+      <div class="mercy-actions">
+        <button class="btn btn-success" @click="accept">
+          <Check :size="18" />
+          同意求饶
+        </button>
+        <button class="btn btn-danger" @click="reject">
+          <X :size="18" />
+          拒绝求饶
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .mercy-overlay {
+    z-index: 2100;
+  }
+
+  .mercy-decision {
+    border: 1px solid rgba(245, 158, 11, 0.4);
+    max-width: 420px;
+  }
+
+  .mercy-header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+    color: var(--color-warning, #f59e0b);
+  }
+
+  .mercy-header h3 {
+    margin: 0;
+    font-size: 1.4rem;
+    color: var(--color-warning, #f59e0b);
+  }
+
+  .mercy-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .mercy-intro {
+    text-align: center;
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 1.05rem;
+  }
+
+  .highlight {
+    font-weight: bold;
+    color: var(--text-primary);
+  }
+
+  .mercy-comparison {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+  }
+
+  .comparison-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.75rem 1.25rem;
+    border-radius: var(--radius-sm);
+    background: var(--bg-glass);
+  }
+
+  .comparison-item.original .comparison-value {
+    color: var(--color-punishment);
+    text-decoration: line-through;
+    opacity: 0.8;
+  }
+
+  .comparison-item.halved {
+    border: 1px solid rgba(46, 204, 113, 0.4);
+  }
+
+  .comparison-item.halved .comparison-value {
+    color: #2ecc71;
+    font-weight: bold;
+  }
+
+  .comparison-label {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+  }
+
+  .comparison-value {
+    font-size: 1.3rem;
+    font-weight: bold;
+  }
+
+  .comparison-arrow {
+    font-size: 1.5rem;
+    color: var(--text-muted);
+  }
+
+  .mercy-cost {
+    margin: 0;
+    text-align: center;
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    padding: 0.75rem;
+    background: rgba(245, 158, 11, 0.1);
+    border: 1px solid rgba(245, 158, 11, 0.3);
+    border-radius: var(--radius-sm);
+  }
+
+  .punishment-brief {
+    text-align: center;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+  }
+
+  .mercy-actions {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+  }
+
+  @media (max-width: 768px) {
+    .mercy-actions {
+      flex-direction: column;
+    }
+
+    .mercy-actions .btn {
+      width: 100%;
+      justify-content: center;
+      min-height: 48px;
+    }
+  }
+</style>

--- a/src/components/PlayerPanel.vue
+++ b/src/components/PlayerPanel.vue
@@ -318,6 +318,13 @@
               :style="{ backgroundColor: player.color, '--player-glow-color': player.color }"
             ></div>
             <span class="player-name">{{ player.name }}</span>
+            <div
+              v-if="player.pendingMercyMultiplier && player.pendingMercyMultiplier > 1"
+              class="mercy-badge"
+              :title="`下次惩罚 ×${player.pendingMercyMultiplier}`"
+            >
+              ×{{ player.pendingMercyMultiplier }}
+            </div>
             <div v-if="player.isWinner" class="winner-badge">🏆</div>
           </div>
           <div class="player-stats">
@@ -431,6 +438,18 @@
   .winner-badge {
     font-size: clamp(1rem, 3vw, 1.2rem);
     animation: bounce 1s infinite;
+  }
+
+  .mercy-badge {
+    font-size: clamp(0.7rem, 2vw, 0.8rem);
+    font-weight: bold;
+    color: #fff;
+    background: linear-gradient(135deg, #f59e0b, #d97706);
+    padding: 0.15rem 0.4rem;
+    border-radius: 999px;
+    line-height: 1.2;
+    box-shadow: 0 0 8px rgba(245, 158, 11, 0.5);
+    white-space: nowrap;
   }
 
   .player-stats {

--- a/src/components/PunishmentConfig.vue
+++ b/src/components/PunishmentConfig.vue
@@ -585,11 +585,7 @@
               <input v-model="newPositionName" placeholder="姿势名称" class="input-field" />
             </div>
             <div class="add-form-actions">
-              <button
-                :disabled="!newPositionName.trim()"
-                class="btn-confirm"
-                @click="addPosition"
-              >
+              <button :disabled="!newPositionName.trim()" class="btn-confirm" @click="addPosition">
                 <Plus :size="14" />
                 添加
               </button>

--- a/src/components/PunishmentDisplay.vue
+++ b/src/components/PunishmentDisplay.vue
@@ -1,18 +1,22 @@
 <script setup lang="ts">
-  import { Zap, Check, SkipForward } from '@lucide/vue'
+  import { Zap, Check, SkipForward, HandHeart } from '@lucide/vue'
   import type { PunishmentAction, Player } from '../types/game'
 
   interface Props {
     punishment: PunishmentAction | null
     executorPlayer?: Player | null
+    canRequestMercy?: boolean
   }
 
   interface Emits {
     (e: 'confirm'): void
     (e: 'skip'): void
+    (e: 'request-mercy'): void
   }
 
-  defineProps<Props>()
+  withDefaults(defineProps<Props>(), {
+    canRequestMercy: false,
+  })
   const emit = defineEmits<Emits>()
 
   const confirmPunishment = () => {
@@ -21,6 +25,10 @@
 
   const skipPunishment = () => {
     emit('skip')
+  }
+
+  const requestMercy = () => {
+    emit('request-mercy')
   }
 </script>
 
@@ -75,6 +83,10 @@
           <button class="btn btn-success" @click="confirmPunishment">
             <Check :size="18" />
             确认执行
+          </button>
+          <button v-if="canRequestMercy" class="btn btn-mercy" @click="requestMercy">
+            <HandHeart :size="18" />
+            求饶
           </button>
           <button class="btn btn-secondary" @click="skipPunishment">
             <SkipForward :size="18" />
@@ -232,6 +244,17 @@
     gap: 1rem;
     justify-content: center;
     margin-top: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .btn-mercy {
+    background: linear-gradient(135deg, #f59e0b, #d97706);
+    color: white;
+    border: none;
+  }
+
+  .btn-mercy:hover {
+    filter: brightness(1.1);
   }
 
   /* 移动端适配 */

--- a/src/components/TakeoffPunishmentDisplay.vue
+++ b/src/components/TakeoffPunishmentDisplay.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Plane, Info } from '@lucide/vue'
+  import { Plane, Info, HandHeart } from '@lucide/vue'
   import type { PunishmentAction } from '../types/game'
 
   interface Props {
@@ -7,17 +7,25 @@
     punishment: PunishmentAction | null
     diceValue: number
     executorName: string
+    canRequestMercy?: boolean
   }
 
   interface Emits {
     (e: 'confirm'): void
+    (e: 'request-mercy'): void
   }
 
-  const props = defineProps<Props>()
+  withDefaults(defineProps<Props>(), {
+    canRequestMercy: true,
+  })
   const emit = defineEmits<Emits>()
 
   const handleConfirm = () => {
     emit('confirm')
+  }
+
+  const requestMercy = () => {
+    emit('request-mercy')
   }
 </script>
 
@@ -64,6 +72,10 @@
       </div>
 
       <div class="punishment-footer">
+        <button v-if="canRequestMercy" class="mercy-btn" @click="requestMercy">
+          <HandHeart :size="18" />
+          求饶
+        </button>
         <button class="confirm-btn" @click="handleConfirm">确认惩罚</button>
       </div>
     </div>
@@ -181,6 +193,28 @@
   .punishment-footer {
     display: flex;
     justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .mercy-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: linear-gradient(135deg, #f59e0b, #d97706);
+    color: white;
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: 0.75rem 1.5rem;
+    font-size: 1.1rem;
+    font-weight: bold;
+    cursor: pointer;
+    transition: all var(--transition-normal);
+  }
+
+  .mercy-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(245, 158, 11, 0.4);
   }
 
   .confirm-btn {

--- a/src/services/gameStateHealth.ts
+++ b/src/services/gameStateHealth.ts
@@ -7,6 +7,7 @@ export interface BlockingOverlayState {
   takeoffRelief: boolean
   doublePunishmentReveal: boolean
   chainPunishmentRoll: boolean
+  mercyDecision: boolean
 }
 
 export const hasBlockingOverlay = (overlays: BlockingOverlayState): boolean =>

--- a/src/tests/gameStateHealth.test.ts
+++ b/src/tests/gameStateHealth.test.ts
@@ -8,6 +8,7 @@ const noBlockingOverlay = {
   takeoffRelief: false,
   doublePunishmentReveal: false,
   chainPunishmentRoll: false,
+  mercyDecision: false,
 }
 
 describe('游戏移动状态健康检查', () => {
@@ -24,6 +25,7 @@ describe('游戏移动状态健康检查', () => {
     'takeoffRelief',
     'doublePunishmentReveal',
     'chainPunishmentRoll',
+    'mercyDecision',
   ] as const)('%s 覆盖层显示期间不恢复移动状态', overlay => {
     expect(
       shouldRecoverMovingState('moving', 5001, {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -7,6 +7,8 @@ export interface Player {
   isMoving?: boolean // 添加移动动画状态
   hasTakenOff?: boolean // 是否已经起飞
   failedTakeoffAttempts?: number // 起飞失败次数
+  /** 求饶成功后的下次惩罚倍数（如 1.5），用完即清除 */
+  pendingMercyMultiplier?: number
 }
 
 export interface PunishmentTool {


### PR DESCRIPTION
## Summary
- 棋盘 UI 重设计：环形布局 + 暗色魔法主题
- 新增求饶机制：受罚方可求饶，施罚方同意后次数减半，下次惩罚 ×1.5
- 版本 bump 至 1.3.0

## Test plan
- [ ] 落惩罚格可看到「求饶」按钮，翻倍惩罚无求饶
- [ ] 求饶同意后 strikes 减半（ceil），玩家头像显示 ×1.5 徽章
- [ ] 下次被罚时次数 ×1.5，徽章消失
- [ ] 求饶拒绝后维持原次数
- [ ] 连锁惩罚每轮可独立求饶；起飞失败惩罚可求饶
- [ ] 棋盘环形布局与视觉正常