### PR TITLE
feat: resolve punishment turns and add safe pause

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,13 @@
   /* eslint-disable @typescript-eslint/ban-ts-comment */
   import { ref, reactive, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
   import { GameService } from './services/gameService'
+  import {
+    applyTurnConsequence,
+    consumePendingSkippedTurn,
+    finalizePunishmentCount,
+    resolveRule,
+    scaleResolvedPunishmentCount,
+  } from './services/ruleResolution'
   import { GAME_CONFIG } from './config/gameConfig'
   import {
     ArrowLeft,
@@ -16,6 +23,7 @@
     Volume2,
     VolumeX,
     AlertCircle,
+    Pause,
   } from '@lucide/vue'
   import type {
     GameState,
@@ -26,6 +34,8 @@
     PunishmentCombination,
     BoardConfig,
     TrapAction,
+    ResolvedPunishmentAction,
+    ResolvedRuleResult,
   } from './types/game'
   import IntroPage from './components/IntroPage.vue'
   import GameBoard from './components/GameBoard.vue'
@@ -44,6 +54,7 @@
   import DoublePunishmentReveal from './components/DoublePunishmentReveal.vue'
   import ChainPunishmentRoll from './components/ChainPunishmentRoll.vue'
   import MercyDecision from './components/MercyDecision.vue'
+  import SessionPauseOverlay from './components/SessionPauseOverlay.vue'
   import ConfigExport from './components/ConfigExport.vue'
   import { saveConfig, loadConfig, loadPlayerSettings } from './utils/cache'
   import { SecureRandom } from './utils/secureRandom'
@@ -75,6 +86,7 @@
   // 游戏控制状态
   const gameStarted = ref(false)
   const gameFinished = ref(false)
+  const sessionPaused = ref(false)
 
   // 移动端 PlayerPanel 折叠状态
   const playerPanelCollapsed = ref(true)
@@ -113,6 +125,8 @@
   const turnCount = ref(0)
   const lastEffect = ref<string>('')
   const currentPunishment = ref<PunishmentAction | null>(null)
+  const currentPunishmentTarget = ref<Player | null>(null)
+  const pendingRuleResolution = ref<ResolvedRuleResult | null>(null)
 
   // 惩罚组合确认状态
   const punishmentCombinations = ref<PunishmentCombination[]>([])
@@ -195,28 +209,32 @@
   // 胜利结算画面状态
   const showVictoryScreen = ref(false)
 
-  const canRequestBoardMercy = computed(() => !isDoublePunishment.value && !mercyRequested.value)
+  const currentPunishmentCountSelection = computed(() => {
+    const resolution = pendingRuleResolution.value
+    const count = resolution?.kind === 'punishment' ? resolution.count : null
+    return count?.kind === 'awaiting_external_count' ? count : null
+  })
+  const currentPunishmentCountMultiplier = computed(() => {
+    const resolution = pendingRuleResolution.value
+    return resolution?.kind === 'punishment' ? (resolution.countMultiplier ?? 1) : 1
+  })
+  const canRequestBoardMercy = computed(
+    () =>
+      !isDoublePunishment.value &&
+      !mercyRequested.value &&
+      currentPunishmentCountSelection.value === null
+  )
   const canRequestTakeoffMercy = computed(() => !mercyRequested.value)
 
-  const rebuildPunishmentDescription = (punishment: PunishmentAction, strikes: number): string => {
-    return `用${punishment.tool.name}打${punishment.bodyPart.name}${strikes}下，姿势：${punishment.position.name}`
-  }
-
-  /** 消耗受罚方 pendingMercyMultiplier，返回可安全修改的惩罚副本 */
-  const preparePunishmentForDisplay = (
-    punishment: PunishmentAction,
-    targetPlayer: Player
-  ): PunishmentAction => {
-    const cloned: PunishmentAction = { ...punishment }
-    const multiplier = targetPlayer.pendingMercyMultiplier
-    if (multiplier && multiplier > 1 && cloned.strikes != null) {
-      const newStrikes = Math.ceil(cloned.strikes * multiplier)
-      cloned.strikes = newStrikes
-      cloned.description = rebuildPunishmentDescription(cloned, newStrikes)
-      targetPlayer.pendingMercyMultiplier = undefined
-    }
-    return cloned
-  }
+  const toMutablePunishmentAction = (punishment: ResolvedPunishmentAction): PunishmentAction => ({
+    ...punishment,
+    tool: { ...punishment.tool },
+    bodyPart: { ...punishment.bodyPart },
+    position: {
+      ...punishment.position,
+      compatibleBodyParts: [...punishment.position.compatibleBodyParts],
+    },
+  })
 
   const handleMercyRequest = (source: 'board' | 'takeoff') => {
     const punishment = source === 'board' ? currentPunishment.value : currentTakeoffPunishment.value
@@ -224,7 +242,10 @@
 
     mercySource.value = source
     mercyHalvedStrikes.value = Math.ceil(punishment.strikes / 2)
-    mercyTargetPlayer.value = gameState.players[gameState.currentPlayerIndex] ?? null
+    mercyTargetPlayer.value =
+      source === 'board'
+        ? currentPunishmentTarget.value
+        : (gameState.players[gameState.currentPlayerIndex] ?? null)
     if (source === 'board') {
       mercyExecutorPlayer.value = currentPunishmentExecutor.value
     } else {
@@ -241,22 +262,27 @@
 
     if (!accepted) return
 
-    const targetPlayer = gameState.players[gameState.currentPlayerIndex]
+    const targetPlayer =
+      mercySource.value === 'board'
+        ? currentPunishmentTarget.value
+        : gameState.players[gameState.currentPlayerIndex]
     if (!targetPlayer) return
 
-    const applyHalve = (punishment: PunishmentAction): PunishmentAction => {
-      const halved = Math.ceil((punishment.strikes ?? 0) / 2)
-      return {
-        ...punishment,
-        strikes: halved,
-        description: rebuildPunishmentDescription(punishment, halved),
-      }
+    const punishmentResolution = pendingRuleResolution.value
+    if (
+      punishmentResolution?.kind !== 'punishment' ||
+      punishmentResolution.count.kind !== 'fixed'
+    ) {
+      return
     }
+    const halvedResolution = scaleResolvedPunishmentCount(punishmentResolution, 0.5)
+    pendingRuleResolution.value = halvedResolution
+    const halvedAction = toMutablePunishmentAction(halvedResolution.action)
 
-    if (mercySource.value === 'board' && currentPunishment.value) {
-      currentPunishment.value = applyHalve(currentPunishment.value)
-    } else if (mercySource.value === 'takeoff' && currentTakeoffPunishment.value) {
-      currentTakeoffPunishment.value = applyHalve(currentTakeoffPunishment.value)
+    if (mercySource.value === 'board') {
+      currentPunishment.value = halvedAction
+    } else {
+      currentTakeoffPunishment.value = halvedAction
     }
 
     targetPlayer.pendingMercyMultiplier = MERCY_MULTIPLIER
@@ -277,7 +303,6 @@
     newPosition: number
     punishment?: PunishmentAction
     cellEffect?: BoardCell['effect']
-    executorIndex?: number
     diceValue?: number
   }
 
@@ -287,7 +312,6 @@
     newPosition,
     punishment,
     cellEffect,
-    executorIndex,
     diceValue,
   }: LandingEffectPayload) => {
     const resolvedCellEffect = cellEffect ?? getCellEffectByPosition(newPosition)
@@ -317,50 +341,78 @@
       effectChainCount.value++
     }
 
-    // 当玩家尚未起飞(仍停留在起点)且出现惩罚时，视为未起飞惩罚
-    if (resolvedPunishment && !currentPlayer.hasTakenOff) {
-      currentTakeoffPunishment.value = preparePunishmentForDisplay(
-        resolvedPunishment,
-        currentPlayer
-      )
-      currentTakeoffDiceValue.value = diceValue ?? gameState.diceValue ?? 0
-      currentTakeoffExecutorIndex.value = executorIndex !== undefined ? executorIndex : -1
-      mercyRequested.value = false
-      showTakeoffPunishmentDisplay.value = true
-      audioService.play('punishment')
-      handleTakeoffPunishmentDisplay()
-      return
-    }
-
     if (resolvedPunishment) {
-      currentPunishment.value = preparePunishmentForDisplay(resolvedPunishment, currentPlayer)
+      const actorIndex = gameState.currentPlayerIndex
+      const punishmentResolution = !currentPlayer.hasTakenOff
+        ? resolveRule({
+            source: 'takeoff_failure',
+            actorIndex,
+            players: gameState.players,
+            punishmentConfig: gameState.punishmentConfig,
+            diceValue: diceValue ?? gameState.diceValue ?? undefined,
+            punishmentAction: resolvedPunishment,
+          })
+        : resolveRule({
+            source: 'board_punishment',
+            actorIndex,
+            players: gameState.players,
+            punishmentConfig: gameState.punishmentConfig,
+            diceValue: diceValue ?? gameState.diceValue ?? undefined,
+            boardAction: resolvedPunishment,
+          })
+      const targetPlayer = gameState.players[punishmentResolution.targetPlayerIndex]
+      const executorPlayer =
+        punishmentResolution.executorIndex === undefined
+          ? null
+          : (gameState.players[punishmentResolution.executorIndex] ?? null)
+      const displayAction = toMutablePunishmentAction(punishmentResolution.action)
+      if (punishmentResolution.countMultiplier) {
+        targetPlayer.pendingMercyMultiplier = undefined
+      }
+      pendingRuleResolution.value = punishmentResolution
+
+      // 当玩家尚未起飞(仍停留在起点)且出现惩罚时，视为未起飞惩罚
+      if (!currentPlayer.hasTakenOff) {
+        currentTakeoffPunishment.value = displayAction
+        currentTakeoffDiceValue.value = diceValue ?? gameState.diceValue ?? 0
+        currentTakeoffExecutorIndex.value = punishmentResolution.executorIndex ?? -1
+        mercyRequested.value = false
+        showTakeoffPunishmentDisplay.value = true
+        audioService.play('punishment')
+        handleTakeoffPunishmentDisplay()
+        return
+      }
+
+      currentPunishment.value = displayAction
+      currentPunishmentTarget.value = targetPlayer
+      currentPunishmentExecutor.value = executorPlayer
       mercyRequested.value = false
       audioService.play('punishment')
-      if (
-        executorIndex !== undefined &&
-        executorIndex >= 0 &&
-        executorIndex < gameState.players.length
-      ) {
-        currentPunishmentExecutor.value = gameState.players[executorIndex]
-      } else {
-        const otherPlayers = gameState.players.filter(
-          (_, index) => index !== gameState.currentPlayerIndex
-        )
-        currentPunishmentExecutor.value =
-          otherPlayers.length > 0 ? SecureRandom.choice(otherPlayers) : null
-      }
       gameState.gameStatus = 'configuring'
       return
     }
 
     if (resolvedCellEffect && resolvedCellEffect.type === 'trap') {
-      currentTrapDescription.value = resolvedCellEffect.description || '未知机关'
+      const trapResolution = resolveRule({
+        source: 'trap',
+        actorIndex: gameState.currentPlayerIndex,
+        players: gameState.players,
+        effect: resolvedCellEffect,
+      })
+      pendingRuleResolution.value = trapResolution
+      currentTrapDescription.value = trapResolution.description || '未知机关'
       showTrapDisplay.value = true
       audioService.play('trap')
       return
     }
 
     if (resolvedCellEffect && resolvedCellEffect.type === 'bounce') {
+      pendingRuleResolution.value = resolveRule({
+        source: 'cell_effect',
+        actorIndex: gameState.currentPlayerIndex,
+        players: gameState.players,
+        effect: resolvedCellEffect,
+      })
       bounceFromPosition.value = fromPosition
       bounceTargetPosition.value = fromPosition + (diceValue ?? gameState.diceValue ?? 0)
       bounceFinalPosition.value = newPosition
@@ -382,6 +434,7 @@
       }
       // 到达第1格（飞机场）时，不显示效果确认弹窗
       if (newPosition === 1) {
+        pendingRuleResolution.value = null
         await continueAfterMove()
         return
       }
@@ -397,15 +450,26 @@
               ? -newPosition
               : 0)
 
+      const effectResolution = resolveRule({
+        source: 'cell_effect',
+        actorIndex: gameState.currentPlayerIndex,
+        players: gameState.players,
+        effect: {
+          type: effectType,
+          value: resolvedCellEffect.value,
+          description: getThreeStepMoveDescription(
+            fromPosition,
+            newPosition,
+            finalPosition,
+            effectType
+          ),
+        },
+      })
+      pendingRuleResolution.value = effectResolution
       gameState.pendingEffect = {
         type: effectType,
         value: resolvedCellEffect.value,
-        description: getThreeStepMoveDescription(
-          fromPosition,
-          newPosition,
-          finalPosition,
-          effectType
-        ),
+        description: effectResolution.effect.description,
       }
       effectFromPosition.value = fromPosition
       effectToPosition.value = newPosition
@@ -413,6 +477,7 @@
       return
     }
 
+    pendingRuleResolution.value = null
     await continueAfterMove()
   }
 
@@ -422,6 +487,7 @@
       gameStarted.value &&
       !gameFinished.value &&
       gameState.gameStatus === 'waiting' &&
+      !sessionPaused.value &&
       !currentPunishment.value &&
       !showTakeoffPunishmentDisplay.value &&
       !showTrapDisplay.value &&
@@ -429,6 +495,28 @@
       !showChainPunishmentRoll.value
     )
   })
+
+  const hasActiveForcedOverlay = computed(
+    () =>
+      Boolean(currentPunishment.value) ||
+      showTakeoffPunishmentDisplay.value ||
+      showTrapDisplay.value ||
+      showBounceDisplay.value ||
+      showDoublePunishmentReveal.value ||
+      showChainPunishmentRoll.value ||
+      showMercyDecision.value ||
+      showTakeoffReliefDisplay.value ||
+      gameState.gameStatus === 'showing_effect'
+  )
+
+  const canPauseSession = computed(
+    () =>
+      gameStarted.value &&
+      !gameFinished.value &&
+      (gameState.gameStatus === 'waiting' ||
+        gameState.gameStatus === 'configuring' ||
+        hasActiveForcedOverlay.value)
+  )
 
   const isConfigValid = computed(() => {
     return GameService.validatePunishmentConfig(gameState.punishmentConfig).isValid
@@ -491,6 +579,8 @@
 
     // 清除其他状态
     currentPunishment.value = null
+    currentPunishmentTarget.value = null
+    pendingRuleResolution.value = null
     showTakeoffPunishmentDisplay.value = false
     currentTakeoffPunishment.value = null
     effectFromPosition.value = undefined
@@ -504,6 +594,7 @@
     mercyRequested.value = false
     mercyExecutorPlayer.value = null
     mercyTargetPlayer.value = null
+    sessionPaused.value = false
     resetEffectChainCount()
 
     devLog('游戏状态已重置')
@@ -530,6 +621,7 @@
       doublePunishmentReveal: showDoublePunishmentReveal.value,
       chainPunishmentRoll: showChainPunishmentRoll.value,
       mercyDecision: showMercyDecision.value,
+      sessionPaused: sessionPaused.value,
     }
 
     // 检查是否卡在 moving 状态超过 5 秒
@@ -673,6 +765,9 @@
         currentTakeoffDiceValue: typeof currentTakeoffDiceValue
         currentTakeoffExecutorIndex: typeof currentTakeoffExecutorIndex
         currentPunishmentExecutor: typeof currentPunishmentExecutor
+        currentPunishmentTarget: typeof currentPunishmentTarget
+        pendingRuleResolution: typeof pendingRuleResolution
+        sessionPaused: typeof sessionPaused
         showTrapDisplay: typeof showTrapDisplay
         currentTrapPunishment: typeof currentTrapPunishment
         currentTrapDescription: typeof currentTrapDescription
@@ -695,6 +790,9 @@
       debugWindow.currentTakeoffDiceValue = currentTakeoffDiceValue
       debugWindow.currentTakeoffExecutorIndex = currentTakeoffExecutorIndex
       debugWindow.currentPunishmentExecutor = currentPunishmentExecutor
+      debugWindow.currentPunishmentTarget = currentPunishmentTarget
+      debugWindow.pendingRuleResolution = pendingRuleResolution
+      debugWindow.sessionPaused = sessionPaused
       debugWindow.showTrapDisplay = showTrapDisplay
       debugWindow.currentTrapPunishment = currentTrapPunishment
       debugWindow.currentTrapDescription = currentTrapDescription
@@ -772,10 +870,13 @@
 
     gameStarted.value = false
     gameFinished.value = false
+    sessionPaused.value = false
     turnCount.value = 0
     lastEffect.value = ''
     currentPunishment.value = null
     currentPunishmentExecutor.value = null // 清除执行惩罚的玩家
+    currentPunishmentTarget.value = null
+    pendingRuleResolution.value = null
 
     // 清除惩罚组合确认状态
     punishmentCombinations.value = []
@@ -890,12 +991,27 @@
     lastEffect.value = ''
     currentPunishment.value = null
     currentPunishmentExecutor.value = null // 清除执行惩罚的玩家
+    currentPunishmentTarget.value = null
+    pendingRuleResolution.value = null
+    sessionPaused.value = false
 
     // 清除惩罚组合确认状态
     punishmentCombinations.value = []
     punishmentStep.value = 'config'
     showTakeoffPunishmentDisplay.value = false
     currentTakeoffPunishment.value = null
+    currentTakeoffExecutorIndex.value = -1
+
+    // 清除所有强制结算弹层，结束本局后不残留旧流程
+    showTrapDisplay.value = false
+    currentTrapPunishment.value = null
+    currentTrapDescription.value = ''
+    showDoublePunishmentReveal.value = false
+    isDoublePunishment.value = false
+    pendingDoublePunishment.value = null
+    showChainPunishmentRoll.value = false
+    isChainPunishment.value = false
+    showTakeoffReliefDisplay.value = false
 
     // 清除反弹效果状态
     showBounceDisplay.value = false
@@ -918,9 +1034,33 @@
     gameState.gameStatus = 'board_settings'
   }
 
+  const pauseSession = () => {
+    if (!canPauseSession.value) return
+    sessionPaused.value = true
+  }
+
+  const resumeSession = () => {
+    sessionPaused.value = false
+  }
+
+  const endPausedSession = () => {
+    sessionPaused.value = false
+    resetGame()
+  }
+
   // 处理骰子滚动
   const handleDiceRoll = async () => {
     if (!canRollDice.value) return
+
+    const currentPlayerIndex = gameState.currentPlayerIndex
+    const currentPlayer = gameState.players[currentPlayerIndex]
+    const pendingTurn = consumePendingSkippedTurn(currentPlayer)
+    if (pendingTurn.shouldSkip) {
+      gameState.players[currentPlayerIndex] = pendingTurn.player
+      lastEffect.value = `${currentPlayer.name}休息一回合，本回合已跳过`
+      advanceToNextPlayablePlayer()
+      return
+    }
 
     audioService.play('diceRoll')
     resetEffectChainCount()
@@ -949,22 +1089,15 @@
 
       const fromPosition = currentPlayer.position
 
-      const {
-        newPosition,
-        effect,
-        punishment,
-        cellEffect,
-        canTakeOff,
-        executorIndex,
-        forcedTakeoffDueToFailure,
-      } = GameService.movePlayer(
-        currentPlayer,
-        diceValue,
-        gameState.board,
-        gameState.currentPlayerIndex,
-        gameState.players.length,
-        gameState.punishmentConfig
-      )
+      const { newPosition, effect, punishment, cellEffect, canTakeOff, forcedTakeoffDueToFailure } =
+        GameService.movePlayer(
+          currentPlayer,
+          diceValue,
+          gameState.board,
+          gameState.currentPlayerIndex,
+          gameState.players.length,
+          gameState.punishmentConfig
+        )
 
       // 更新玩家位置
       currentPlayer.position = newPosition
@@ -1011,7 +1144,6 @@
         newPosition,
         punishment,
         cellEffect,
-        executorIndex,
         diceValue,
       })
     } catch (error) {
@@ -1035,11 +1167,16 @@
         return
       }
 
-      const currentPlayer = gameState.players[gameState.currentPlayerIndex]
+      let currentPlayer = gameState.players[gameState.currentPlayerIndex]
       const landingPositionBeforeEffect = currentPlayer.position
 
       // 保存效果类型，因为后面会清除pendingEffect
-      const effectType = gameState.pendingEffect.type
+      const pendingEffect = gameState.pendingEffect
+      const effectType = pendingEffect.type
+      const effectResolution = pendingRuleResolution.value
+      if (effectResolution?.kind !== 'cell_effect') {
+        throw new Error('缺少已解析的格子效果')
+      }
 
       // 记录三段路径的位置
       const originalPosition = effectFromPosition.value // 原始位置（骰子移动前）
@@ -1049,15 +1186,18 @@
       const currentBoardSize = gameState.board.length
       const { newPosition } = GameService.processCellEffect(
         currentPlayer,
-        gameState.pendingEffect,
+        pendingEffect,
         currentBoardSize
       )
 
-      // 更新玩家位置
+      // 更新玩家位置与回合后果
+      currentPlayer = applyTurnConsequence(currentPlayer, effectResolution.turnConsequence)
       currentPlayer.position = newPosition
+      gameState.players[gameState.currentPlayerIndex] = currentPlayer
 
       // 立即清除待处理效果和状态，避免显示多余的弹窗
       gameState.pendingEffect = null
+      pendingRuleResolution.value = null
       effectFromPosition.value = undefined
       effectToPosition.value = undefined
       gameState.gameStatus = 'waiting'
@@ -1110,6 +1250,7 @@
       // 确保在发生错误时重置游戏状态
       gameState.gameStatus = 'waiting'
       gameState.pendingEffect = null
+      pendingRuleResolution.value = null
       effectFromPosition.value = undefined
       effectToPosition.value = undefined
       // 清除玩家移动状态
@@ -1172,6 +1313,42 @@
     }
   }
 
+  function advanceToNextPlayablePlayer() {
+    if (gameState.players.length === 0) return
+
+    gameState.currentPlayerIndex = GameService.getNextPlayer(
+      gameState.currentPlayerIndex,
+      gameState.players.length
+    )
+    turnCount.value++
+
+    const pendingTurnBudget =
+      gameState.players.reduce(
+        (total, player) => total + Math.max(0, player.pendingSkippedTurns ?? 0),
+        0
+      ) + gameState.players.length
+    let remainingChecks = pendingTurnBudget
+
+    while (remainingChecks > 0) {
+      const playerIndex = gameState.currentPlayerIndex
+      const player = gameState.players[playerIndex]
+      const consumedTurn = consumePendingSkippedTurn(player)
+      if (!consumedTurn.shouldSkip) break
+
+      gameState.players[playerIndex] = consumedTurn.player
+      lastEffect.value = `${player.name}休息一回合，本回合已跳过`
+      gameState.currentPlayerIndex = GameService.getNextPlayer(
+        playerIndex,
+        gameState.players.length
+      )
+      turnCount.value++
+      remainingChecks--
+    }
+
+    gameState.diceValue = null
+    gameState.gameStatus = 'waiting'
+  }
+
   // 移动后的继续流程
   const continueAfterMove = async () => {
     try {
@@ -1191,15 +1368,7 @@
       // 等待移动动画完成
       await new Promise(resolve => setTimeout(resolve, 500))
 
-      // 切换到下一个玩家
-      gameState.currentPlayerIndex = GameService.getNextPlayer(
-        gameState.currentPlayerIndex,
-        gameState.players.length
-      )
-
-      turnCount.value++
-      gameState.diceValue = null
-      gameState.gameStatus = 'waiting'
+      advanceToNextPlayablePlayer()
 
       // 清除上一步效果
       setTimeout(() => {
@@ -1219,8 +1388,21 @@
   }
 
   // 确认惩罚
-  const confirmPunishment = async () => {
+  const confirmPunishment = async (selectedCount?: number) => {
     try {
+      const punishmentResolution = pendingRuleResolution.value
+      if (
+        punishmentResolution?.kind === 'punishment' &&
+        punishmentResolution.count.kind === 'awaiting_external_count'
+      ) {
+        if (selectedCount === undefined || !currentPunishmentTarget.value) {
+          throw new Error('需要先选择本次惩罚次数')
+        }
+        const finalizedResolution = finalizePunishmentCount(punishmentResolution, selectedCount)
+        currentPunishment.value = toMutablePunishmentAction(finalizedResolution.action)
+        pendingRuleResolution.value = finalizedResolution
+      }
+
       // 连锁惩罚：确认后进入连锁掷骰阶段
       if (isChainPunishment.value) {
         currentPunishment.value = null
@@ -1243,6 +1425,8 @@
       isDoublePunishment.value = false
       currentPunishment.value = null
       currentPunishmentExecutor.value = null
+      currentPunishmentTarget.value = null
+      pendingRuleResolution.value = null
       gameState.gameStatus = 'waiting'
 
       // 继续游戏流程
@@ -1252,6 +1436,8 @@
       gameState.gameStatus = 'waiting'
       currentPunishment.value = null
       currentPunishmentExecutor.value = null
+      currentPunishmentTarget.value = null
+      pendingRuleResolution.value = null
       isDoublePunishment.value = false
       isChainPunishment.value = false
     }
@@ -1272,16 +1458,33 @@
     showChainPunishmentRoll.value = false
     if (continueChain) {
       const newPunishment = GameService.generateRandomPunishment(gameState.punishmentConfig)
-      const targetPlayer = gameState.players[gameState.currentPlayerIndex]
-      currentPunishment.value = targetPlayer
-        ? preparePunishmentForDisplay(newPunishment, targetPlayer)
-        : newPunishment
+      const chainResolution = resolveRule({
+        source: 'board_punishment',
+        actorIndex: gameState.currentPlayerIndex,
+        players: gameState.players,
+        punishmentConfig: gameState.punishmentConfig,
+        diceValue: gameState.diceValue ?? undefined,
+        boardAction: newPunishment,
+      })
+      const targetPlayer = gameState.players[chainResolution.targetPlayerIndex]
+      pendingRuleResolution.value = chainResolution
+      currentPunishmentTarget.value = targetPlayer
+      currentPunishmentExecutor.value =
+        chainResolution.executorIndex === undefined
+          ? null
+          : (gameState.players[chainResolution.executorIndex] ?? null)
+      currentPunishment.value = toMutablePunishmentAction(chainResolution.action)
+      if (chainResolution.countMultiplier) {
+        targetPlayer.pendingMercyMultiplier = undefined
+      }
       mercyRequested.value = false
       gameState.gameStatus = 'configuring'
     } else {
       isChainPunishment.value = false
       currentPunishment.value = null
       currentPunishmentExecutor.value = null
+      currentPunishmentTarget.value = null
+      pendingRuleResolution.value = null
       gameState.gameStatus = 'waiting'
       continueAfterPunishment()
     }
@@ -1301,6 +1504,8 @@
       isChainPunishment.value = false
       currentPunishment.value = null
       currentPunishmentExecutor.value = null
+      currentPunishmentTarget.value = null
+      pendingRuleResolution.value = null
       gameState.gameStatus = 'waiting'
 
       // 继续游戏流程
@@ -1310,6 +1515,8 @@
       gameState.gameStatus = 'waiting'
       currentPunishment.value = null
       currentPunishmentExecutor.value = null
+      currentPunishmentTarget.value = null
+      pendingRuleResolution.value = null
       isDoublePunishment.value = false
       isChainPunishment.value = false
     }
@@ -1334,15 +1541,7 @@
       // 等待移动动画完成
       await new Promise(resolve => setTimeout(resolve, 500))
 
-      // 切换到下一个玩家
-      gameState.currentPlayerIndex = GameService.getNextPlayer(
-        gameState.currentPlayerIndex,
-        gameState.players.length
-      )
-
-      turnCount.value++
-      gameState.diceValue = null
-      gameState.gameStatus = 'waiting'
+      advanceToNextPlayablePlayer()
 
       // 清除上一步效果
       setTimeout(() => {
@@ -1401,6 +1600,7 @@
   const confirmTakeoffPunishment = async () => {
     showTakeoffPunishmentDisplay.value = false
     currentTakeoffPunishment.value = null
+    pendingRuleResolution.value = null
     gameState.gameStatus = 'waiting'
 
     // 继续游戏流程
@@ -1464,9 +1664,15 @@
   // 确认机关陷阱
   const confirmTrap = async () => {
     try {
+      const trapResolution = pendingRuleResolution.value
+      if (trapResolution?.kind !== 'trap' || !trapResolution.acknowledgementRequired) {
+        throw new Error('缺少已解析的机关确认')
+      }
+
       showTrapDisplay.value = false
       currentTrapPunishment.value = null
       currentTrapDescription.value = ''
+      pendingRuleResolution.value = null
       gameState.gameStatus = 'waiting'
 
       // 继续游戏流程
@@ -1478,12 +1684,17 @@
       showTrapDisplay.value = false
       currentTrapPunishment.value = null
       currentTrapDescription.value = ''
+      pendingRuleResolution.value = null
     }
   }
 
   // 确认反弹效果
   const confirmBounce = async () => {
     try {
+      if (pendingRuleResolution.value?.kind !== 'cell_effect') {
+        throw new Error('缺少已解析的反弹效果')
+      }
+
       const currentPlayer = gameState.players[gameState.currentPlayerIndex]
       const landingPosition = currentPlayer.position
       const bounceStartPosition = bounceFromPosition.value || landingPosition
@@ -1493,6 +1704,7 @@
       bounceTargetPosition.value = 0
       bounceFinalPosition.value = 0
       bounceOverflowSteps.value = 0
+      pendingRuleResolution.value = null
       gameState.gameStatus = 'waiting'
 
       // 反弹确认后继续结算反弹落点格子的效果
@@ -1510,6 +1722,7 @@
       bounceTargetPosition.value = 0
       bounceFinalPosition.value = 0
       bounceOverflowSteps.value = 0
+      pendingRuleResolution.value = null
     }
   }
 
@@ -2252,6 +2465,9 @@
       <PunishmentDisplay
         :punishment="currentPunishment"
         :executor-player="currentPunishmentExecutor"
+        :target-player="currentPunishmentTarget"
+        :count-selection="currentPunishmentCountSelection"
+        :count-multiplier="currentPunishmentCountMultiplier"
         :can-request-mercy="canRequestBoardMercy"
         @confirm="confirmPunishment"
         @skip="skipPunishment"
@@ -2330,6 +2546,22 @@
       :visible="showTakeoffReliefDisplay"
       :failed-count="failedTakeoffCountForMessage"
       @confirm="confirmTakeoffRelief"
+    />
+
+    <button
+      v-if="canPauseSession && !sessionPaused"
+      class="session-pause-trigger"
+      aria-label="暂停本局"
+      @click="pauseSession"
+    >
+      <Pause :size="18" aria-hidden="true" />
+      <span>暂停本局</span>
+    </button>
+
+    <SessionPauseOverlay
+      :visible="sessionPaused"
+      @resume="resumeSession"
+      @end-session="endPausedSession"
     />
 
     <!-- 用户引导按钮和设置 -->
@@ -3126,8 +3358,46 @@
     line-height: 1.3;
   }
 
+  .session-pause-trigger {
+    position: fixed;
+    z-index: 19000;
+    right: 1rem;
+    bottom: 6rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    min-height: 44px;
+    padding: 0.7rem 1rem;
+    color: white;
+    background: rgba(30, 41, 59, 0.96);
+    border: 1px solid rgba(147, 197, 253, 0.55);
+    border-radius: 999px;
+    box-shadow: var(--glass-shadow-lg);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .session-pause-trigger:hover {
+    background: rgba(37, 99, 235, 0.96);
+  }
+
+  .session-pause-trigger:focus-visible {
+    outline: 3px solid #93c5fd;
+    outline-offset: 3px;
+  }
+
   /* 移动端适配 */
   @media (max-width: 768px) {
+    .session-pause-trigger {
+      right: 0.75rem;
+      bottom: 4.75rem;
+    }
+
+    .session-pause-trigger span {
+      display: none;
+    }
+
     .guide-btn {
       width: 50px;
       height: 50px;

--- a/src/components/PunishmentDisplay.vue
+++ b/src/components/PunishmentDisplay.vue
@@ -1,26 +1,62 @@
 <script setup lang="ts">
+  import { computed, ref, watch } from 'vue'
   import { Zap, Check, SkipForward, HandHeart } from '@lucide/vue'
-  import type { PunishmentAction, Player } from '../types/game'
+  import type { PunishmentAction, Player, ResolvedPunishmentCount } from '../types/game'
+
+  type ExternalCountSelection = Extract<
+    ResolvedPunishmentCount,
+    { kind: 'awaiting_external_count' }
+  >
 
   interface Props {
     punishment: PunishmentAction | null
     executorPlayer?: Player | null
+    targetPlayer?: Player | null
+    countSelection?: ExternalCountSelection | null
+    countMultiplier?: number
     canRequestMercy?: boolean
   }
 
   interface Emits {
-    (e: 'confirm'): void
+    (e: 'confirm', selectedCount?: number): void
     (e: 'skip'): void
     (e: 'request-mercy'): void
   }
 
-  withDefaults(defineProps<Props>(), {
+  const props = withDefaults(defineProps<Props>(), {
     canRequestMercy: false,
+    countMultiplier: 1,
   })
   const emit = defineEmits<Emits>()
 
+  const countOptions = computed(() => {
+    if (!props.countSelection) return []
+
+    const step = Math.max(1, props.countSelection.step)
+    const firstOption = Math.ceil(props.countSelection.minimum / step) * step
+    const options: number[] = []
+    for (let count = firstOption; count <= props.countSelection.maximum; count += step) {
+      options.push(count)
+    }
+    return options
+  })
+  const selectedCount = ref<number | undefined>()
+  const finalizedCountPreview = computed(() =>
+    selectedCount.value === undefined
+      ? undefined
+      : Math.ceil(selectedCount.value * props.countMultiplier)
+  )
+
+  watch(
+    countOptions,
+    options => {
+      selectedCount.value = options[0]
+    },
+    { immediate: true }
+  )
+
   const confirmPunishment = () => {
-    emit('confirm')
+    emit('confirm', props.countSelection ? selectedCount.value : undefined)
   }
 
   const skipPunishment = () => {
@@ -44,6 +80,14 @@
       </div>
 
       <div class="punishment-content">
+        <div v-if="targetPlayer" class="target-info">
+          <span class="target-label">受罚玩家</span>
+          <div class="target-player">
+            <div class="target-avatar" :style="{ backgroundColor: targetPlayer.color }"></div>
+            <span class="target-name">{{ targetPlayer.name }}</span>
+          </div>
+        </div>
+
         <!-- 执行惩罚的玩家信息 -->
         <div v-if="executorPlayer" class="executor-info">
           <div class="executor-header">
@@ -72,15 +116,43 @@
             <span class="label">姿势:</span>
             <span class="value position">{{ punishment.position.name }}</span>
           </div>
+
+          <div v-if="punishment.strikes != null" class="punishment-item">
+            <span class="label">次数:</span>
+            <span class="value strikes">{{ punishment.strikes }} 下</span>
+          </div>
         </div>
 
         <div class="punishment-summary">
           <h4>执行内容:</h4>
-          <p class="summary-text">{{ punishment.description }}</p>
+          <p v-if="countSelection" class="summary-text">
+            由{{ executorPlayer?.name || '其他玩家' }}决定本次惩罚次数
+          </p>
+          <p v-else class="summary-text">{{ punishment.description }}</p>
         </div>
 
+        <label v-if="countSelection" class="count-selection">
+          <span>惩罚次数</span>
+          <select v-model.number="selectedCount" aria-label="惩罚次数">
+            <option v-for="count in countOptions" :key="count" :value="count">
+              {{ count }} 下
+            </option>
+          </select>
+          <small>
+            可选范围 {{ countSelection.minimum }}–{{ countSelection.maximum }}，按
+            {{ countSelection.step }} 递增
+          </small>
+          <small v-if="countMultiplier > 1" class="multiplier-preview">
+            本次倍率 ×{{ countMultiplier }}，最终执行 {{ finalizedCountPreview }} 下
+          </small>
+        </label>
+
         <div class="punishment-actions">
-          <button class="btn btn-success" @click="confirmPunishment">
+          <button
+            class="btn btn-success"
+            :disabled="Boolean(countSelection) && selectedCount === undefined"
+            @click="confirmPunishment"
+          >
             <Check :size="18" />
             确认执行
           </button>
@@ -129,6 +201,61 @@
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+  }
+
+  .target-info,
+  .count-selection {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    padding: 1rem;
+    border: 1px solid rgba(255, 71, 87, 0.35);
+    border-radius: var(--radius-sm);
+    background: rgba(255, 71, 87, 0.08);
+  }
+
+  .target-label,
+  .count-selection > span {
+    color: var(--text-secondary);
+    font-weight: 700;
+  }
+
+  .target-player {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .target-avatar {
+    width: 32px;
+    height: 32px;
+    border: 2px solid rgba(255, 255, 255, 0.25);
+    border-radius: 50%;
+  }
+
+  .target-name {
+    color: var(--text-primary);
+    font-size: 1.1rem;
+    font-weight: 700;
+  }
+
+  .count-selection select {
+    min-height: 44px;
+    padding: 0.65rem 0.75rem;
+    color: var(--text-primary);
+    background: var(--bg-secondary);
+    border: 1px solid var(--color-punishment);
+    border-radius: var(--radius-sm);
+    font: inherit;
+  }
+
+  .count-selection small {
+    color: var(--text-muted);
+  }
+
+  .count-selection .multiplier-preview {
+    color: var(--color-warning);
+    font-weight: 700;
   }
 
   .executor-info {
@@ -208,6 +335,10 @@
 
   .position {
     color: var(--color-special);
+  }
+
+  .strikes {
+    color: var(--color-warning);
   }
 
   .intensity,

--- a/src/components/SessionPauseOverlay.vue
+++ b/src/components/SessionPauseOverlay.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+  import { LogOut, Play, Shield } from '@lucide/vue'
+
+  interface Props {
+    visible: boolean
+  }
+
+  interface Emits {
+    (event: 'resume'): void
+    (event: 'end-session'): void
+  }
+
+  defineProps<Props>()
+  const emit = defineEmits<Emits>()
+
+  const resumeSession = () => emit('resume')
+  const endSession = () => emit('end-session')
+</script>
+
+<template>
+  <div
+    v-if="visible"
+    class="session-pause-overlay"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="session-pause-title"
+  >
+    <div class="session-pause-card">
+      <Shield :size="48" aria-hidden="true" />
+      <h2 id="session-pause-title">本局已暂停</h2>
+      <p>当前回合和弹窗状态均已保留，可以随时继续。</p>
+
+      <div class="session-pause-actions">
+        <button class="resume-button" @click="resumeSession">
+          <Play :size="18" aria-hidden="true" />
+          继续游戏
+        </button>
+        <button class="end-button" @click="endSession">
+          <LogOut :size="18" aria-hidden="true" />
+          结束本局
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .session-pause-overlay {
+    position: fixed;
+    z-index: 20000;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    padding: 1rem;
+    background: rgba(5, 8, 20, 0.9);
+    backdrop-filter: blur(12px);
+  }
+
+  .session-pause-card {
+    width: min(92vw, 440px);
+    padding: 2rem;
+    color: var(--text-primary);
+    text-align: center;
+    background: rgba(20, 24, 45, 0.98);
+    border: 1px solid rgba(96, 165, 250, 0.45);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--glass-shadow-lg);
+  }
+
+  .session-pause-card > svg {
+    color: #60a5fa;
+  }
+
+  .session-pause-card h2 {
+    margin: 1rem 0 0.5rem;
+  }
+
+  .session-pause-card p {
+    margin: 0 0 1.5rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+  }
+
+  .session-pause-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+  }
+
+  .session-pause-actions button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    min-height: 44px;
+    padding: 0.75rem 1.25rem;
+    color: white;
+    border: 0;
+    border-radius: var(--radius-sm);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .resume-button {
+    background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  }
+
+  .end-button {
+    background: rgba(255, 255, 255, 0.12);
+  }
+
+  .session-pause-actions button:focus-visible {
+    outline: 3px solid #93c5fd;
+    outline-offset: 3px;
+  }
+</style>

--- a/src/services/gameStateHealth.ts
+++ b/src/services/gameStateHealth.ts
@@ -8,6 +8,7 @@ export interface BlockingOverlayState {
   doublePunishmentReveal: boolean
   chainPunishmentRoll: boolean
   mercyDecision: boolean
+  sessionPaused: boolean
 }
 
 export const hasBlockingOverlay = (overlays: BlockingOverlayState): boolean =>

--- a/src/services/ruleResolution.ts
+++ b/src/services/ruleResolution.ts
@@ -1,12 +1,17 @@
 import type {
+  BoardCell,
   Player,
   PunishmentAction,
   PunishmentBodyPart,
   PunishmentConfig,
   PunishmentPosition,
   PunishmentTool,
+  ResolvedCellEffectResult,
   ResolvedPunishmentAction,
   ResolvedPunishmentResult,
+  ResolvedRuleResult,
+  ResolvedTrapResult,
+  TurnConsequence,
 } from '../types/game'
 import { SecureRandom } from '../utils/secureRandom'
 
@@ -29,6 +34,22 @@ export type PunishmentRuleInput =
       randomSource?: RuleRandomSource
       punishmentAction: PunishmentAction
     }
+
+export interface CellEffectRuleInput {
+  source: 'cell_effect'
+  actorIndex: number
+  players: readonly Player[]
+  effect: NonNullable<BoardCell['effect']>
+}
+
+export interface TrapRuleInput {
+  source: 'trap'
+  actorIndex: number
+  players: readonly Player[]
+  effect: NonNullable<BoardCell['effect']>
+}
+
+export type RuleInput = PunishmentRuleInput | CellEffectRuleInput | TrapRuleInput
 
 export interface RuleRandomSource {
   weightedChoice<T>(entries: readonly T[], weights: readonly number[]): T
@@ -141,9 +162,119 @@ const copyAction = (
     }),
   })
 
-export const resolveRule = (input: PunishmentRuleInput): ResolvedPunishmentResult => {
+export const finalizePunishmentCount = (
+  result: ResolvedPunishmentResult,
+  selectedCount: number
+): ResolvedPunishmentResult => {
+  if (result.count.kind !== 'awaiting_external_count') {
+    throw new Error('惩罚次数已经固定')
+  }
+
+  const { minimum, maximum } = result.count
+  const step = Math.max(1, result.count.step)
+  if (
+    !Number.isInteger(selectedCount) ||
+    selectedCount < minimum ||
+    selectedCount > maximum ||
+    selectedCount % step !== 0
+  ) {
+    throw new Error('选择的惩罚次数不符合规则')
+  }
+
+  const finalizedCount = Math.ceil(selectedCount * (result.countMultiplier ?? 1))
+  return Object.freeze({
+    ...result,
+    action: Object.freeze({
+      ...result.action,
+      strikes: finalizedCount,
+      description: `用${result.action.tool.name}打${result.action.bodyPart.name}${finalizedCount}下，姿势：${result.action.position.name}`,
+    }),
+    count: Object.freeze({ kind: 'fixed', value: finalizedCount }),
+  })
+}
+
+export const scaleResolvedPunishmentCount = (
+  result: ResolvedPunishmentResult,
+  multiplier: number
+): ResolvedPunishmentResult => {
+  if (result.count.kind !== 'fixed' || !Number.isFinite(multiplier) || multiplier <= 0) {
+    throw new Error('只有固定次数惩罚可以按倍率结算')
+  }
+
+  const scaledCount = Math.ceil(result.count.value * multiplier)
+  return Object.freeze({
+    ...result,
+    action: Object.freeze({
+      ...result.action,
+      strikes: scaledCount,
+      description: `用${result.action.tool.name}打${result.action.bodyPart.name}${scaledCount}下，姿势：${result.action.position.name}`,
+    }),
+    count: Object.freeze({ kind: 'fixed', value: scaledCount }),
+  })
+}
+
+export const applyTurnConsequence = (player: Player, consequence: TurnConsequence): Player => ({
+  ...player,
+  pendingSkippedTurns:
+    consequence.kind === 'skip_next_turns'
+      ? Math.max(0, player.pendingSkippedTurns ?? 0) + Math.max(0, consequence.count)
+      : Math.max(0, player.pendingSkippedTurns ?? 0),
+})
+
+export const consumePendingSkippedTurn = (
+  player: Player
+): { shouldSkip: boolean; player: Player } => {
+  const pendingSkippedTurns = Math.max(0, player.pendingSkippedTurns ?? 0)
+  if (pendingSkippedTurns === 0) {
+    return {
+      shouldSkip: false,
+      player: { ...player, pendingSkippedTurns: 0 },
+    }
+  }
+
+  return {
+    shouldSkip: true,
+    player: { ...player, pendingSkippedTurns: pendingSkippedTurns - 1 },
+  }
+}
+
+export function resolveRule(input: PunishmentRuleInput): ResolvedPunishmentResult
+export function resolveRule(input: CellEffectRuleInput): ResolvedCellEffectResult
+export function resolveRule(input: TrapRuleInput): ResolvedTrapResult
+export function resolveRule(input: RuleInput): ResolvedRuleResult {
   if (input.actorIndex < 0 || input.actorIndex >= input.players.length) {
     throw new Error('规则解析需要有效的触发玩家索引')
+  }
+
+  if (input.source === 'trap') {
+    if (input.effect.type !== 'trap') {
+      throw new Error('机关规则需要 trap 类型效果')
+    }
+
+    return Object.freeze({
+      kind: 'trap',
+      source: 'trap',
+      actorIndex: input.actorIndex,
+      acknowledgementRequired: true,
+      description: input.effect.description,
+      turnConsequence: Object.freeze({ kind: 'none' }),
+    })
+  }
+
+  if (input.source === 'cell_effect') {
+    const skipCount =
+      input.effect.type === 'rest' ? Math.max(1, Math.trunc(input.effect.value) || 1) : 0
+
+    return Object.freeze({
+      kind: 'cell_effect',
+      source: 'cell_effect',
+      actorIndex: input.actorIndex,
+      effect: Object.freeze({ ...input.effect }),
+      turnConsequence:
+        skipCount > 0
+          ? Object.freeze({ kind: 'skip_next_turns', count: skipCount })
+          : Object.freeze({ kind: 'none' }),
+    })
   }
 
   const action = input.source === 'board_punishment' ? input.boardAction : input.punishmentAction
@@ -189,13 +320,14 @@ export const resolveRule = (input: PunishmentRuleInput): ResolvedPunishmentResul
     count = Object.freeze({ kind: 'fixed', value: actionStrikes })
   }
 
+  const countMultiplier = input.players[targetPlayerIndex].pendingMercyMultiplier
   const executorCandidates = input.players.flatMap((_, index) =>
     index === targetPlayerIndex ? [] : [index]
   )
   const executorIndex =
     executorCandidates.length > 0 ? randomSource.choice(executorCandidates) : undefined
 
-  return Object.freeze({
+  const result: ResolvedPunishmentResult = Object.freeze({
     kind: 'punishment',
     source: input.source,
     actorIndex: input.actorIndex,
@@ -203,6 +335,12 @@ export const resolveRule = (input: PunishmentRuleInput): ResolvedPunishmentResul
     executorIndex,
     action: copyAction(action, actionStrikes),
     count,
+    countMultiplier:
+      countMultiplier !== undefined && countMultiplier > 1 ? countMultiplier : undefined,
     turnConsequence: Object.freeze({ kind: 'none' }),
   })
+
+  return result.count.kind === 'fixed' && result.countMultiplier
+    ? scaleResolvedPunishmentCount(result, result.countMultiplier)
+    : result
 }

--- a/src/tests/gameStateHealth.test.ts
+++ b/src/tests/gameStateHealth.test.ts
@@ -9,6 +9,7 @@ const noBlockingOverlay = {
   doublePunishmentReveal: false,
   chainPunishmentRoll: false,
   mercyDecision: false,
+  sessionPaused: false,
 }
 
 describe('游戏移动状态健康检查', () => {
@@ -26,6 +27,7 @@ describe('游戏移动状态健康检查', () => {
     'doublePunishmentReveal',
     'chainPunishmentRoll',
     'mercyDecision',
+    'sessionPaused',
   ] as const)('%s 覆盖层显示期间不恢复移动状态', overlay => {
     expect(
       shouldRecoverMovingState('moving', 5001, {

--- a/src/tests/ruleResolution.test.ts
+++ b/src/tests/ruleResolution.test.ts
@@ -1,8 +1,21 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createCompatiblePunishmentAction, resolveRule } from '../services/ruleResolution'
+import {
+  applyTurnConsequence,
+  consumePendingSkippedTurn,
+  createCompatiblePunishmentAction,
+  finalizePunishmentCount,
+  resolveRule,
+  scaleResolvedPunishmentCount,
+} from '../services/ruleResolution'
 import { GameService } from '../services/gameService'
 import { SecureRandom } from '../utils/secureRandom'
-import type { BoardConfig, Player, PunishmentAction, PunishmentConfig } from '../types/game'
+import type {
+  BoardCell,
+  BoardConfig,
+  Player,
+  PunishmentAction,
+  PunishmentConfig,
+} from '../types/game'
 
 const players: Player[] = [
   {
@@ -199,7 +212,7 @@ describe('规则结果解析', () => {
     expect(result).toMatchObject({
       targetPlayerIndex: 1,
       count: { kind: 'fixed', value: 12 },
-      action: { strikes: 12 },
+      action: { strikes: 12, description: boardAction.description },
     })
   })
 
@@ -232,6 +245,44 @@ describe('规则结果解析', () => {
     expect(() => (eligibleChooserIndices as number[]).push(7)).toThrow(TypeError)
   })
 
+  it('用其他玩家选择的合法次数完成待定惩罚', () => {
+    const pendingResult = resolveRule({
+      source: 'board_punishment',
+      actorIndex: 1,
+      players: threePlayers,
+      punishmentConfig: compatibilityConfig,
+      boardAction: { ...boardAction, dynamicType: 'other_player_choice' },
+    })
+
+    const finalizedResult = finalizePunishmentCount(pendingResult, 15)
+
+    expect(finalizedResult).toMatchObject({
+      count: { kind: 'fixed', value: 15 },
+      action: {
+        strikes: 15,
+        description: '用皮拍打臀部15下，姿势：俯卧',
+      },
+    })
+    expect(pendingResult).toMatchObject({
+      count: { kind: 'awaiting_external_count' },
+      action: { strikes: undefined },
+    })
+  })
+
+  it.each([4, 12, 20])('拒绝不符合范围或步长的外部次数 %i', selectedCount => {
+    const pendingResult = resolveRule({
+      source: 'board_punishment',
+      actorIndex: 1,
+      players: threePlayers,
+      punishmentConfig: compatibilityConfig,
+      boardAction: { ...boardAction, dynamicType: 'other_player_choice' },
+    })
+
+    expect(() => finalizePunishmentCount(pendingResult, selectedCount)).toThrow(
+      '选择的惩罚次数不符合规则'
+    )
+  })
+
   it('在规则结果中解析执行者并安全处理单人局', () => {
     const multiplayerResult = resolveRule({
       source: 'board_punishment',
@@ -252,5 +303,134 @@ describe('规则结果解析', () => {
 
     expect(multiplayerResult.executorIndex).toBe(2)
     expect(singlePlayerResult.executorIndex).toBeUndefined()
+  })
+
+  it('把受罚玩家待结算倍率写入同一个固定次数结果', () => {
+    const result = resolveRule({
+      source: 'board_punishment',
+      actorIndex: 0,
+      players: [{ ...players[0], pendingMercyMultiplier: 1.5 }, players[1]],
+      punishmentConfig: compatibilityConfig,
+      boardAction,
+    })
+
+    expect(result).toMatchObject({
+      count: { kind: 'fixed', value: 15 },
+      action: { strikes: 15 },
+      countMultiplier: 1.5,
+    })
+  })
+
+  it('在外部次数确定时一并结算受罚玩家倍率', () => {
+    const pendingResult = resolveRule({
+      source: 'board_punishment',
+      actorIndex: 0,
+      players: [{ ...players[0], pendingMercyMultiplier: 1.5 }, players[1]],
+      punishmentConfig: compatibilityConfig,
+      boardAction: { ...boardAction, dynamicType: 'other_player_choice' },
+    })
+
+    const finalizedResult = finalizePunishmentCount(pendingResult, 15)
+
+    expect(finalizedResult).toMatchObject({
+      count: { kind: 'fixed', value: 23 },
+      action: { strikes: 23 },
+      countMultiplier: 1.5,
+    })
+  })
+
+  it('用结构化结果结算求饶减半而不改写原结果', () => {
+    const originalResult = resolveRule({
+      source: 'board_punishment',
+      actorIndex: 0,
+      players,
+      punishmentConfig: compatibilityConfig,
+      boardAction,
+    })
+
+    const halvedResult = scaleResolvedPunishmentCount(originalResult, 0.5)
+
+    expect(halvedResult).toMatchObject({
+      count: { kind: 'fixed', value: 5 },
+      action: { strikes: 5 },
+    })
+    expect(originalResult).toMatchObject({
+      count: { kind: 'fixed', value: 10 },
+      action: { strikes: 10 },
+    })
+  })
+
+  it('把休息格解析为下一回合跳过一次', () => {
+    const restEffect: NonNullable<BoardCell['effect']> = {
+      type: 'rest',
+      value: 1,
+      description: '休息一回合',
+    }
+
+    const result = resolveRule({
+      source: 'cell_effect',
+      actorIndex: 0,
+      players,
+      effect: restEffect,
+    })
+
+    expect(result).toMatchObject({
+      kind: 'cell_effect',
+      source: 'cell_effect',
+      actorIndex: 0,
+      effect: restEffect,
+      turnConsequence: { kind: 'skip_next_turns', count: 1 },
+    })
+  })
+
+  it('把机关解析为必须确认的结构化结果', () => {
+    const trapEffect: NonNullable<BoardCell['effect']> = {
+      type: 'trap',
+      value: 0,
+      description: '戴眼罩完成下一回合',
+    }
+
+    const result = resolveRule({
+      source: 'trap',
+      actorIndex: 1,
+      players,
+      effect: trapEffect,
+    })
+
+    expect(result).toMatchObject({
+      kind: 'trap',
+      source: 'trap',
+      actorIndex: 1,
+      acknowledgementRequired: true,
+      description: '戴眼罩完成下一回合',
+      turnConsequence: { kind: 'none' },
+    })
+  })
+
+  it('累积并只消费一次待跳过回合', () => {
+    const consequence = {
+      kind: 'skip_next_turns' as const,
+      count: 2,
+    }
+
+    const restedPlayer = applyTurnConsequence(players[0], consequence)
+    const firstTurn = consumePendingSkippedTurn(restedPlayer)
+    const secondTurn = consumePendingSkippedTurn(firstTurn.player)
+    const thirdTurn = consumePendingSkippedTurn(secondTurn.player)
+
+    expect(restedPlayer.pendingSkippedTurns).toBe(2)
+    expect(players[0].pendingSkippedTurns).toBeUndefined()
+    expect(firstTurn).toMatchObject({
+      shouldSkip: true,
+      player: { pendingSkippedTurns: 1 },
+    })
+    expect(secondTurn).toMatchObject({
+      shouldSkip: true,
+      player: { pendingSkippedTurns: 0 },
+    })
+    expect(thirdTurn).toMatchObject({
+      shouldSkip: false,
+      player: { pendingSkippedTurns: 0 },
+    })
   })
 })

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -9,6 +9,8 @@ export interface Player {
   failedTakeoffAttempts?: number // 起飞失败次数
   /** 求饶成功后的下次惩罚倍数（如 1.5），用完即清除 */
   pendingMercyMultiplier?: number
+  /** 尚未消费的跳过回合数 */
+  pendingSkippedTurns?: number
 }
 
 export interface PunishmentTool {
@@ -94,6 +96,7 @@ export interface ResolvedPunishmentResult {
   readonly executorIndex?: number
   readonly action: ResolvedPunishmentAction
   readonly count: ResolvedPunishmentCount
+  readonly countMultiplier?: number
   readonly turnConsequence: TurnConsequence
 }
 

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -192,6 +192,341 @@ test('movement watchdog preserves a turn while a trap overlay is active', async 
   })
 })
 
+test('dynamic punishment resolves its target and external count before confirmation', async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await page.goto('/flying-chess/')
+  await page.evaluate(() => {
+    const debugWindow = window as typeof window & {
+      gameState: {
+        players: Array<{
+          id: number
+          name: string
+          color: string
+          position: number
+          isWinner: boolean
+          hasTakenOff: boolean
+        }>
+        board: Array<{ position: number; type: string; effect?: unknown }>
+        currentPlayerIndex: number
+        gameStatus: string
+        diceValue: number | null
+        punishmentConfig: {
+          minStrikes: number
+          maxStrikes: number
+          step: number
+          doublePunishmentChance: number
+        }
+      }
+      gameStarted: { value: boolean }
+    }
+    debugWindow.gameState.players = [
+      {
+        id: 1,
+        name: '红方',
+        color: '#ef4444',
+        position: 4,
+        isWinner: false,
+        hasTakenOff: true,
+      },
+      {
+        id: 2,
+        name: '蓝方',
+        color: '#3b82f6',
+        position: 12,
+        isWinner: false,
+        hasTakenOff: true,
+      },
+      {
+        id: 3,
+        name: '绿方',
+        color: '#22c55e',
+        position: 10,
+        isWinner: false,
+        hasTakenOff: true,
+      },
+    ]
+    debugWindow.gameState.currentPlayerIndex = 1
+    debugWindow.gameState.gameStatus = 'waiting'
+    debugWindow.gameState.diceValue = null
+    debugWindow.gameState.punishmentConfig.minStrikes = 5
+    debugWindow.gameState.punishmentConfig.maxStrikes = 15
+    debugWindow.gameState.punishmentConfig.step = 5
+    debugWindow.gameState.punishmentConfig.doublePunishmentChance = 0
+    debugWindow.gameStarted.value = true
+
+    const landingCell = debugWindow.gameState.board.find(cell => cell.position === 16)
+    if (!landingCell) throw new Error('缺少第16格')
+    landingCell.type = 'punishment'
+    landingCell.effect = {
+      type: 'punishment',
+      value: 0,
+      description: '数量由其他玩家决定',
+      punishment: {
+        tool: { name: '藤条', intensity: 3, ratio: 100 },
+        bodyPart: { name: '臀部', sensitivity: 4, ratio: 100 },
+        position: { name: '手抓膝盖', ratio: 100, compatibleBodyParts: ['臀部'] },
+        strikes: 10,
+        description: '数量由其他玩家决定',
+        dynamicType: 'other_player_choice',
+      },
+    }
+
+    let randomCall = 0
+    Object.defineProperty(window.crypto, 'getRandomValues', {
+      configurable: true,
+      value: (values: Uint32Array) => {
+        values[0] = randomCall++ % 2 === 0 ? 0 : 3
+        return values
+      },
+    })
+  })
+
+  await page.locator('.dice-cube').click({ force: true })
+  await expect(page.getByText('受罚玩家')).toBeVisible()
+  await expect(page.locator('.target-name')).toHaveText('蓝方')
+  await expect(page.getByLabel('惩罚次数')).toHaveValue('5')
+  await page.getByLabel('惩罚次数').selectOption('15')
+  await page.getByRole('button', { name: '确认执行' }).click()
+  await expect(page.getByText('惩罚时间')).toBeHidden()
+})
+
+test('rest effect consumes the affected player next turn without a dice roll', async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await page.goto('/flying-chess/')
+  await page.evaluate(() => {
+    const debugWindow = window as typeof window & {
+      gameState: {
+        players: Array<{
+          id: number
+          name: string
+          color: string
+          position: number
+          isWinner: boolean
+          hasTakenOff: boolean
+          pendingSkippedTurns?: number
+        }>
+        board: Array<{ position: number; type: string; effect?: unknown }>
+        currentPlayerIndex: number
+        gameStatus: string
+        diceValue: number | null
+        pendingEffect: unknown
+      }
+      gameStarted: { value: boolean }
+      turnCount: { value: number }
+    }
+    debugWindow.gameState.players = [
+      {
+        id: 1,
+        name: '红方',
+        color: '#ef4444',
+        position: 7,
+        isWinner: false,
+        hasTakenOff: true,
+      },
+      {
+        id: 2,
+        name: '蓝方',
+        color: '#3b82f6',
+        position: 5,
+        isWinner: false,
+        hasTakenOff: true,
+      },
+    ]
+    debugWindow.gameState.currentPlayerIndex = 0
+    debugWindow.gameState.gameStatus = 'waiting'
+    debugWindow.gameState.diceValue = null
+    debugWindow.gameState.pendingEffect = null
+    debugWindow.gameStarted.value = true
+    debugWindow.turnCount.value = 1
+
+    const restCell = debugWindow.gameState.board.find(cell => cell.position === 8)
+    if (!restCell) throw new Error('缺少第8格')
+    restCell.type = 'special'
+    restCell.effect = {
+      type: 'rest',
+      value: 1,
+      description: '休息一回合',
+    }
+
+    Object.defineProperty(window.crypto, 'getRandomValues', {
+      configurable: true,
+      value: (values: Uint32Array) => {
+        values[0] = 0
+        return values
+      },
+    })
+  })
+
+  await page.locator('.dice-cube').click({ force: true })
+  await expect(page.getByText('休息一回合', { exact: true }).first()).toBeVisible()
+  await page.getByRole('button', { name: '确认', exact: true }).click()
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const debugWindow = window as typeof window & {
+          gameState: {
+            currentPlayerIndex: number
+            players: Array<{ pendingSkippedTurns?: number }>
+          }
+        }
+        return {
+          currentPlayerIndex: debugWindow.gameState.currentPlayerIndex,
+          pendingSkippedTurns: debugWindow.gameState.players[0].pendingSkippedTurns,
+        }
+      })
+    )
+    .toEqual({ currentPlayerIndex: 1, pendingSkippedTurns: 1 })
+
+  await page.evaluate(() => {
+    const debugWindow = window as typeof window & {
+      gameState: {
+        board: Array<{ position: number; type: string; effect?: unknown }>
+      }
+    }
+    const landingCell = debugWindow.gameState.board.find(cell => cell.position === 6)
+    if (!landingCell) throw new Error('缺少第6格')
+    landingCell.type = 'bonus'
+    delete landingCell.effect
+  })
+
+  await expect(page.locator('.dice-cube')).toHaveClass(/can-roll/)
+  await page.locator('.dice-cube').click({ force: true })
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const debugWindow = window as typeof window & {
+          gameState: {
+            currentPlayerIndex: number
+            players: Array<{ pendingSkippedTurns?: number }>
+          }
+          lastEffect: { value: string }
+        }
+        return {
+          currentPlayerIndex: debugWindow.gameState.currentPlayerIndex,
+          pendingSkippedTurns: debugWindow.gameState.players[0].pendingSkippedTurns,
+          lastEffect: debugWindow.lastEffect.value,
+        }
+      })
+    )
+    .toEqual({
+      currentPlayerIndex: 1,
+      pendingSkippedTurns: 0,
+      lastEffect: '红方休息一回合，本回合已跳过',
+    })
+})
+
+test('a forced overlay can pause, resume, and end the local session safely', async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await page.goto('/flying-chess/')
+  await page.evaluate(() => {
+    const debugWindow = window as typeof window & {
+      gameState: {
+        players: Array<{
+          id: number
+          name: string
+          color: string
+          position: number
+          isWinner: boolean
+          hasTakenOff: boolean
+        }>
+        board: Array<{ position: number; type: string; effect?: unknown }>
+        currentPlayerIndex: number
+        gameStatus: string
+        diceValue: number | null
+      }
+      gameStarted: { value: boolean }
+    }
+    debugWindow.gameState.players = [
+      {
+        id: 1,
+        name: '红方',
+        color: '#ef4444',
+        position: 7,
+        isWinner: false,
+        hasTakenOff: true,
+      },
+      {
+        id: 2,
+        name: '蓝方',
+        color: '#3b82f6',
+        position: 5,
+        isWinner: false,
+        hasTakenOff: true,
+      },
+    ]
+    debugWindow.gameState.currentPlayerIndex = 0
+    debugWindow.gameState.gameStatus = 'waiting'
+    debugWindow.gameState.diceValue = null
+    debugWindow.gameStarted.value = true
+
+    const trapCell = debugWindow.gameState.board.find(cell => cell.position === 8)
+    if (!trapCell) throw new Error('缺少第8格')
+    trapCell.type = 'trap'
+    trapCell.effect = {
+      type: 'trap',
+      value: 0,
+      description: '测试机关',
+    }
+
+    Object.defineProperty(window.crypto, 'getRandomValues', {
+      configurable: true,
+      value: (values: Uint32Array) => {
+        values[0] = 0
+        return values
+      },
+    })
+  })
+
+  await page.locator('.dice-cube').click({ force: true })
+  await expect(page.getByText('测试机关', { exact: true })).toBeVisible()
+  await page.getByRole('button', { name: '暂停本局' }).click()
+  await expect(page.getByRole('heading', { name: '本局已暂停' })).toBeVisible()
+
+  const trapWhilePaused = await page.evaluate(() => {
+    return (
+      window as typeof window & {
+        showTrapDisplay: { value: boolean }
+      }
+    ).showTrapDisplay.value
+  })
+  expect(trapWhilePaused).toBe(true)
+
+  await page.getByRole('button', { name: '继续游戏' }).click()
+  await expect(page.getByText('测试机关', { exact: true })).toBeVisible()
+
+  await page.getByRole('button', { name: '暂停本局' }).click()
+  await page.getByRole('button', { name: '结束本局' }).click()
+  await expect(page.getByRole('heading', { name: '游戏设置' })).toBeVisible()
+  await expect(page.getByText('测试机关', { exact: true })).toBeHidden()
+
+  const resetResolutionState = await page.evaluate(() => {
+    const debugWindow = window as typeof window & {
+      currentPunishmentTarget: { value: unknown }
+      pendingRuleResolution: { value: unknown }
+      sessionPaused: { value: boolean }
+    }
+    return {
+      currentPunishmentTarget: debugWindow.currentPunishmentTarget.value,
+      pendingRuleResolution: debugWindow.pendingRuleResolution.value,
+      sessionPaused: debugWindow.sessionPaused.value,
+    }
+  })
+  expect(resetResolutionState).toEqual({
+    currentPunishmentTarget: null,
+    pendingRuleResolution: null,
+    sessionPaused: false,
+  })
+})
+
 test('clear local game data removes every persisted game key', async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== 'desktop-chrome')
 


### PR DESCRIPTION
## 变更内容

- 将动态惩罚、机关和特殊格统一接入可执行的规则解析结果
- 支持前后玩家目标、其他玩家决定次数及求饶倍率的确定性结算
- 让“休息一回合”真实消耗受影响玩家的下一回合
- 在强制结算阶段增加安全暂停、继续和结束本局入口
- 结束本局时完整清理旧惩罚、机关、反弹和暂停状态
- 将版本升级到 v1.7.2

## 用户影响

偏好惩罚体验的玩家现在会得到更明确、可执行且不会被描述文本绕过的惩罚流程，同时仍可在本地安全暂停或终止当前对局。

## 验证

- `npm test`：76 passed
- `npm run type-check`：passed
- `npm run lint:check`：0 errors，8 existing warnings
- `npm run build`：passed
- `npm run test:e2e`：13 passed，13 project-specific skipped
- Standards / Spec 最终评审：无发现