### PR TITLE
feat: 棋盘移动端布局优化

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -74,6 +74,23 @@
   const gameStarted = ref(false)
   const gameFinished = ref(false)
 
+  // 移动端 PlayerPanel 折叠状态
+  const playerPanelCollapsed = ref(true)
+  const windowWidth = ref(window.innerWidth)
+
+  const isMobileView = computed(() => windowWidth.value <= 768)
+
+  const onWindowResize = () => {
+    windowWidth.value = window.innerWidth
+    if (!isMobileView.value) {
+      playerPanelCollapsed.value = false
+    }
+  }
+
+  const togglePlayerPanel = () => {
+    playerPanelCollapsed.value = !playerPanelCollapsed.value
+  }
+
   // 设置页 Tab 状态
   const settingsTab = ref<'board' | 'punishment' | 'trap'>('board')
 
@@ -549,7 +566,7 @@
     audioService.init()
     audioEnabled.value = audioService.enabled
 
-    // 监听未捕获的 Promise 错误
+    window.addEventListener('resize', onWindowResize)
     window.addEventListener('unhandledrejection', handleUnhandledRejection)
 
     // 监听全局错误
@@ -696,6 +713,7 @@
   })
 
   onBeforeUnmount(() => {
+    window.removeEventListener('resize', onWindowResize)
     window.removeEventListener('unhandledrejection', handleUnhandledRejection)
     window.removeEventListener('error', handleGlobalError)
 
@@ -2068,179 +2086,89 @@
 
     <!-- 游戏页面 -->
     <div v-else class="game-page">
-      <!-- 移动端顶部栏 -->
       <header class="game-header">
         <div class="header-content">
           <h1>
-            <Dices :size="24" />
+            <Dices :size="20" />
             惩罚飞行棋
           </h1>
-          <button
-            class="audio-toggle-btn"
-            :title="audioEnabled ? '静音' : '开启声音'"
-            @click="toggleAudio"
-          >
-            <Volume2 v-if="audioEnabled" :size="18" />
-            <VolumeX v-else :size="18" />
-          </button>
-        </div>
-        <p>环形棋盘游戏，支持自定义惩罚设置</p>
-      </header>
 
-      <!-- 主要内容区域 -->
-      <main class="game-main">
-        <!-- 左侧控制区域 -->
-        <div class="left-sidebar">
-          <div class="sidebar-content">
-            <!-- 控制按钮 -->
-            <div class="control-buttons">
-              <PButton
-                v-if="!gameStarted"
-                label="开始游戏"
-                icon="pi pi-play"
-                class="p-button-success w-full"
-                @click="handleGameControlsStart"
-              />
-              <PButton
-                v-if="gameFinished"
-                label="再来一局"
-                icon="pi pi-refresh"
-                class="p-button-info w-full"
-                @click="resetGame"
-              />
-            </div>
+          <div v-if="gameStarted" class="header-status">
+            <Badge :value="turnCount" class="turn-badge" />
+            <Tag
+              :value="gameStatusText"
+              :severity="getStatusSeverity(gameState.gameStatus)"
+              class="status-tag"
+            />
           </div>
-        </div>
 
-        <!-- 右侧游戏区域 -->
-        <div class="game-area">
-          <!-- 移动端控制面板 -->
-          <div class="mobile-control-panel">
-            <!-- 玩家状态区域 -->
-            <div class="mobile-status-section">
-              <div class="mobile-combined-status">
-                <div class="mobile-turn-display">
-                  <div class="turn-number">{{ turnCount }}</div>
-                  <div class="turn-label">回合</div>
-                </div>
-                <div class="mobile-game-status">
-                  <Tag
-                    :value="gameStatusText"
-                    :severity="getStatusSeverity(gameState.gameStatus)"
-                    class="status-tag-mobile"
-                  />
-                </div>
-              </div>
+          <PlayerPanel
+            v-if="gameState.players.length > 0"
+            :players="gameState.players"
+            :current-player-index="gameState.currentPlayerIndex"
+            :collapsed="isMobileView && playerPanelCollapsed"
+            class="header-players"
+            @toggle="togglePlayerPanel"
+          />
 
-              <!-- 玩家状态面板 (移动端) -->
-              <div class="mobile-players-container">
+          <!-- Mobile player panel dropdown -->
+          <Transition name="panel-dropdown">
+            <div
+              v-if="isMobileView && !playerPanelCollapsed && gameState.players.length > 0"
+              class="mobile-panel-dropdown"
+            >
+              <div class="mobile-panel-backdrop" @click="playerPanelCollapsed = true"></div>
+              <div class="mobile-panel-content">
                 <PlayerPanel
                   :players="gameState.players"
                   :current-player-index="gameState.currentPlayerIndex"
-                  class="mobile-player-panel"
+                  :collapsed="false"
+                  @toggle="togglePlayerPanel"
                 />
               </div>
             </div>
-          </div>
+          </Transition>
 
-          <!-- 棋盘上方状态区域（桌面端） -->
-          <div class="top-status-area desktop-only">
-            <!-- 游戏状态 -->
-            <Card class="compact-status-card">
-              <template #content>
-                <div class="compact-status-info">
-                  <div class="status-item">
-                    <i class="pi pi-info-circle status-icon"></i>
-                    <span class="status-label">回合:</span>
-                    <Badge :value="turnCount" class="turn-badge" />
-                  </div>
-                  <div class="status-item">
-                    <span class="status-label">状态:</span>
-                    <Tag
-                      :value="gameStatusText"
-                      :severity="getStatusSeverity(gameState.gameStatus)"
-                      class="status-tag"
-                    />
-                  </div>
-                </div>
-              </template>
-            </Card>
-
-            <!-- 当前玩家 -->
-            <Card
-              v-if="gameState.players[gameState.currentPlayerIndex]"
-              class="compact-current-player-card"
+          <div class="header-actions">
+            <PButton
+              v-if="!gameStarted"
+              label="开始游戏"
+              icon="pi pi-play"
+              class="p-button-success p-button-sm"
+              @click="handleGameControlsStart"
+            />
+            <PButton
+              v-if="gameFinished"
+              label="再来一局"
+              icon="pi pi-refresh"
+              class="p-button-info p-button-sm"
+              @click="resetGame"
+            />
+            <button
+              class="audio-toggle-btn"
+              :title="audioEnabled ? '静音' : '开启声音'"
+              @click="toggleAudio"
             >
-              <template #content>
-                <div class="compact-current-player">
-                  <div
-                    class="current-avatar"
-                    :style="{
-                      backgroundColor: gameState.players[gameState.currentPlayerIndex].color,
-                    }"
-                  >
-                    {{ gameState.players[gameState.currentPlayerIndex].name.charAt(0) }}
-                  </div>
-                  <div class="current-info">
-                    <div class="current-name">
-                      {{ gameState.players[gameState.currentPlayerIndex].name }}
-                      <span
-                        v-if="
-                          (gameState.players[gameState.currentPlayerIndex].pendingMercyMultiplier ??
-                            0) > 1
-                        "
-                        class="mercy-multiplier-badge"
-                      >
-                        ×{{
-                          gameState.players[gameState.currentPlayerIndex].pendingMercyMultiplier
-                        }}
-                      </span>
-                    </div>
-                    <div class="current-position">
-                      {{
-                        gameState.players[gameState.currentPlayerIndex].position === 0
-                          ? '起点'
-                          : `第${gameState.players[gameState.currentPlayerIndex].position}格`
-                      }}
-                    </div>
-                  </div>
-                </div>
-              </template>
-            </Card>
-
-            <!-- 玩家状态面板 (桌面端紧凑版) -->
-            <PlayerPanel
-              :players="gameState.players"
-              :current-player-index="gameState.currentPlayerIndex"
-            />
-
-            <!-- 获胜者信息 -->
-            <Card v-if="gameState.winner" class="compact-winner-card">
-              <template #content>
-                <div class="compact-winner-display">
-                  <i class="pi pi-trophy winner-icon"></i>
-                  <div class="winner-avatar" :style="{ backgroundColor: gameState.winner.color }">
-                    {{ gameState.winner.name.charAt(0) }}
-                  </div>
-                  <div class="winner-name">{{ gameState.winner.name }} 获胜!</div>
-                </div>
-              </template>
-            </Card>
+              <Volume2 v-if="audioEnabled" :size="18" />
+              <VolumeX v-else :size="18" />
+            </button>
           </div>
+        </div>
+      </header>
 
-          <!-- 棋盘区域 -->
-          <div class="board-section">
-            <GameBoard
-              :board="gameState.board"
-              :players="gameState.players"
-              :current-player-index="gameState.currentPlayerIndex"
-              :last-effect="lastEffect"
-              :can-roll="canRollDice"
-              :dice-value="gameState.diceValue"
-              @cell-click="handleCellClick"
-              @roll="handleDiceRoll"
-            />
-          </div>
+      <main class="game-main">
+        <div class="board-section">
+          <GameBoard
+            :board="gameState.board"
+            :players="gameState.players"
+            :current-player-index="gameState.currentPlayerIndex"
+            :last-effect="lastEffect"
+            :can-roll="canRollDice"
+            :dice-value="gameState.diceValue"
+            :turn-count="turnCount"
+            @cell-click="handleCellClick"
+            @roll="handleDiceRoll"
+          />
         </div>
       </main>
 
@@ -2541,31 +2469,52 @@
   }
 
   .game-header {
-    text-align: center;
-    padding: clamp(0.5rem, 2vw, 1rem);
+    padding: 0.5rem 1rem;
     background: var(--bg-glass);
     backdrop-filter: blur(var(--glass-blur));
     border-bottom: var(--glass-border);
     box-shadow: var(--glass-shadow);
+    flex-shrink: 0;
   }
 
   .header-content {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    max-width: 1200px;
+    gap: 0.75rem;
+    max-width: 1400px;
     margin: 0 auto;
   }
 
   .game-header h1 {
     margin: 0;
-    font-size: clamp(1.2rem, 4vw, 1.8rem);
+    font-size: 1.1rem;
     font-weight: bold;
     color: var(--text-primary);
-    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .header-status {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-shrink: 0;
+  }
+
+  .header-players {
+    flex: 1;
+    min-width: 0;
+    justify-content: center;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-shrink: 0;
   }
 
   .audio-toggle-btn {
@@ -2573,14 +2522,14 @@
     border: var(--glass-border);
     border-radius: var(--radius-sm);
     color: var(--text-secondary);
-    padding: 0.4rem;
+    padding: 0.3rem;
     cursor: pointer;
     transition: all var(--transition-fast);
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 32px;
-    min-width: 32px;
+    min-height: 30px;
+    min-width: 30px;
   }
 
   .audio-toggle-btn:hover {
@@ -2588,60 +2537,12 @@
     background: var(--bg-glass-hover);
   }
 
-  .game-header p {
-    margin: clamp(0.25rem, 1vw, 0.5rem) 0 0 0;
-    font-size: clamp(0.7rem, 2vw, 0.9rem);
-    color: var(--text-secondary);
-  }
-
   .game-main {
     flex: 1;
     display: flex;
-    max-width: 1400px;
-    margin: 0 auto;
+    flex-direction: column;
     width: 100%;
-    gap: 1rem;
-    padding: 1rem;
-  }
-
-  .left-sidebar {
-    width: 280px;
-    min-width: 280px;
-    display: flex;
-    flex-direction: column;
-    background: var(--bg-glass);
-    backdrop-filter: blur(var(--glass-blur));
-    border-right: var(--glass-border);
-    box-shadow: var(--glass-shadow);
-    overflow-y: auto;
-  }
-
-  .sidebar-content {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    height: 100%;
-    padding: 1rem;
-  }
-
-  .game-area {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-  }
-
-  .top-status-area {
-    background: var(--bg-glass);
-    backdrop-filter: blur(var(--glass-blur));
-    border-bottom: var(--glass-border);
-    box-shadow: var(--glass-shadow);
-    padding: 1rem 2rem;
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-    flex-wrap: wrap;
-    min-height: 80px;
+    min-height: 0;
   }
 
   .board-section {
@@ -2649,108 +2550,11 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    min-height: 500px;
-    padding: 1rem;
+    min-height: 0;
+    padding: 0.5rem;
   }
 
-  /* 卡片样式 */
-  .card-title {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--text-primary);
-  }
-
-  .dice-card,
-  .status-card,
-  .current-player-card,
-  .players-card,
-  .winner-card {
-    margin-bottom: 1rem;
-  }
-
-  .dice-section {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 1rem 0;
-    min-height: 200px;
-  }
-
-  /* 紧凑状态卡片样式 */
-  .compact-status-card,
-  .compact-current-player-card,
-  .compact-players-card,
-  .compact-winner-card {
-    margin: 0;
-    background: var(--bg-glass);
-    box-shadow: var(--glass-shadow);
-    border-radius: var(--radius-md);
-    border: var(--glass-border);
-    backdrop-filter: blur(var(--glass-blur));
-  }
-
-  .compact-status-card .p-card-content,
-  .compact-current-player-card .p-card-content,
-  .compact-players-card .p-card-content,
-  .compact-winner-card .p-card-content {
-    padding: 0.75rem 1rem;
-  }
-
-  .compact-status-info {
-    display: flex;
-    gap: 1.5rem;
-    align-items: center;
-    flex-wrap: wrap;
-  }
-
-  .compact-status-info .status-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.9rem;
-  }
-
-  .status-icon {
-    color: var(--color-accent);
-    font-size: 1rem;
-  }
-
-  .compact-current-player {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  .compact-current-player .current-avatar {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1rem;
-    color: white;
-    font-weight: bold;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  }
-
-  .compact-current-player .current-info {
-    flex: 1;
-  }
-
-  .compact-current-player .current-name {
-    font-weight: 600;
-    color: var(--text-primary);
-    font-size: 0.9rem;
-    margin-bottom: 0.1rem;
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-  }
-
+  /* 状态样式 */
   .mercy-multiplier-badge {
     font-size: 0.7rem;
     font-weight: bold;
@@ -2761,338 +2565,12 @@
     box-shadow: 0 0 8px rgba(245, 158, 11, 0.45);
   }
 
-  .compact-current-player .current-position {
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-  }
-
-  .compact-players-list {
-    display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
-
-  .compact-player-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.4rem 0.6rem;
-    border-radius: var(--radius-sm);
-    background: var(--bg-glass);
-    border: var(--glass-border);
-    transition: all var(--transition-normal);
-    font-size: 0.85rem;
-  }
-
-  .compact-player-item.current-player {
-    background: rgba(102, 126, 234, 0.15);
-    border-color: rgba(102, 126, 234, 0.4);
-    box-shadow: 0 0 16px rgba(102, 126, 234, 0.25);
-    transform: scale(1.02);
-  }
-
-  .compact-player-item .player-avatar {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.8rem;
-    color: white;
-    font-weight: bold;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-  }
-
-  .compact-player-item .player-details {
-    flex: 1;
-  }
-
-  .compact-player-item .player-name {
-    font-weight: 600;
-    color: var(--text-primary);
-    margin-bottom: 0.1rem;
-    font-size: 0.8rem;
-  }
-
-  .compact-player-item .player-position {
-    font-size: 0.7rem;
-    color: var(--text-secondary);
-  }
-
-  .compact-player-item .current-indicator {
-    color: var(--color-accent-light);
-    font-size: 0.8rem;
-  }
-
-  .compact-winner-display {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    color: var(--color-warning);
-    font-weight: 600;
-  }
-
-  .winner-icon {
-    font-size: 1.2rem;
-    color: var(--color-warning);
-  }
-
-  .compact-winner-display .winner-avatar {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1rem;
-    color: white;
-    font-weight: bold;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  }
-
-  .compact-winner-display .winner-name {
-    font-size: 0.9rem;
-  }
-
-  /* 移动端控制面板 */
-  .mobile-control-panel {
-    display: none;
-  }
-
-  .mobile-dice-section {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .mobile-status-section {
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-    padding: 0.6rem;
-    height: 100%;
-  }
-
-  /* 合并的回合数和游戏状态显示 */
-  .mobile-combined-status {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    background: var(--bg-glass);
-    backdrop-filter: blur(var(--glass-blur));
-    border-radius: var(--radius-sm);
-    padding: 0.5rem;
-    border: var(--glass-border);
-    box-shadow: var(--glass-shadow);
-    flex-shrink: 0;
-  }
-
-  /* 移动端回合数显示 - 紧凑版 */
-  .mobile-turn-display {
-    text-align: center;
-    background: linear-gradient(135deg, var(--color-accent) 0%, #764ba2 100%);
-    color: white;
-    padding: 0.4rem 0.6rem;
-    border-radius: 6px;
-    box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
-    min-width: 60px;
-    flex-shrink: 0;
-  }
-
-  .turn-number {
-    font-size: 1.2rem;
-    font-weight: bold;
-    line-height: 1;
-  }
-
-  .turn-label {
-    font-size: 0.7rem;
-    opacity: 0.9;
-    margin-top: 0.1rem;
-  }
-
-  /* 移动端游戏状态 - 紧凑版 */
-  .mobile-game-status {
-    display: flex;
-    justify-content: flex-start;
-    flex: 1;
-  }
-
-  .status-tag-mobile {
-    font-size: 0.75rem;
-    padding: 0.3rem 0.6rem;
-    white-space: nowrap;
-  }
-
-  /* 桌面端专用类 */
-  .desktop-only {
-    display: block;
-  }
-
-  /* 状态信息样式 */
-  .status-info {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-  }
-
-  .status-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .status-label {
-    font-weight: 500;
-    color: var(--text-secondary);
-  }
-
   .turn-badge {
     background: var(--color-accent);
   }
 
   .status-tag {
-    font-size: 0.875rem;
-  }
-
-  /* 当前玩家样式 */
-  .current-player-display {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 0.5rem;
-    background: rgba(102, 126, 234, 0.12);
-    border-radius: var(--radius-sm);
-    border: 1px solid rgba(102, 126, 234, 0.25);
-  }
-
-  .current-avatar {
-    width: 50px;
-    height: 50px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.5rem;
-    color: white;
-    font-weight: bold;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-  }
-
-  .current-info {
-    flex: 1;
-  }
-
-  .current-name {
-    font-weight: bold;
-    font-size: 1.1rem;
-    color: var(--text-primary);
-    margin-bottom: 0.25rem;
-  }
-
-  .current-position {
-    font-size: 0.9rem;
-    color: var(--text-secondary);
-  }
-
-  /* 玩家列表样式 */
-  .players-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .player-item {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem;
-    border-radius: var(--radius-sm);
-    background: var(--bg-glass);
-    border: var(--glass-border);
-    transition: all var(--transition-normal);
-  }
-
-  .player-item.current-player {
-    background: rgba(102, 126, 234, 0.15);
-    border-color: rgba(102, 126, 234, 0.4);
-    box-shadow: 0 0 16px rgba(102, 126, 234, 0.25);
-    transform: scale(1.02);
-  }
-
-  .player-item.player-moving {
-    animation: pulse 1s infinite;
-  }
-
-  .player-avatar {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.2rem;
-    color: white;
-    font-weight: bold;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  }
-
-  .player-details {
-    flex: 1;
-  }
-
-  .player-name {
-    font-weight: 600;
-    color: var(--text-primary);
-    margin-bottom: 0.25rem;
-  }
-
-  .player-position {
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-  }
-
-  .current-indicator {
-    color: var(--color-accent-light);
-    font-size: 1.2rem;
-    animation: bounce 1s infinite;
-  }
-
-  /* 获胜者样式 */
-  .winner-display {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 1rem;
-    background: linear-gradient(135deg, #fbbf24, #f59e0b);
-    border-radius: 12px;
-    color: white;
-    text-align: center;
-  }
-
-  .winner-avatar {
-    width: 60px;
-    height: 60px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 2rem;
-    background: rgba(255, 255, 255, 0.2);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  }
-
-  .winner-name {
-    font-size: 1.3rem;
-    font-weight: bold;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
-  }
-
-  /* 控制按钮样式 */
-  .control-buttons {
-    margin-top: auto;
-    padding-top: 1rem;
+    font-size: 0.8rem;
   }
 
   /* 动画效果 */
@@ -3122,629 +2600,154 @@
     }
   }
 
-  /* 平板端适配 */
-  @media (max-width: 1024px) and (min-width: 769px) {
-    .game-main {
-      flex-direction: column;
-      padding: 0.5rem;
-    }
-
-    .left-sidebar {
-      width: 100%;
-      min-width: unset;
-      border-right: none;
-      border-bottom: var(--glass-border);
-      overflow-y: visible;
-    }
-
-    .sidebar-content {
-      flex-direction: row;
-      gap: 1rem;
-      padding: 1rem;
-      justify-content: center;
-    }
-
-    .dice-card {
-      flex: 0 0 auto;
-      min-width: 300px;
-    }
-
-    .game-area {
-      flex: 1;
-    }
-
-    .mobile-dice-area {
-      display: none;
-    }
-
-    .top-status-area {
-      padding: 0.75rem 1rem;
-      gap: 0.75rem;
-    }
-
-    .board-section {
-      min-height: 400px;
-    }
-  }
-
   /* 移动端适配 */
   @media (max-width: 768px) {
-    .game-main {
-      flex-direction: column;
-      padding: 0;
-      height: 100vh;
-    }
-
-    .left-sidebar {
-      display: none;
-    }
-
-    .game-area {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      height: 100vh;
-    }
-
-    /* 移动端控制面板 - 扩大玩家状态区域 */
-    .mobile-control-panel {
-      display: flex;
-      height: 38vh; /* 增加到屏幕高度的38% */
-      background: var(--bg-glass);
-      backdrop-filter: blur(var(--glass-blur));
-      border-bottom: var(--glass-border);
-      box-shadow: var(--glass-shadow);
-      flex-shrink: 0;
-    }
-
-    /* 左侧骰子区域 - 占据控制面板的30% */
-    .mobile-dice-section {
-      width: 30%;
-      border-right: var(--glass-border);
-      background: var(--bg-secondary);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    /* 右侧状态区域 - 占据控制面板的70% */
-    .mobile-status-section {
-      width: 70%;
-      height: 100%;
-      overflow: hidden;
-      display: flex;
-      flex-direction: column;
-    }
-
-    /* 移动端玩家面板容器 - 扩展显示区域 */
-    .mobile-players-container {
-      flex: 1;
-      overflow: hidden;
-      min-height: 0; /* 允许flex子项收缩 */
-      background: var(--bg-secondary);
-      border-radius: var(--radius-sm);
-      margin-top: 0.3rem;
-      padding: 0.2rem;
-    }
-
-    /* 移动端玩家面板样式调整 */
-    .mobile-player-panel {
-      height: 100%;
-      margin-bottom: 0;
-    }
-
-    .mobile-player-panel .player-panel {
-      height: 100%;
-      margin-bottom: 0;
-      padding: 0.5rem;
-      background: transparent;
-    }
-
-    .mobile-player-panel .player-panel h3 {
-      margin: 0 0 0.5rem 0;
-      font-size: 0.9rem;
-      color: var(--text-primary);
-      text-align: center;
-      font-weight: 600;
-    }
-
-    .mobile-player-panel .players-container {
-      max-height: none;
-      height: calc(100% - 2rem); /* 减去标题高度 */
-      min-height: 0;
-      overflow-y: auto;
-    }
-
-    .mobile-player-panel .players-grid {
-      grid-template-columns: 1fr;
-      gap: 0.4rem;
-      padding: 0.2rem;
-    }
-
-    .mobile-player-panel .player-card {
-      padding: 0.5rem;
-      border-width: 1px;
-      background: var(--bg-glass);
-      border: var(--glass-border);
-      border-radius: var(--radius-sm);
-      box-shadow: var(--glass-shadow);
-      transition: all var(--transition-fast);
-    }
-
-    .mobile-player-panel .player-card.current {
-      background: rgba(102, 126, 234, 0.15);
-      border-color: rgba(102, 126, 234, 0.4);
-      box-shadow: 0 0 16px rgba(102, 126, 234, 0.25);
-      transform: translateY(-1px);
-    }
-
-    .mobile-player-panel .player-header {
-      gap: 0.5rem;
-      margin-bottom: 0.4rem;
-      align-items: center;
-    }
-
-    .mobile-player-panel .player-color {
-      width: 16px;
-      height: 16px;
-      border-width: 2px;
-      flex-shrink: 0;
-      border-radius: 50%;
-    }
-
-    .mobile-player-panel .player-name {
-      font-size: 0.85rem;
-      font-weight: 600;
-      flex: 1;
-      min-width: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      color: var(--text-primary);
-    }
-
-    .mobile-player-panel .player-stats {
-      gap: 0.35rem;
-    }
-
-    .mobile-player-panel .stat {
-      gap: 0.4rem;
-      align-items: center;
-    }
-
-    .mobile-player-panel .label {
-      font-size: 0.75rem;
-      min-width: 35px;
-      color: var(--text-secondary);
-      font-weight: 500;
-    }
-
-    .mobile-player-panel .value {
-      font-size: 0.75rem;
-      font-weight: 600;
-      color: var(--text-primary);
-    }
-
-    .mobile-player-panel .players-container::-webkit-scrollbar {
-      width: 2px;
-    }
-
-    .mobile-player-panel .players-container::-webkit-scrollbar-track {
-      background: var(--bg-secondary);
-      border-radius: 1px;
-    }
-
-    .mobile-player-panel .players-container::-webkit-scrollbar-thumb {
-      background: rgba(255, 255, 255, 0.2);
-      border-radius: 1px;
-    }
-
-    /* 隐藏桌面端状态区域 */
-    .desktop-only {
-      display: none;
-    }
-
-    /* 棋盘区域 - 相应减少高度 */
-    .board-section {
-      height: 62vh; /* 减少到屏幕高度的62% */
-      flex-shrink: 0;
-      padding: 0.5rem;
-      overflow: hidden;
-    }
-
-    /* 移动端骰子尺寸调整 - 更紧凑 */
-    .mobile-dice-section .cool-dice-container {
-      padding: 0.3rem;
-      gap: 0.3rem;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      height: 100%;
-    }
-
-    .mobile-dice-section .dice-cube {
-      width: 45px;
-      height: 45px;
-      margin: 0.5rem;
-    }
-
-    .mobile-dice-section .face {
-      width: 45px;
-      height: 45px;
-    }
-
-    .mobile-dice-section .face-1 {
-      transform: rotateY(0deg) translateZ(22.5px);
-    }
-    .mobile-dice-section .face-2 {
-      transform: rotateY(90deg) translateZ(22.5px);
-    }
-    .mobile-dice-section .face-3 {
-      transform: rotateY(180deg) translateZ(22.5px);
-    }
-    .mobile-dice-section .face-4 {
-      transform: rotateY(-90deg) translateZ(22.5px);
-    }
-    .mobile-dice-section .face-5 {
-      transform: rotateX(90deg) translateZ(22.5px);
-    }
-    .mobile-dice-section .face-6 {
-      transform: rotateX(-90deg) translateZ(22.5px);
-    }
-
-    .mobile-dice-section .dot {
-      width: 7px;
-      height: 7px;
-    }
-
-    .mobile-dice-section .result-display {
-      padding: 0.3rem 0.6rem;
-      border-radius: 4px;
-      background: var(--bg-glass);
-      border: var(--glass-border);
-      box-shadow: var(--glass-shadow);
-    }
-
-    .mobile-dice-section .result-number {
-      font-size: 1.1rem;
-      font-weight: bold;
-    }
-
-    .mobile-dice-section .dice-status {
-      font-size: 0.7rem;
-      margin-top: 0.2rem;
-    }
-
-    .mobile-dice-section .status-rolling,
-    .mobile-dice-section .status-result,
-    .mobile-dice-section .status-prompt {
-      padding: 0.25rem 0.5rem;
-      font-size: 0.65rem;
-      border-radius: 3px;
-      background: var(--bg-glass);
-      border: var(--glass-border);
-      color: var(--text-secondary);
-      text-align: center;
-    }
-  }
-
-  @media (max-width: 768px) {
     .game-header {
-      padding: 0.75rem;
+      padding: 0.4rem 0.5rem;
+    }
+
+    .header-content {
+      gap: 0.4rem;
     }
 
     .game-header h1 {
-      font-size: 1.3rem;
+      font-size: 0.95rem;
     }
 
-    .game-header p {
-      font-size: 0.8rem;
+    .header-players {
+      flex: 0 0 auto;
     }
 
-    .current-player-display {
-      flex-direction: column;
-      text-align: center;
-      gap: 0.5rem;
+    .board-section {
+      padding: 0.25rem;
     }
+  }
 
-    .current-avatar {
-      width: 45px;
-      height: 45px;
-      font-size: 1.3rem;
-    }
+  /* Mobile player panel dropdown */
+  .mobile-panel-dropdown {
+    position: fixed;
+    inset: 0;
+    z-index: 1500;
+  }
 
-    .player-avatar {
-      width: 35px;
-      height: 35px;
-      font-size: 1rem;
-    }
+  .mobile-panel-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+  }
 
-    .winner-avatar {
-      width: 50px;
-      height: 50px;
-      font-size: 1.5rem;
-    }
+  .mobile-panel-content {
+    position: absolute;
+    top: 50px;
+    left: 0.5rem;
+    right: 0.5rem;
+    padding: 0.75rem;
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    border-radius: var(--radius-md, 12px);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  }
 
-    .winner-name {
-      font-size: 1.1rem;
-    }
+  .panel-dropdown-enter-active {
+    transition: opacity 0.2s ease-out;
+  }
+  .panel-dropdown-enter-active .mobile-panel-content {
+    transition: transform 0.2s ease-out;
+  }
+  .panel-dropdown-leave-active {
+    transition: opacity 0.15s ease-in;
+  }
+  .panel-dropdown-leave-active .mobile-panel-content {
+    transition: transform 0.15s ease-in;
+  }
+  .panel-dropdown-enter-from,
+  .panel-dropdown-leave-to {
+    opacity: 0;
+  }
+  .panel-dropdown-enter-from .mobile-panel-content,
+  .panel-dropdown-leave-to .mobile-panel-content {
+    transform: translateY(-10px);
   }
 
   @media (max-width: 480px) {
-    .game-main {
-      padding: 0.25rem;
+    .game-header h1 {
+      font-size: 0.85rem;
     }
 
-    /* 小屏幕优化控制面板高度 */
-    .mobile-control-panel {
-      height: 35vh; /* 保持合理的高度给玩家状态 */
-    }
-
-    .board-section {
-      height: 65vh; /* 相应调整棋盘高度 */
-    }
-
-    /* 更紧凑的合并状态显示 */
-    .mobile-combined-status {
-      gap: 0.5rem;
-      padding: 0.4rem;
-    }
-
-    .mobile-turn-display {
-      padding: 0.3rem 0.5rem;
-      min-width: 50px;
-    }
-
-    .turn-number {
-      font-size: 1.1rem;
-    }
-
-    .turn-label {
-      font-size: 0.65rem;
-    }
-
-    .status-tag-mobile {
-      font-size: 0.7rem;
+    .header-actions .p-button {
+      font-size: 0.75rem;
       padding: 0.25rem 0.5rem;
     }
-
-    /* 小屏幕骰子调整 */
-    .mobile-dice-section .dice-cube {
-      width: 40px;
-      height: 40px;
-      margin: 0.4rem;
-    }
-
-    .mobile-dice-section .face {
-      width: 40px;
-      height: 40px;
-    }
-
-    .mobile-dice-section .face-1 {
-      transform: rotateY(0deg) translateZ(20px);
-    }
-    .mobile-dice-section .face-2 {
-      transform: rotateY(90deg) translateZ(20px);
-    }
-    .mobile-dice-section .face-3 {
-      transform: rotateY(180deg) translateZ(20px);
-    }
-    .mobile-dice-section .face-4 {
-      transform: rotateY(-90deg) translateZ(20px);
-    }
-    .mobile-dice-section .face-5 {
-      transform: rotateX(90deg) translateZ(20px);
-    }
-    .mobile-dice-section .face-6 {
-      transform: rotateX(-90deg) translateZ(20px);
-    }
-
-    .mobile-dice-section .dot {
-      width: 6px;
-      height: 6px;
-    }
-
-    .mobile-dice-section .result-number {
-      font-size: 1rem;
-    }
-
-    .mobile-dice-section .dice-status {
-      font-size: 0.65rem;
-    }
-
-    /* 小屏幕玩家面板优化 */
-    .mobile-player-panel .player-panel h3 {
-      font-size: 0.8rem;
-      margin-bottom: 0.3rem;
-    }
-
-    .mobile-player-panel .player-card {
-      padding: 0.3rem;
-    }
-
-    .mobile-player-panel .player-name {
-      font-size: 0.75rem;
-    }
-
-    .mobile-player-panel .label {
-      font-size: 0.65rem;
-      min-width: 28px;
-    }
-
-    .mobile-player-panel .value {
-      font-size: 0.65rem;
-    }
-
-    .card-title {
-      font-size: 0.9rem;
-    }
-
-    .current-name {
-      font-size: 1rem;
-    }
-
-    .player-name {
-      font-size: 0.9rem;
-    }
-
-    .status-item {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 0.25rem;
-    }
   }
 
-  /* 触摸优化 */
-  @media (hover: none) and (pointer: coarse) {
-    .dice:hover {
-      transform: none;
-      filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.3));
-    }
-
-    .dice:active {
-      transform: scale(0.95);
-      filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.4));
-    }
-
-    .player-item:hover {
-      background: var(--bg-glass-hover);
-      transform: none;
-    }
-
-    .player-item:active {
-      background: rgba(102, 126, 234, 0.15);
-      transform: scale(0.98);
-    }
-
-    /* 增大触摸目标 */
-
-    .control-buttons .p-button {
-      min-height: 48px;
-      padding: 0.75rem 1.5rem;
-    }
-  }
-
-  /* 横屏模式优化 */
-  @media (max-width: 1024px) and (orientation: landscape) {
-    .game-header {
-      padding: 0.5rem;
-    }
-
-    .game-header h1 {
-      font-size: 1.2rem;
-    }
-
-    .game-header p {
-      font-size: 0.75rem;
-    }
-
-    .game-main {
-      padding: 0.25rem;
-    }
-
-    .board-section {
-      min-height: 300px;
-    }
-
-    .sidebar-content {
-      gap: 0.75rem;
-    }
-
-    .dice-card .dice-section {
-      padding: 0.5rem 0;
-    }
-
-    /* 横屏模式下的移动端控制面板优化 */
-    .mobile-control-panel {
-      height: 35vh; /* 横屏时稍微增加高度 */
-    }
-
-    .board-section {
-      height: 65vh;
-    }
-
-    .mobile-combined-status {
+  /* 横屏模式优化：header 变为左侧竖栏 */
+  @media (orientation: landscape) and (max-height: 600px) {
+    .game-page {
       flex-direction: row;
+    }
+
+    .game-header {
+      flex-shrink: 0;
+      width: 60px;
+      padding: 0.4rem;
+      border-bottom: none;
+      border-right: var(--glass-border);
+      overflow-y: auto;
+      overflow-x: hidden;
+    }
+
+    .header-content {
+      flex-direction: column;
+      gap: 0.5rem;
+      max-width: none;
       align-items: center;
     }
 
-    .mobile-dice-section {
-      width: 25%; /* 横屏时减少骰子区域宽度 */
+    .game-header h1 {
+      font-size: 0;
+      gap: 0;
     }
 
-    .mobile-status-section {
-      width: 75%; /* 横屏时增加状态区域宽度 */
-    }
-  }
-
-  /* 高分辨率屏幕优化 */
-  @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-    .dice-face {
-      border-width: 2px;
+    .game-header h1 .pi-map {
+      font-size: 1.2rem;
     }
 
-    .dot {
-      width: 13px;
-      height: 13px;
+    .header-status {
+      flex-direction: column;
+      gap: 0.2rem;
     }
 
-    .player-avatar,
-    .current-avatar,
-    .winner-avatar {
-      border-width: 1px;
+    .header-actions {
+      flex-direction: column;
+      gap: 0.3rem;
+    }
+
+    .header-actions .p-button {
+      font-size: 0;
+      padding: 0.4rem;
+      min-width: 36px;
+    }
+
+    .header-actions .p-button .p-button-icon {
+      margin: 0;
+    }
+
+    .header-players {
+      flex: 0 0 auto;
+    }
+
+    .game-main {
+      min-height: 0;
+      height: 100vh;
     }
   }
 
   /* 减少动画偏好 */
   @media (prefers-reduced-motion: reduce) {
-    .dice.rolling {
-      animation: none;
-      transform: rotateX(360deg) rotateY(360deg);
-    }
-
-    .dice.can-roll {
-      animation: none;
-    }
-
-    .dice.rolled {
-      animation: none;
-    }
-
-    .current-indicator {
-      animation: none;
-    }
-
-    .player-item.player-moving {
-      animation: none;
-    }
-
     * {
       transition-duration: 0.1s !important;
     }
-  }
-
-  /* 顶部信息区域 */
-  /* 旧样式已被新的PrimeVue布局替代 */
-
-  /* 旧的响应式样式已被新的PrimeVue响应式设计替代 */
-
-  /* 旧的移动端样式已被新的响应式设计替代 */
-
-  /* 旧的超小屏幕样式已被新的响应式设计替代 */
-
-  /* 游戏状态样式 */
-  .status-waiting {
-    color: #4ecdc4;
-  }
-
-  .status-rolling {
-    color: #ff6b6b;
-    animation: pulse 1s infinite;
-  }
-
-  .status-moving {
-    color: #45b7d1;
   }
 
   .status-showing_effect {

--- a/src/components/GameBoard.vue
+++ b/src/components/GameBoard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { computed, ref, watch, nextTick } from 'vue'
+  import { computed, ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
   import type { BoardCell, Player } from '../types/game'
   import { CELL_ICON_NAMES } from '../config/gameConfig'
   import { Zap, Gift, Undo2, Moon, RotateCcw, Skull, Rocket, Sparkles, Link } from '@lucide/vue'
@@ -12,6 +12,7 @@
     lastEffect?: string
     canRoll?: boolean
     diceValue?: number | null
+    turnCount?: number
   }
 
   interface Emits {
@@ -41,12 +42,44 @@
   const activatedCell = ref<number | null>(null)
   const landingCell = ref<number | null>(null)
 
-  // Ring layout: distribute N cells along 4 edges of a rectangle
+  const boardRingRef = ref<HTMLElement | null>(null)
+  const containerWidth = ref(800)
+  const containerHeight = ref(600)
+  let resizeObserver: ResizeObserver | null = null
+
+  onMounted(() => {
+    if (boardRingRef.value) {
+      const rect = boardRingRef.value.getBoundingClientRect()
+      containerWidth.value = rect.width || 800
+      containerHeight.value = rect.height || 600
+    }
+    resizeObserver = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        containerWidth.value = entry.contentRect.width
+        containerHeight.value = entry.contentRect.height
+      }
+    })
+    if (boardRingRef.value) {
+      resizeObserver.observe(boardRingRef.value)
+    }
+  })
+
+  onUnmounted(() => {
+    resizeObserver?.disconnect()
+  })
+
+  const isMobile = computed(() => containerWidth.value < 600)
+
+  const layoutRatio = computed(() => {
+    const isPortrait = containerHeight.value > containerWidth.value
+    return isPortrait ? 1.0 : 1.6
+  })
+
   const ringLayout = computed(() => {
     const totalCells = props.board.length
     if (totalCells === 0) return { top: [], right: [], bottom: [], left: [] }
 
-    const ratio = 1.6
+    const ratio = layoutRatio.value
     const adjustedHorizontal = Math.ceil((totalCells * ratio) / (2 * (1 + ratio)))
     const adjustedVertical = Math.ceil((totalCells - 2 * adjustedHorizontal) / 2)
 
@@ -119,10 +152,52 @@
     return props.players.filter(p => p.position === position)
   }
 
+  const cellSize = computed(() => {
+    const { top, bottom } = ringLayout.value
+    const maxHorizontalCells = Math.max(top.length, bottom.length, 1)
+    const gap = 4
+    const edgePadding = 4
+    const availableWidth = containerWidth.value - edgePadding - (maxHorizontalCells - 1) * gap
+    const idealSize = Math.floor(availableWidth / maxHorizontalCells)
+    return Math.max(24, Math.min(idealSize, 56))
+  })
+
+  const cellIconSize = computed(() => Math.max(10, Math.round(cellSize.value * 0.38)))
+
+  const cellBorderRadius = computed(() => Math.max(6, Math.round(cellSize.value * 0.2)))
+
+  const markerSize = computed(() => Math.max(14, Math.min(Math.round(cellSize.value * 0.4), 24)))
+
+  const boardAspect = computed(() => {
+    const r = containerWidth.value / Math.max(containerHeight.value, 1)
+    if (r >= 1.6) return 1.8
+    if (r >= 1.0) return 0.4 * r + 1.16
+    return 1.0
+  })
+
+  const diceScale = computed(() => {
+    const s = cellSize.value
+    if (s >= 50) return 1
+    if (s >= 40) return 0.75
+    if (s >= 32) return 0.6
+    return 0.5
+  })
+
+  const boardCssVars = computed(() => ({
+    '--cell-size': `${cellSize.value}px`,
+    '--cell-icon-size': `${cellIconSize.value}px`,
+    '--cell-border-radius': `${cellBorderRadius.value}px`,
+    '--marker-size': `${markerSize.value}px`,
+    '--marker-offset': `${-markerSize.value / 2}px`,
+    '--board-aspect': `${boardAspect.value} / 1`,
+    '--dice-scale': `${diceScale.value}`,
+    '--edge-gap': `${cellSize.value >= 44 ? 4 : cellSize.value >= 36 ? 3 : 2}px`,
+  }))
+
   const getPlayerOffset = (playerIndex: number, totalOnCell: number): { x: number; y: number } => {
     if (totalOnCell === 1) return { x: 0, y: 0 }
     const angle = ((2 * Math.PI) / totalOnCell) * playerIndex - Math.PI / 2
-    const radius = 14
+    const radius = Math.max(8, cellSize.value * 0.25)
     return { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius }
   }
 
@@ -132,9 +207,66 @@
 
   const handleDiceRoll = () => {
     emit('roll')
+    vibrate(15)
+  }
+
+  const vibrate = (ms: number) => {
+    try {
+      navigator?.vibrate?.(ms)
+    } catch {
+      // vibration not supported
+    }
+  }
+
+  let longPressTimer: ReturnType<typeof setTimeout> | null = null
+  const isTouchDevice = ref(false)
+
+  const handleTouchStart = (cell: BoardCell, event: TouchEvent) => {
+    isTouchDevice.value = true
+    longPressTimer = setTimeout(() => {
+      showTooltipForCell(cell, event.touches[0].clientX, event.touches[0].clientY)
+      vibrate(10)
+    }, 300)
+  }
+
+  const handleTouchEnd = () => {
+    if (longPressTimer) {
+      clearTimeout(longPressTimer)
+      longPressTimer = null
+    }
+    setTimeout(hideTooltip, 200)
+  }
+
+  const handleTouchMove = () => {
+    if (longPressTimer) {
+      clearTimeout(longPressTimer)
+      longPressTimer = null
+    }
+  }
+
+  const showTooltipForCell = (cell: BoardCell, clientX: number, clientY: number) => {
+    tooltipCell.value = cell
+    tooltipVisible.value = true
+
+    if (isMobile.value) {
+      tooltipStyle.value = { left: '0px', top: '0px' }
+      return
+    }
+
+    const tooltipWidth = 220
+    const tooltipHeight = 120
+    let left = clientX - tooltipWidth / 2
+    let top = clientY - tooltipHeight - 16
+
+    if (left < 8) left = 8
+    if (left + tooltipWidth > window.innerWidth - 8) left = window.innerWidth - tooltipWidth - 8
+    if (top < 8) top = clientY + 16
+
+    tooltipStyle.value = { left: `${left}px`, top: `${top}px` }
   }
 
   const showTooltip = (cell: BoardCell, event: MouseEvent | TouchEvent) => {
+    if (isTouchDevice.value) return
     tooltipCell.value = cell
     tooltipVisible.value = true
 
@@ -158,15 +290,20 @@
     tooltipCell.value = null
   }
 
-  // Animation: trigger cell activation pulse
+  const handleBoardClick = (event: MouseEvent) => {
+    const target = event.target as HTMLElement
+    if (target.closest('.board-cell')) return
+    hideTooltip()
+  }
+
   const triggerCellActivation = (position: number) => {
     activatedCell.value = position
+    vibrate(10)
     setTimeout(() => {
       activatedCell.value = null
     }, 1500)
   }
 
-  // Animation: trigger landing effect
   const triggerLanding = (position: number) => {
     landingCell.value = position
     setTimeout(() => {
@@ -194,8 +331,8 @@
 </script>
 
 <template>
-  <div class="game-board">
-    <div class="board-ring">
+  <div class="game-board" @click="handleBoardClick">
+    <div ref="boardRingRef" class="board-ring" :style="boardCssVars">
       <!-- Top edge -->
       <div class="ring-edge ring-top">
         <div
@@ -206,13 +343,15 @@
           @click="handleCellClick(getCellByPosition(pos))"
           @mouseenter="showTooltip(getCellByPosition(pos), $event)"
           @mouseleave="hideTooltip"
+          @touchstart.passive="handleTouchStart(getCellByPosition(pos), $event)"
+          @touchend.passive="handleTouchEnd()"
+          @touchmove.passive="handleTouchMove()"
         >
           <div class="cell-glow"></div>
           <div class="cell-icon">
-            <component :is="getCellIcon(pos)" v-if="getCellIcon(pos)" :size="20" />
+            <component :is="getCellIcon(pos)" v-if="getCellIcon(pos)" :size="cellIconSize" />
           </div>
           <span class="cell-number">{{ pos }}</span>
-          <!-- Player markers -->
           <div class="cell-players">
             <div
               v-for="(player, pIdx) in getPlayersOnCell(pos)"
@@ -243,10 +382,13 @@
           @click="handleCellClick(getCellByPosition(pos))"
           @mouseenter="showTooltip(getCellByPosition(pos), $event)"
           @mouseleave="hideTooltip"
+          @touchstart.passive="handleTouchStart(getCellByPosition(pos), $event)"
+          @touchend.passive="handleTouchEnd()"
+          @touchmove.passive="handleTouchMove()"
         >
           <div class="cell-glow"></div>
           <div class="cell-icon">
-            <component :is="getCellIcon(pos)" v-if="getCellIcon(pos)" :size="20" />
+            <component :is="getCellIcon(pos)" v-if="getCellIcon(pos)" :size="cellIconSize" />
           </div>
           <span class="cell-number">{{ pos }}</span>
           <div class="cell-players">
@@ -278,18 +420,18 @@
             @roll="handleDiceRoll"
           />
         </div>
-        <div v-if="currentPlayer" class="center-status">
+        <div v-if="currentPlayer && !isMobile" class="center-status">
           <div class="status-player">
             <span class="status-avatar" :style="{ backgroundColor: currentPlayer.color }">
               {{ currentPlayer.name.charAt(0) }}
             </span>
             <span class="status-name">{{ currentPlayer.name }}</span>
+            <span v-if="turnCount" class="status-turn">R{{ turnCount }}</span>
           </div>
           <div class="status-position">
             {{ currentPlayer.position === 0 ? '等待起飞' : `第 ${currentPlayer.position} 格` }}
           </div>
         </div>
-        <!-- Players at position 0 (waiting to take off) -->
         <div v-if="playersAtStart.length > 0" class="start-zone">
           <Rocket :size="14" class="start-zone-icon" />
           <div class="start-zone-players">
@@ -304,7 +446,7 @@
             </div>
           </div>
         </div>
-        <div v-if="lastEffect" class="center-effect">
+        <div v-if="lastEffect && !isMobile" class="center-effect">
           <Sparkles :size="14" />
           <span>{{ lastEffect }}</span>
         </div>
@@ -320,10 +462,13 @@
           @click="handleCellClick(getCellByPosition(pos))"
           @mouseenter="showTooltip(getCellByPosition(pos), $event)"
           @mouseleave="hideTooltip"
+          @touchstart.passive="handleTouchStart(getCellByPosition(pos), $event)"
+          @touchend.passive="handleTouchEnd()"
+          @touchmove.passive="handleTouchMove()"
         >
           <div class="cell-glow"></div>
           <div class="cell-icon">
-            <component :is="getCellIcon(pos)" v-if="getCellIcon(pos)" :size="20" />
+            <component :is="getCellIcon(pos)" v-if="getCellIcon(pos)" :size="cellIconSize" />
           </div>
           <span class="cell-number">{{ pos }}</span>
           <div class="cell-players">
@@ -356,10 +501,13 @@
           @click="handleCellClick(getCellByPosition(pos))"
           @mouseenter="showTooltip(getCellByPosition(pos), $event)"
           @mouseleave="hideTooltip"
+          @touchstart.passive="handleTouchStart(getCellByPosition(pos), $event)"
+          @touchend.passive="handleTouchEnd()"
+          @touchmove.passive="handleTouchMove()"
         >
           <div class="cell-glow"></div>
           <div class="cell-icon">
-            <component :is="getCellIcon(pos)" v-if="getCellIcon(pos)" :size="20" />
+            <component :is="getCellIcon(pos)" v-if="getCellIcon(pos)" :size="cellIconSize" />
           </div>
           <span class="cell-number">{{ pos }}</span>
           <div class="cell-players">
@@ -389,9 +537,13 @@
       <div class="corner corner-tl"></div>
     </div>
 
-    <!-- Tooltip -->
+    <!-- Desktop tooltip (follows cursor) -->
     <Teleport to="body">
-      <div v-if="tooltipVisible && tooltipCell" class="cell-tooltip" :style="tooltipStyle">
+      <div
+        v-if="tooltipVisible && tooltipCell && !isMobile"
+        class="cell-tooltip"
+        :style="tooltipStyle"
+      >
         <div class="tooltip-header">
           <span class="tooltip-number">#{{ tooltipCell.position }}</span>
           <span class="tooltip-type" :class="'type-' + tooltipCell.type">
@@ -431,6 +583,19 @@
       </div>
     </Teleport>
 
+    <!-- Mobile tooltip (bottom bar) -->
+    <Transition name="mobile-tooltip">
+      <div v-if="tooltipVisible && tooltipCell && isMobile" class="mobile-tooltip-bar">
+        <span class="tooltip-number">#{{ tooltipCell.position }}</span>
+        <span class="tooltip-type" :class="'type-' + tooltipCell.type">
+          {{ getCellTypeName(tooltipCell.type) }}
+        </span>
+        <span v-if="tooltipCell.effect" class="tooltip-desc-inline">
+          {{ tooltipCell.effect.description }}
+        </span>
+      </div>
+    </Transition>
+
     <!-- Full-screen effect flash -->
     <Transition name="flash">
       <div
@@ -449,11 +614,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 1rem;
+    padding: 0.5rem;
     position: relative;
   }
 
-  /* === Ring Layout === */
+  /* === Ring Layout (CSS-var driven) === */
   .board-ring {
     display: grid;
     grid-template-areas:
@@ -464,14 +629,14 @@
     grid-template-rows: auto 1fr auto;
     gap: 0;
     width: 100%;
-    max-width: 800px;
-    aspect-ratio: 1.4 / 1;
+    max-width: 1100px;
+    aspect-ratio: var(--board-aspect, 1.4 / 1);
     position: relative;
   }
 
   .ring-edge {
     display: flex;
-    gap: 4px;
+    gap: var(--edge-gap, 4px);
     padding: 2px;
   }
 
@@ -506,8 +671,8 @@
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
-    padding: 1rem;
-    min-height: 200px;
+    padding: 0.5rem;
+    min-height: 0;
   }
 
   /* === Corner Connectors === */
@@ -535,12 +700,12 @@
     left: 0;
   }
 
-  /* === Cell Design === */
+  /* === Cell Design (dynamic via CSS vars) === */
   .board-cell {
     position: relative;
-    width: 56px;
-    height: 56px;
-    border-radius: 12px;
+    width: var(--cell-size, 56px);
+    height: var(--cell-size, 56px);
+    border-radius: var(--cell-border-radius, 12px);
     cursor: pointer;
     display: flex;
     flex-direction: column;
@@ -556,6 +721,13 @@
     overflow: visible;
   }
 
+  .board-cell::before {
+    content: '';
+    position: absolute;
+    inset: -4px;
+    z-index: 1;
+  }
+
   .board-cell:hover {
     transform: scale(1.12);
     z-index: 5;
@@ -564,10 +736,17 @@
   .board-cell .cell-glow {
     position: absolute;
     inset: -2px;
-    border-radius: 14px;
-    opacity: 0.4;
+    border-radius: calc(var(--cell-border-radius, 12px) + 2px);
+    opacity: 0;
     transition: opacity 0.3s ease;
     pointer-events: none;
+    display: none;
+  }
+
+  .board-cell:hover .cell-glow,
+  .board-cell.cell-occupied .cell-glow {
+    display: block;
+    opacity: 0.4;
   }
 
   .board-cell:hover .cell-glow {
@@ -583,9 +762,9 @@
 
   .board-cell .cell-number {
     position: absolute;
-    bottom: 2px;
-    right: 4px;
-    font-size: 0.55rem;
+    bottom: 1px;
+    right: 2px;
+    font-size: 0.5rem;
     font-weight: 600;
     opacity: 0.4;
     z-index: 2;
@@ -728,12 +907,11 @@
     }
   }
 
-  /* Ripple effect on landing */
   .cell-landing::after {
     content: '';
     position: absolute;
     inset: -4px;
-    border-radius: 16px;
+    border-radius: calc(var(--cell-border-radius, 12px) + 4px);
     border: 2px solid rgba(255, 255, 255, 0.5);
     animation: ripple 0.8s ease-out forwards;
     pointer-events: none;
@@ -750,10 +928,10 @@
     }
   }
 
-  /* === Player Markers === */
+  /* === Player Markers (dynamic via CSS vars) === */
   .cell-players {
     position: absolute;
-    top: -12px;
+    top: var(--marker-offset, -12px);
     left: 50%;
     transform: translateX(-50%);
     display: flex;
@@ -764,15 +942,15 @@
   }
 
   .player-marker {
-    width: 24px;
-    height: 24px;
+    width: var(--marker-size, 24px);
+    height: var(--marker-size, 24px);
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     color: white;
     font-weight: 700;
-    font-size: 10px;
+    font-size: calc(var(--marker-size, 24px) * 0.4);
     border: 2px solid rgba(255, 255, 255, 0.7);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
     text-transform: uppercase;
@@ -786,6 +964,7 @@
       0 0 8px rgba(255, 215, 0, 0.6),
       0 0 20px rgba(255, 215, 0, 0.3);
     animation: playerPulse 2s ease-in-out infinite;
+    will-change: transform, box-shadow;
   }
 
   .player-marker.player-moving {
@@ -825,8 +1004,8 @@
 
   /* === Center Area === */
   .center-dice {
-    transform: scale(0.75);
     transform-origin: center;
+    transform: scale(var(--dice-scale, 1));
   }
 
   .center-status {
@@ -834,7 +1013,7 @@
     flex-direction: column;
     align-items: center;
     gap: 0.25rem;
-    padding: 0.5rem 1rem;
+    padding: 0.3rem 0.6rem;
     background: rgba(255, 255, 255, 0.04);
     border-radius: 12px;
     border: 1px solid rgba(255, 255, 255, 0.06);
@@ -863,6 +1042,16 @@
     font-weight: 600;
     font-size: 0.85rem;
     color: var(--text-primary);
+  }
+
+  .status-turn {
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    background: rgba(255, 255, 255, 0.06);
+    padding: 0.1rem 0.35rem;
+    border-radius: 4px;
+    font-variant-numeric: tabular-nums;
   }
 
   .status-position {
@@ -921,7 +1110,7 @@
     }
   }
 
-  /* === Tooltip === */
+  /* === Tooltip (desktop) === */
   .cell-tooltip {
     position: fixed;
     z-index: 10000;
@@ -1012,6 +1201,52 @@
     font-size: 0.7rem;
   }
 
+  /* === Mobile Tooltip (bottom bar) === */
+  .mobile-tooltip-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: rgba(15, 15, 35, 0.95);
+    backdrop-filter: blur(12px);
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    font-size: 0.8rem;
+    color: var(--text-primary);
+  }
+
+  .mobile-tooltip-bar .tooltip-number {
+    font-size: 0.8rem;
+    flex-shrink: 0;
+  }
+
+  .mobile-tooltip-bar .tooltip-type {
+    flex-shrink: 0;
+  }
+
+  .tooltip-desc-inline {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mobile-tooltip-enter-active {
+    transition: transform 0.2s ease-out;
+  }
+  .mobile-tooltip-leave-active {
+    transition: transform 0.15s ease-in;
+  }
+  .mobile-tooltip-enter-from,
+  .mobile-tooltip-leave-to {
+    transform: translateY(100%);
+  }
+
   /* === Full-screen Effect Flash === */
   .effect-flash {
     position: fixed;
@@ -1055,169 +1290,37 @@
     animation: flashPulse 0.3s ease-out reverse;
   }
 
-  /* === Responsive: >= 768px (Desktop/Tablet) === */
-  @media (min-width: 768px) {
-    .board-cell {
-      width: 56px;
-      height: 56px;
-    }
-    .board-cell .cell-icon :deep(svg) {
-      width: 22px;
-      height: 22px;
-    }
-  }
-
-  /* === Responsive: 480-767px (Small Tablet / Large Phone) === */
-  @media (max-width: 767px) {
-    .game-board {
-      padding: 0.5rem;
-    }
-
-    .board-ring {
-      aspect-ratio: 1.2 / 1;
-    }
-
-    .board-cell {
-      width: 44px;
-      height: 44px;
-      border-radius: 10px;
-    }
-
-    .board-cell .cell-icon :deep(svg) {
-      width: 18px;
-      height: 18px;
-    }
-
-    .cell-number {
-      font-size: 0.5rem;
-    }
-
-    .ring-edge {
-      gap: 3px;
-    }
-
-    .ring-center {
-      padding: 0.5rem;
-      min-height: 140px;
-    }
-
-    .center-dice {
-      transform: scale(0.6);
-    }
-
-    .center-status {
-      padding: 0.3rem 0.6rem;
-    }
-
-    .status-name {
-      font-size: 0.75rem;
-    }
-    .status-position {
-      font-size: 0.65rem;
-    }
-
-    .player-marker {
-      width: 20px;
-      height: 20px;
-      font-size: 8px;
-    }
-  }
-
-  /* === Responsive: < 480px (Phone) === */
-  @media (max-width: 479px) {
-    .game-board {
-      padding: 0.25rem;
-    }
-
-    .board-ring {
-      aspect-ratio: 1.1 / 1;
-    }
-
-    .board-cell {
-      width: 36px;
-      height: 36px;
-      border-radius: 8px;
-      border-width: 1.5px;
-    }
-
-    .board-cell .cell-icon :deep(svg) {
-      width: 15px;
-      height: 15px;
-    }
-
-    .cell-number {
-      font-size: 0.45rem;
-      bottom: 1px;
-      right: 2px;
-    }
-
-    .ring-edge {
-      gap: 2px;
-      padding: 1px;
-    }
-
-    .ring-center {
-      padding: 0.25rem;
-      min-height: 100px;
-      gap: 0.25rem;
-    }
-
-    .center-dice {
-      transform: scale(0.5);
-    }
-
-    .center-status {
-      padding: 0.2rem 0.5rem;
-    }
-
-    .center-effect {
-      font-size: 0.65rem;
-      padding: 0.25rem 0.5rem;
-      max-width: 140px;
-    }
-
-    .status-name {
-      font-size: 0.7rem;
-    }
-    .status-position {
-      font-size: 0.6rem;
-    }
-
-    .player-marker {
-      width: 18px;
-      height: 18px;
-      font-size: 7px;
-      border-width: 1.5px;
-    }
-
-    .cell-players {
-      top: -10px;
-    }
-  }
-
   /* === Landscape mode === */
-  @media (max-height: 500px) and (orientation: landscape) {
-    .board-ring {
-      aspect-ratio: 2 / 1;
-      max-width: 90vw;
-    }
-
-    .board-cell {
-      width: 32px;
-      height: 32px;
-    }
-
-    .board-cell .cell-icon :deep(svg) {
-      width: 14px;
-      height: 14px;
+  @media (orientation: landscape) and (max-height: 600px) {
+    .game-board {
+      padding: 0.25rem;
     }
 
     .ring-center {
-      min-height: 80px;
+      gap: 0.25rem;
+      padding: 0.25rem;
+    }
+  }
+
+  /* === Reduced motion === */
+  @media (prefers-reduced-motion: reduce) {
+    .board-cell,
+    .player-marker,
+    .center-effect {
+      transition: none !important;
+      animation: none !important;
     }
 
-    .center-dice {
-      transform: scale(0.45);
+    .cell-landing::after {
+      animation: none !important;
+    }
+
+    .player-marker.current-player {
+      animation: none !important;
+    }
+
+    .effect-flash {
+      display: none;
     }
   }
 </style>

--- a/src/components/PlayerPanel.vue
+++ b/src/components/PlayerPanel.vue
@@ -1,765 +1,180 @@
 <script setup lang="ts">
-  import { ref, watch, nextTick, onMounted } from 'vue'
   import type { Player } from '../types/game'
-  import { devLog } from '../utils/logger'
 
   interface Props {
     players: Player[]
     currentPlayerIndex: number
+    collapsed?: boolean
   }
 
   const props = defineProps<Props>()
 
-  // 引用玩家列表容器和当前玩家元素
-  const playersContainer = ref<HTMLElement>()
-  const playerCardRefs = ref<(HTMLElement | null)[]>([])
+  defineEmits<{
+    (e: 'toggle'): void
+  }>()
 
-  // 设置玩家卡片引用的函数
-  const setPlayerCardRef = (el: HTMLElement | null, index: number) => {
-    // 确保数组有足够的长度
-    if (!playerCardRefs.value) {
-      playerCardRefs.value = []
-    }
+  const currentPlayer = computed(() => props.players[props.currentPlayerIndex])
 
-    // 扩展数组长度以适应索引
-    while (playerCardRefs.value.length <= index) {
-      playerCardRefs.value.push(null)
-    }
-
-    playerCardRefs.value[index] = el
-
-    // 调试信息
-    devLog(`Setting ref for player ${index}:`, !!el)
-  }
-
-  // 自动滚动到当前玩家
-  const scrollToCurrentPlayer = () => {
-    devLog('=== scrollToCurrentPlayer called ===')
-    devLog('currentPlayerIndex:', props.currentPlayerIndex)
-    devLog('players.length:', props.players.length)
-
-    // 检测是否在移动设备上
-    const isMobile = window.innerWidth <= 768
-    devLog('📱 Device info:', {
-      isMobile,
-      windowWidth: window.innerWidth,
-      windowHeight: window.innerHeight,
-      userAgent: navigator.userAgent.includes('Mobile') ? 'Mobile' : 'Desktop',
-    })
-
-    if (!playersContainer.value) {
-      devLog('❌ playersContainer not found')
-      return
-    }
-
-    if (!playerCardRefs.value || playerCardRefs.value.length === 0) {
-      devLog('❌ playerCardRefs array is empty or null')
-      devLog('playerCardRefs.value:', playerCardRefs.value)
-      return
-    }
-
-    if (props.currentPlayerIndex < 0 || props.currentPlayerIndex >= props.players.length) {
-      devLog('❌ Invalid currentPlayerIndex:', props.currentPlayerIndex)
-      return
-    }
-
-    const currentElement = playerCardRefs.value[props.currentPlayerIndex]
-    if (!currentElement) {
-      devLog('❌ currentElement not found for index:', props.currentPlayerIndex)
-      devLog(
-        'Available refs:',
-        playerCardRefs.value.map((ref, i) => ({ index: i, exists: !!ref }))
-      )
-      return
-    }
-
-    const container = playersContainer.value
-    const containerHeight = container.clientHeight
-    const containerScrollTop = container.scrollTop
-    const containerScrollHeight = container.scrollHeight
-
-    // 获取元素相对于滚动容器的位置
-    // 使用getBoundingClientRect来获取更准确的位置信息
-    const containerRect = container.getBoundingClientRect()
-    const elementRect = currentElement.getBoundingClientRect()
-
-    // 计算元素相对于容器顶部的位置
-    const elementTop = currentElement.offsetTop
-    const elementHeight = currentElement.clientHeight
-
-    // 也计算相对位置作为备用
-    const relativeTop = elementRect.top - containerRect.top + containerScrollTop
-
-    devLog('📊 Scroll calculation data:', {
-      containerHeight,
-      containerScrollTop,
-      containerScrollHeight,
-      elementTop,
-      elementHeight,
-      relativeTop,
-      containerRect: { top: containerRect.top, height: containerRect.height },
-      elementRect: { top: elementRect.top, height: elementRect.height },
-      currentPlayerIndex: props.currentPlayerIndex,
-    })
-
-    // 使用更准确的相对位置计算
-    const useRelativePosition = Math.abs(relativeTop - elementTop) > 10
-    const actualElementTop = useRelativePosition ? relativeTop : elementTop
-
-    devLog('📍 Using position:', useRelativePosition ? 'relative' : 'offset', actualElementTop)
-
-    // 计算目标滚动位置：让当前玩家卡片的顶部对齐到容器顶部，并留出一些边距
-    // 移动端使用更小的边距，确保更多内容可见
-    const topMargin = isMobile ? 10 : 20 // 移动端10px，桌面端20px边距
-    const targetScrollTop = actualElementTop - topMargin
-
-    // 确保滚动位置在有效范围内
-    const maxScrollTop = containerScrollHeight - containerHeight
-    const finalScrollTop = Math.max(0, Math.min(targetScrollTop, maxScrollTop))
-
-    devLog('🎯 Scroll target:', {
-      targetScrollTop,
-      finalScrollTop,
-      maxScrollTop,
-      scrollDistance: Math.abs(finalScrollTop - containerScrollTop),
-    })
-
-    // 只有当滚动距离足够大时才执行滚动
-    const minScrollDistance = 5
-    if (Math.abs(finalScrollTop - containerScrollTop) < minScrollDistance) {
-      devLog('⏭️ Scroll distance too small, skipping')
-      return
-    }
-
-    // 执行滚动
-    devLog('🚀 Executing scroll from', containerScrollTop, 'to', finalScrollTop)
-
-    try {
-      container.scrollTo({
-        top: finalScrollTop,
-        behavior: 'smooth',
-      })
-    } catch (error) {
-      console.warn('⚠️ scrollTo failed, trying scrollIntoView fallback:', error)
-      // 备用方案：使用scrollIntoView
-      currentElement.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-        inline: 'nearest',
-      })
-    }
-
-    // 验证滚动结果
-    setTimeout(() => {
-      const newScrollTop = container.scrollTop
-      devLog('✅ Scroll completed. New position:', newScrollTop)
-      devLog('Expected:', finalScrollTop, 'Actual:', newScrollTop)
-
-      // 如果滚动没有达到预期位置，尝试备用方案
-      const scrollDifference = Math.abs(newScrollTop - finalScrollTop)
-      if (scrollDifference > 20) {
-        console.warn('⚠️ Scroll position not as expected, trying scrollIntoView fallback')
-        currentElement.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start',
-          inline: 'nearest',
-        })
-      }
-    }, 600)
-  }
-
-  // 监听当前玩家变化，自动滚动
-  watch(
-    () => props.currentPlayerIndex,
-    (newIndex, oldIndex) => {
-      devLog('🔄 === WATCH TRIGGERED ===')
-      devLog('currentPlayerIndex changed from', oldIndex, 'to', newIndex)
-      devLog('Total players:', props.players.length)
-
-      if (newIndex < 0 || newIndex >= props.players.length) {
-        devLog('❌ Invalid player index:', newIndex)
-        return
-      }
-
-      // 使用多重延迟确保DOM完全更新
-      nextTick(() => {
-        devLog('⏳ nextTick executed, waiting for DOM update...')
-
-        // 第一次延迟：等待DOM更新
-        setTimeout(() => {
-          devLog('⏳ First timeout executed, checking refs...')
-
-          // 检查refs是否已经准备好
-          if (!playerCardRefs.value || !playerCardRefs.value[newIndex]) {
-            devLog('⚠️ Refs not ready, waiting longer...')
-
-            // 第二次延迟：等待refs准备好
-            setTimeout(() => {
-              devLog('⏳ Second timeout executed, calling scrollToCurrentPlayer')
-              scrollToCurrentPlayer()
-            }, 200)
-          } else {
-            devLog('✅ Refs ready, calling scrollToCurrentPlayer')
-            scrollToCurrentPlayer()
-          }
-        }, 100)
-      })
-    },
-    { immediate: false }
-  )
-
-  // 也监听players数组的变化，以防数组更新时需要重新滚动
-  watch(
-    () => props.players.length,
-    (newLength, oldLength) => {
-      devLog('👥 Players length changed from', oldLength, 'to', newLength)
-      if (newLength > 0 && newLength !== oldLength) {
-        // 重置refs数组以匹配新的玩家数量
-        playerCardRefs.value = new Array(newLength).fill(null)
-
-        nextTick(() => {
-          setTimeout(() => {
-            devLog('🔄 Scrolling after players array change')
-            scrollToCurrentPlayer()
-          }, 300)
-        })
-      }
-    }
-  )
-
-  // 组件挂载后初始化
-  onMounted(() => {
-    devLog('🚀 PlayerPanel mounted')
-    devLog('Initial players:', props.players.length)
-    devLog('Initial currentPlayerIndex:', props.currentPlayerIndex)
-
-    // 初始化refs数组
-    if (props.players.length > 0) {
-      playerCardRefs.value = new Array(props.players.length).fill(null)
-    }
-
-    // 初始化时也执行一次滚动，给更多时间让DOM完全渲染
-    nextTick(() => {
-      setTimeout(() => {
-        devLog('🎯 Initial scroll after mount')
-        scrollToCurrentPlayer()
-      }, 500)
-    })
-  })
-
-  // 暴露方法供调试使用
-  const debugScroll = () => {
-    devLog('🔍 === Debug Scroll Info ===')
-    devLog('playersContainer.value:', !!playersContainer.value)
-    devLog(
-      'playerCardRefs.value:',
-      playerCardRefs.value?.map((ref, i) => ({ index: i, exists: !!ref }))
-    )
-    devLog('props.currentPlayerIndex:', props.currentPlayerIndex)
-    devLog('props.players.length:', props.players.length)
-
-    if (playersContainer.value) {
-      const container = playersContainer.value
-      devLog('Container info:', {
-        clientHeight: container.clientHeight,
-        scrollHeight: container.scrollHeight,
-        scrollTop: container.scrollTop,
-        hasScrollbar: container.scrollHeight > container.clientHeight,
-      })
-    }
-
-    scrollToCurrentPlayer()
-  }
-
-  // 强制滚动方法（使用scrollIntoView）
-  const forceScrollToCurrentPlayer = () => {
-    devLog('🔧 Force scroll using scrollIntoView')
-    const currentElement = playerCardRefs.value?.[props.currentPlayerIndex]
-    if (currentElement) {
-      currentElement.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-        inline: 'nearest',
-      })
-    } else {
-      devLog('❌ No element found for force scroll')
-    }
-  }
-
-  // 在开发环境下暴露到window对象供调试
-  if (import.meta.env.DEV) {
-    const debugWindow = window as typeof window & {
-      debugPlayerPanelScroll: typeof debugScroll
-      forcePlayerPanelScroll: typeof forceScrollToCurrentPlayer
-    }
-    debugWindow.debugPlayerPanelScroll = debugScroll
-    debugWindow.forcePlayerPanelScroll = forceScrollToCurrentPlayer
-  }
+  import { computed } from 'vue'
 </script>
 
 <template>
-  <div class="player-panel">
-    <h3>玩家状态</h3>
-    <div ref="playersContainer" class="players-container">
-      <div class="players-grid">
-        <div
-          v-for="(player, index) in players"
-          :key="player.id"
-          :ref="el => setPlayerCardRef(el as HTMLElement | null, index)"
-          class="player-card"
-          :class="{
-            current: currentPlayerIndex === index,
-            winner: player.isWinner,
-          }"
+  <div class="player-panel-wrapper" :class="{ 'is-collapsed': collapsed }">
+    <!-- Collapsed: show current player avatar as toggle -->
+    <button
+      v-if="collapsed"
+      class="collapsed-toggle"
+      :style="{ backgroundColor: currentPlayer?.color }"
+      @click="$emit('toggle')"
+    >
+      {{ currentPlayer?.name?.charAt(0) || '?' }}
+    </button>
+
+    <!-- Expanded: full pill list -->
+    <div v-else class="player-pills">
+      <div
+        v-for="(player, index) in players"
+        :key="player.id"
+        class="player-pill"
+        :class="{
+          current: currentPlayerIndex === index,
+          winner: player.isWinner,
+        }"
+      >
+        <div class="pill-color" :style="{ backgroundColor: player.color }"></div>
+        <span class="pill-name">{{ player.name }}</span>
+        <span class="pill-pos">{{ player.position === 0 ? '起点' : player.position }}</span>
+        <span
+          v-if="player.pendingMercyMultiplier && player.pendingMercyMultiplier > 1"
+          class="pill-mercy"
         >
-          <div class="player-header">
-            <div
-              class="player-color"
-              :style="{ backgroundColor: player.color, '--player-glow-color': player.color }"
-            ></div>
-            <span class="player-name">{{ player.name }}</span>
-            <div
-              v-if="player.pendingMercyMultiplier && player.pendingMercyMultiplier > 1"
-              class="mercy-badge"
-              :title="`下次惩罚 ×${player.pendingMercyMultiplier}`"
-            >
-              ×{{ player.pendingMercyMultiplier }}
-            </div>
-            <div v-if="player.isWinner" class="winner-badge">🏆</div>
-          </div>
-          <div class="player-stats">
-            <div class="stat">
-              <span class="label">位置:</span>
-              <span class="value">{{ player.position === 0 ? '飞机场' : player.position }}</span>
-            </div>
-          </div>
-        </div>
+          ×{{ player.pendingMercyMultiplier }}
+        </span>
+        <span v-if="player.isWinner" class="pill-trophy">🏆</span>
       </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-  .player-panel {
-    background: transparent;
-    border-radius: var(--radius-sm);
-    padding: clamp(0.8rem, 2.5vw, 1rem);
-    margin-bottom: clamp(0.8rem, 2.5vw, 1rem);
-  }
-
-  .player-panel h3 {
-    margin: 0 0 clamp(0.8rem, 2.5vw, 1rem) 0;
-    color: var(--text-primary);
-    text-align: center;
-    font-size: clamp(1.1rem, 3vw, 1.3rem);
-  }
-
-  .players-container {
-    max-height: 60vh;
-    min-height: 200px;
-    overflow-y: auto;
-    overflow-x: hidden;
-    scroll-behavior: smooth;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: thin;
-    scrollbar-color: rgba(255, 255, 255, 0.15) rgba(255, 255, 255, 0.05);
-    position: relative;
-  }
-
-  .players-container::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  .players-container::-webkit-scrollbar-track {
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: 3px;
-  }
-
-  .players-container::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.15);
-    border-radius: 3px;
-  }
-
-  .players-container::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.25);
-  }
-
-  .players-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(min(180px, 80vw), 1fr));
-    gap: clamp(0.8rem, 2.5vw, 1rem);
-    padding: clamp(0.2rem, 0.5vw, 0.4rem);
-  }
-
-  .player-card {
-    border: var(--glass-border);
-    border-radius: var(--radius-md);
-    padding: clamp(0.8rem, 2.5vw, 1rem);
-    transition: all var(--transition-normal);
-    background: var(--bg-glass);
-    backdrop-filter: blur(var(--glass-blur));
-  }
-
-  .player-card.current {
-    border-color: rgba(102, 126, 234, 0.5);
-    background: var(--bg-glass-hover);
-    box-shadow: var(--glow-sm) rgba(102, 126, 234, 0.3);
-    transform: translateY(-2px);
-  }
-
-  .player-card.winner {
-    border-color: rgba(254, 202, 87, 0.5);
-    background: var(--bg-glass-hover);
-    box-shadow: var(--glow-sm) rgba(254, 202, 87, 0.3);
-  }
-
-  .player-header {
+  .player-panel-wrapper {
     display: flex;
     align-items: center;
-    gap: clamp(0.4rem, 1vw, 0.5rem);
-    margin-bottom: clamp(0.4rem, 1vw, 0.5rem);
   }
 
-  .player-color {
-    width: clamp(16px, 4vw, 20px);
-    height: clamp(16px, 4vw, 20px);
+  .collapsed-toggle {
+    width: 32px;
+    height: 32px;
     border-radius: 50%;
-    border: 2px solid rgba(255, 255, 255, 0.2);
-    box-shadow: var(--glow-sm) var(--player-glow-color, rgba(255, 255, 255, 0.3));
+    border: 2px solid rgba(255, 255, 255, 0.5);
+    color: white;
+    font-weight: 700;
+    font-size: 12px;
+    text-transform: uppercase;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 0 8px rgba(102, 126, 234, 0.4);
+    transition: transform 0.2s ease;
   }
 
-  .player-name {
-    font-weight: bold;
+  .collapsed-toggle:hover {
+    transform: scale(1.1);
+  }
+
+  .player-pills {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  .player-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1.5px solid rgba(255, 255, 255, 0.1);
+    font-size: 0.8rem;
+    white-space: nowrap;
+    transition: all 0.2s ease;
+  }
+
+  .player-pill.current {
+    border-color: rgba(102, 126, 234, 0.6);
+    background: rgba(102, 126, 234, 0.15);
+    box-shadow: 0 0 8px rgba(102, 126, 234, 0.25);
+  }
+
+  .player-pill.winner {
+    border-color: rgba(254, 202, 87, 0.5);
+    background: rgba(254, 202, 87, 0.1);
+  }
+
+  .pill-color {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .pill-name {
+    font-weight: 600;
     color: var(--text-primary);
-    flex: 1;
-    font-size: clamp(0.9rem, 2.5vw, 1rem);
+    max-width: 5em;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
-  .winner-badge {
-    font-size: clamp(1rem, 3vw, 1.2rem);
-    animation: bounce 1s infinite;
+  .pill-pos {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
   }
 
-  .mercy-badge {
-    font-size: clamp(0.7rem, 2vw, 0.8rem);
+  .pill-mercy {
+    font-size: 0.65rem;
     font-weight: bold;
     color: #fff;
     background: linear-gradient(135deg, #f59e0b, #d97706);
-    padding: 0.15rem 0.4rem;
+    padding: 0.05rem 0.3rem;
     border-radius: 999px;
     line-height: 1.2;
-    box-shadow: 0 0 8px rgba(245, 158, 11, 0.5);
-    white-space: nowrap;
   }
 
-  .player-stats {
-    display: flex;
-    flex-direction: column;
-    gap: clamp(0.4rem, 1vw, 0.5rem);
+  .pill-trophy {
+    font-size: 0.75rem;
   }
 
-  .stat {
-    display: flex;
-    align-items: center;
-    gap: clamp(0.4rem, 1vw, 0.5rem);
-  }
-
-  .label {
-    font-size: clamp(0.8rem, 2.5vw, 0.9rem);
-    color: var(--text-muted);
-    min-width: clamp(35px, 8vw, 40px);
-  }
-
-  .value {
-    font-weight: bold;
-    color: var(--text-secondary);
-    font-size: clamp(0.8rem, 2.5vw, 0.9rem);
-  }
-
-  @keyframes bounce {
-    0%,
-    20%,
-    50%,
-    80%,
-    100% {
-      transform: translateY(0);
-    }
-    40% {
-      transform: translateY(-5px);
-    }
-    60% {
-      transform: translateY(-3px);
-    }
-  }
-
-  /* 自适应布局 - 移除固定断点，使用相对单位 */
-  @media (max-width: 1023px) {
-    .players-container {
-      max-height: 50vh;
-      min-height: 180px;
-    }
-
-    .players-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  /* 移动端优化 */
-  @media (max-width: 767px) {
-    .player-panel {
-      padding: 0.5rem;
-      margin-bottom: 0.5rem;
-    }
-
-    .player-panel h3 {
-      margin: 0 0 0.5rem 0;
-      font-size: clamp(1rem, 2.5vw, 1.1rem);
-    }
-
-    .players-container {
-      max-height: 40vh;
-      min-height: 160px;
-    }
-
-    .players-container::-webkit-scrollbar {
-      width: 4px;
-    }
-
-    .players-grid {
-      gap: 0.5rem;
-      padding: 0.2rem;
-    }
-
-    .player-card {
-      padding: 0.5rem;
-      border-width: 1px;
-    }
-
-    .player-header {
+  @media (max-width: 768px) {
+    .player-pills {
       gap: 0.3rem;
-      margin-bottom: 0.3rem;
+      overflow-x: auto;
+      flex-wrap: nowrap;
+      scrollbar-width: none;
+      -webkit-overflow-scrolling: touch;
     }
 
-    .player-color {
-      width: clamp(12px, 3vw, 16px);
-      height: clamp(12px, 3vw, 16px);
-      border-width: 1px;
+    .player-pills::-webkit-scrollbar {
+      display: none;
     }
 
-    .player-name {
-      font-size: clamp(0.8rem, 2.2vw, 0.9rem);
-    }
-
-    .winner-badge {
-      font-size: clamp(0.8rem, 2.5vw, 1rem);
-    }
-
-    .player-stats {
-      gap: 0.3rem;
-    }
-
-    .stat {
-      gap: 0.3rem;
-    }
-
-    .label {
-      font-size: clamp(0.7rem, 2vw, 0.8rem);
-      min-width: clamp(30px, 7vw, 35px);
-    }
-
-    .value {
-      font-size: clamp(0.7rem, 2vw, 0.8rem);
-    }
-  }
-
-  /* 小屏手机优化 */
-  @media (max-width: 480px) {
-    .player-panel {
-      padding: 0.4rem;
-      margin-bottom: 0.4rem;
-    }
-
-    .player-panel h3 {
-      margin: 0 0 0.4rem 0;
-      font-size: clamp(0.9rem, 2.2vw, 1rem);
-    }
-
-    .players-container {
-      max-height: 35vh;
-    }
-
-    .players-container::-webkit-scrollbar {
-      width: 3px;
-    }
-
-    .players-grid {
-      gap: 0.4rem;
-      padding: 0.1rem;
-    }
-
-    .player-card {
-      padding: 0.4rem;
-    }
-
-    .player-header {
-      gap: 0.25rem;
-      margin-bottom: 0.25rem;
-    }
-
-    .player-color {
-      width: clamp(10px, 2.5vw, 12px);
-      height: clamp(10px, 2.5vw, 12px);
-    }
-
-    .player-name {
-      font-size: clamp(0.75rem, 2vw, 0.8rem);
-    }
-
-    .winner-badge {
-      font-size: clamp(0.7rem, 2.2vw, 0.8rem);
-    }
-
-    .player-stats {
+    .player-pill {
+      font-size: 0.75rem;
+      padding: 0.2rem 0.5rem;
       gap: 0.25rem;
     }
 
-    .stat {
-      gap: 0.25rem;
+    .pill-color {
+      width: 8px;
+      height: 8px;
     }
 
-    .label {
-      font-size: clamp(0.65rem, 1.8vw, 0.7rem);
-      min-width: clamp(25px, 6vw, 30px);
-    }
-
-    .value {
-      font-size: clamp(0.65rem, 1.8vw, 0.7rem);
-    }
-  }
-
-  /* 超小屏手机优化 */
-  @media (max-width: 360px) {
-    .player-panel {
-      padding: 0.3rem;
-      margin-bottom: 0.3rem;
-    }
-
-    .player-panel h3 {
-      margin: 0 0 0.3rem 0;
-      font-size: clamp(0.8rem, 2vw, 0.9rem);
-    }
-
-    .players-container {
-      max-height: 30vh;
-    }
-
-    .players-container::-webkit-scrollbar {
-      width: 2px;
-    }
-
-    .players-grid {
-      gap: 0.3rem;
-      padding: 0.1rem;
-    }
-
-    .player-card {
-      padding: 0.3rem;
-    }
-
-    .player-header {
-      gap: 0.2rem;
-      margin-bottom: 0.2rem;
-    }
-
-    .player-color {
-      width: clamp(8px, 2vw, 10px);
-      height: clamp(8px, 2vw, 10px);
-    }
-
-    .player-name {
-      font-size: clamp(0.7rem, 1.8vw, 0.75rem);
-    }
-
-    .winner-badge {
-      font-size: clamp(0.6rem, 1.8vw, 0.7rem);
-    }
-
-    .player-stats {
-      gap: 0.2rem;
-    }
-
-    .stat {
-      gap: 0.2rem;
-    }
-
-    .label {
-      font-size: clamp(0.6rem, 1.5vw, 0.65rem);
-      min-width: clamp(20px, 5vw, 25px);
-    }
-
-    .value {
-      font-size: clamp(0.6rem, 1.5vw, 0.65rem);
-    }
-  }
-
-  /* 横屏模式优化 */
-  @media (max-width: 767px) and (orientation: landscape) {
-    .player-panel {
-      padding: 0.3rem;
-      margin-bottom: 0.3rem;
-    }
-
-    .player-panel h3 {
-      margin: 0 0 0.3rem 0;
-      font-size: clamp(0.8rem, 2vw, 0.9rem);
-    }
-
-    .players-container {
-      max-height: 25vh;
-    }
-
-    .players-container::-webkit-scrollbar {
-      width: 3px;
-    }
-
-    .players-grid {
-      gap: 0.3rem;
-      padding: 0.1rem;
-    }
-
-    .player-card {
-      padding: 0.3rem;
-    }
-
-    .player-header {
-      gap: 0.2rem;
-      margin-bottom: 0.2rem;
-    }
-
-    .player-color {
-      width: clamp(10px, 2.5vw, 12px);
-      height: clamp(10px, 2.5vw, 12px);
-    }
-
-    .player-name {
-      font-size: clamp(0.75rem, 2vw, 0.8rem);
-    }
-
-    .player-stats {
-      gap: 0.2rem;
-    }
-
-    .stat {
-      gap: 0.2rem;
-    }
-
-    .label {
-      font-size: clamp(0.65rem, 1.8vw, 0.7rem);
-      min-width: clamp(25px, 6vw, 30px);
-    }
-
-    .value {
-      font-size: clamp(0.65rem, 1.8vw, 0.7rem);
+    .pill-pos {
+      font-size: 0.7rem;
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- 棋盘格子改为 ResizeObserver 动态尺寸，环形布局横竖比随屏幕方向自适应
- 移动端折叠中心状态区与 PlayerPanel（可点开浮层），横屏改为左侧竖栏布局
- 增强触摸长按 tooltip、底部信息条、振动反馈，并优化 glow/动画性能

## Test plan
- [ ] 竖屏手机：棋盘格子不溢出、中心只保留骰子与起飞区
- [ ] 点击 header 当前玩家头像可展开/收起 PlayerPanel
- [ ] 长按格子出现底部 tooltip，点击空白关闭
- [ ] 横屏：header 变为左侧竖栏，棋盘占右侧
- [ ] 桌面端 hover tooltip 与原布局行为正常
- [ ] `npm test` / `npm run build` 通过


Made with [Cursor](https://cursor.com)