### PR TITLE
fix: improve mobile interaction reliability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -132,6 +132,13 @@
   const punishmentCombinations = ref<PunishmentCombination[]>([])
   const punishmentStep = ref<'config' | 'confirm'>('config')
 
+  watch([settingsTab, punishmentStep], () => {
+    if (!isMobileView.value) return
+    void nextTick(() => {
+      window.scrollTo({ top: 0, behavior: 'auto' })
+    })
+  })
+
   // 新增效果位置状态
   const effectFromPosition = ref<number | undefined>(undefined)
   const effectToPosition = ref<number | undefined>(undefined)
@@ -2229,7 +2236,13 @@
 </script>
 
 <template>
-  <div class="app">
+  <div
+    class="app"
+    :class="{
+      'app--settings':
+        gameState.gameStatus === 'board_settings' || gameState.gameStatus === 'settings',
+    }"
+  >
     <!-- 开始页面 -->
     <IntroPage v-if="gameState.gameStatus === 'intro'" @start="handleIntroStart" />
 
@@ -2551,6 +2564,7 @@
     <button
       v-if="canPauseSession && !sessionPaused"
       class="session-pause-trigger"
+      :class="{ 'session-pause-trigger--blocked': hasActiveForcedOverlay }"
       aria-label="暂停本局"
       @click="pauseSession"
     >
@@ -3389,9 +3403,17 @@
 
   /* 移动端适配 */
   @media (max-width: 768px) {
+    .app--settings .guide-controls {
+      display: none;
+    }
+
     .session-pause-trigger {
       right: 0.75rem;
       bottom: 4.75rem;
+    }
+
+    .session-pause-trigger--blocked {
+      display: none;
     }
 
     .session-pause-trigger span {

--- a/src/components/CoolDice.vue
+++ b/src/components/CoolDice.vue
@@ -54,64 +54,67 @@
   <div class="cool-dice-container">
     <!-- 3D骰子 -->
     <div class="dice-scene">
-      <div
+      <button
+        type="button"
         class="dice-cube"
         :class="{
           rolling: isRolling,
           'can-roll': canRoll && !isRolling,
           [getCurrentFaceClass()]: !isRolling,
         }"
+        :aria-label="isRolling ? '骰子滚动中' : canRoll ? '投掷骰子' : '当前不可投掷骰子'"
+        :disabled="!canRoll || isRolling"
         @click="handleRoll"
       >
         <!-- 面1: 中心一个点 -->
-        <div class="face face-1">
-          <div class="dot center"></div>
-        </div>
+        <span class="face face-1">
+          <span class="dot center"></span>
+        </span>
 
         <!-- 面2: 对角两个点 -->
-        <div class="face face-2">
-          <div class="dot top-left"></div>
-          <div class="dot bottom-right"></div>
-        </div>
+        <span class="face face-2">
+          <span class="dot top-left"></span>
+          <span class="dot bottom-right"></span>
+        </span>
 
         <!-- 面3: 对角三个点 -->
-        <div class="face face-3">
-          <div class="dot top-left"></div>
-          <div class="dot center"></div>
-          <div class="dot bottom-right"></div>
-        </div>
+        <span class="face face-3">
+          <span class="dot top-left"></span>
+          <span class="dot center"></span>
+          <span class="dot bottom-right"></span>
+        </span>
 
         <!-- 面4: 四角四个点 -->
-        <div class="face face-4">
-          <div class="dot top-left"></div>
-          <div class="dot top-right"></div>
-          <div class="dot bottom-left"></div>
-          <div class="dot bottom-right"></div>
-        </div>
+        <span class="face face-4">
+          <span class="dot top-left"></span>
+          <span class="dot top-right"></span>
+          <span class="dot bottom-left"></span>
+          <span class="dot bottom-right"></span>
+        </span>
 
         <!-- 面5: 四角加中心 -->
-        <div class="face face-5">
-          <div class="dot top-left"></div>
-          <div class="dot top-right"></div>
-          <div class="dot center"></div>
-          <div class="dot bottom-left"></div>
-          <div class="dot bottom-right"></div>
-        </div>
+        <span class="face face-5">
+          <span class="dot top-left"></span>
+          <span class="dot top-right"></span>
+          <span class="dot center"></span>
+          <span class="dot bottom-left"></span>
+          <span class="dot bottom-right"></span>
+        </span>
 
         <!-- 面6: 两列各三个点 -->
-        <div class="face face-6">
-          <div class="column left">
-            <div class="dot"></div>
-            <div class="dot"></div>
-            <div class="dot"></div>
-          </div>
-          <div class="column right">
-            <div class="dot"></div>
-            <div class="dot"></div>
-            <div class="dot"></div>
-          </div>
-        </div>
-      </div>
+        <span class="face face-6">
+          <span class="column left">
+            <span class="dot"></span>
+            <span class="dot"></span>
+            <span class="dot"></span>
+          </span>
+          <span class="column right">
+            <span class="dot"></span>
+            <span class="dot"></span>
+            <span class="dot"></span>
+          </span>
+        </span>
+      </button>
     </div>
 
     <!-- 结果显示 -->
@@ -157,6 +160,11 @@
     position: relative;
     width: 100px;
     height: 100px;
+    padding: 0;
+    color: inherit;
+    appearance: none;
+    background: transparent;
+    border: 0;
     transform-style: preserve-3d;
     transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
     cursor: pointer;
@@ -167,6 +175,15 @@
   .dice-cube:hover:not(.rolling) {
     transform: scale(1.05) rotateX(5deg) rotateY(5deg);
     filter: drop-shadow(0 6px 16px rgba(102, 126, 234, 0.5));
+  }
+
+  .dice-cube:disabled {
+    cursor: default;
+  }
+
+  .dice-cube:focus-visible {
+    outline: 3px solid var(--color-accent-light);
+    outline-offset: 8px;
   }
 
   .dice-cube.can-roll {

--- a/src/components/GameBoard.vue
+++ b/src/components/GameBoard.vue
@@ -144,7 +144,7 @@
   }))
 
   const diceScale = computed(() => {
-    if (isMobile.value) return 0.6
+    if (isMobile.value) return 0.8
     const s = cellSize.value
     if (s >= 50) return 0.85
     if (s >= 40) return 0.7

--- a/src/components/PunishmentDisplay.vue
+++ b/src/components/PunishmentDisplay.vue
@@ -80,72 +80,74 @@
       </div>
 
       <div class="punishment-content">
-        <div v-if="targetPlayer" class="target-info">
-          <span class="target-label">受罚玩家</span>
-          <div class="target-player">
-            <div class="target-avatar" :style="{ backgroundColor: targetPlayer.color }"></div>
-            <span class="target-name">{{ targetPlayer.name }}</span>
+        <div class="punishment-scroll-body">
+          <div v-if="targetPlayer" class="target-info">
+            <span class="target-label">受罚玩家</span>
+            <div class="target-player">
+              <div class="target-avatar" :style="{ backgroundColor: targetPlayer.color }"></div>
+              <span class="target-name">{{ targetPlayer.name }}</span>
+            </div>
           </div>
+
+          <!-- 执行惩罚的玩家信息 -->
+          <div v-if="executorPlayer" class="executor-info">
+            <div class="executor-header">
+              <span class="executor-label">执行惩罚的玩家:</span>
+            </div>
+            <div class="executor-player">
+              <div class="executor-avatar" :style="{ backgroundColor: executorPlayer.color }"></div>
+              <span class="executor-name">{{ executorPlayer.name }}</span>
+            </div>
+          </div>
+
+          <div class="punishment-details">
+            <div class="punishment-item">
+              <span class="label">工具:</span>
+              <span class="value tool">{{ punishment.tool.name }}</span>
+              <span class="intensity">强度: {{ punishment.tool.intensity }}/10</span>
+            </div>
+
+            <div class="punishment-item">
+              <span class="label">部位:</span>
+              <span class="value body-part">{{ punishment.bodyPart.name }}</span>
+              <span class="sensitivity">耐受度: {{ punishment.bodyPart.sensitivity }}/10</span>
+            </div>
+
+            <div class="punishment-item">
+              <span class="label">姿势:</span>
+              <span class="value position">{{ punishment.position.name }}</span>
+            </div>
+
+            <div v-if="punishment.strikes != null" class="punishment-item">
+              <span class="label">次数:</span>
+              <span class="value strikes">{{ punishment.strikes }} 下</span>
+            </div>
+          </div>
+
+          <div class="punishment-summary">
+            <h4>执行内容:</h4>
+            <p v-if="countSelection" class="summary-text">
+              由{{ executorPlayer?.name || '其他玩家' }}决定本次惩罚次数
+            </p>
+            <p v-else class="summary-text">{{ punishment.description }}</p>
+          </div>
+
+          <label v-if="countSelection" class="count-selection">
+            <span>惩罚次数</span>
+            <select v-model.number="selectedCount" aria-label="惩罚次数">
+              <option v-for="count in countOptions" :key="count" :value="count">
+                {{ count }} 下
+              </option>
+            </select>
+            <small>
+              可选范围 {{ countSelection.minimum }}–{{ countSelection.maximum }}，按
+              {{ countSelection.step }} 递增
+            </small>
+            <small v-if="countMultiplier > 1" class="multiplier-preview">
+              本次倍率 ×{{ countMultiplier }}，最终执行 {{ finalizedCountPreview }} 下
+            </small>
+          </label>
         </div>
-
-        <!-- 执行惩罚的玩家信息 -->
-        <div v-if="executorPlayer" class="executor-info">
-          <div class="executor-header">
-            <span class="executor-label">执行惩罚的玩家:</span>
-          </div>
-          <div class="executor-player">
-            <div class="executor-avatar" :style="{ backgroundColor: executorPlayer.color }"></div>
-            <span class="executor-name">{{ executorPlayer.name }}</span>
-          </div>
-        </div>
-
-        <div class="punishment-details">
-          <div class="punishment-item">
-            <span class="label">工具:</span>
-            <span class="value tool">{{ punishment.tool.name }}</span>
-            <span class="intensity">强度: {{ punishment.tool.intensity }}/10</span>
-          </div>
-
-          <div class="punishment-item">
-            <span class="label">部位:</span>
-            <span class="value body-part">{{ punishment.bodyPart.name }}</span>
-            <span class="sensitivity">耐受度: {{ punishment.bodyPart.sensitivity }}/10</span>
-          </div>
-
-          <div class="punishment-item">
-            <span class="label">姿势:</span>
-            <span class="value position">{{ punishment.position.name }}</span>
-          </div>
-
-          <div v-if="punishment.strikes != null" class="punishment-item">
-            <span class="label">次数:</span>
-            <span class="value strikes">{{ punishment.strikes }} 下</span>
-          </div>
-        </div>
-
-        <div class="punishment-summary">
-          <h4>执行内容:</h4>
-          <p v-if="countSelection" class="summary-text">
-            由{{ executorPlayer?.name || '其他玩家' }}决定本次惩罚次数
-          </p>
-          <p v-else class="summary-text">{{ punishment.description }}</p>
-        </div>
-
-        <label v-if="countSelection" class="count-selection">
-          <span>惩罚次数</span>
-          <select v-model.number="selectedCount" aria-label="惩罚次数">
-            <option v-for="count in countOptions" :key="count" :value="count">
-              {{ count }} 下
-            </option>
-          </select>
-          <small>
-            可选范围 {{ countSelection.minimum }}–{{ countSelection.maximum }}，按
-            {{ countSelection.step }} 递增
-          </small>
-          <small v-if="countMultiplier > 1" class="multiplier-preview">
-            本次倍率 ×{{ countMultiplier }}，最终执行 {{ finalizedCountPreview }} 下
-          </small>
-        </label>
 
         <div class="punishment-actions">
           <button
@@ -174,6 +176,10 @@
   .punishment-display {
     border: 1px solid rgba(255, 71, 87, 0.3);
     max-width: 500px;
+    display: flex;
+    flex-direction: column;
+    max-height: 90dvh;
+    overflow: hidden;
   }
 
   .punishment-header {
@@ -201,6 +207,16 @@
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+    min-height: 0;
+  }
+
+  .punishment-scroll-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: 0.25rem;
   }
 
   .target-info,
@@ -374,8 +390,10 @@
     display: flex;
     gap: 1rem;
     justify-content: center;
-    margin-top: 1rem;
     flex-wrap: wrap;
+    flex-shrink: 0;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
   }
 
   .btn-mercy {
@@ -393,7 +411,7 @@
     .punishment-display {
       padding: 1rem;
       width: 95%;
-      max-height: 95vh;
+      max-height: 95dvh;
     }
 
     .punishment-header h3 {
@@ -441,7 +459,7 @@
     .punishment-actions {
       flex-direction: column;
       gap: 0.75rem;
-      margin-top: 1.5rem;
+      padding-top: 0.75rem;
     }
 
     .punishment-actions .btn {
@@ -458,7 +476,7 @@
     .punishment-display {
       padding: 0.75rem;
       width: 98%;
-      max-height: 98vh;
+      max-height: 98dvh;
     }
 
     .punishment-header {
@@ -510,7 +528,7 @@
 
     .punishment-actions {
       gap: 0.5rem;
-      margin-top: 1rem;
+      padding-top: 0.5rem;
     }
 
     .punishment-actions .btn {

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import type { Page } from '@playwright/test'
 
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
@@ -10,6 +11,21 @@ test.beforeEach(async ({ page }) => {
     )
   })
 })
+
+async function enterDefaultSettings(page: Page) {
+  await page.goto('/flying-chess/')
+  await page.locator('.start-btn').click()
+  await expect(page.getByRole('heading', { name: '游戏设置' })).toBeVisible()
+}
+
+async function startDefaultGame(page: Page) {
+  await enterDefaultSettings(page)
+  await page.locator('.page-actions .btn-primary').click()
+  await page.locator('.page-actions .btn-primary').click()
+  await page.getByRole('button', { name: /生成惩罚组合/ }).click()
+  await page.getByRole('button', { name: /开始游戏/ }).click()
+  await expect(page.locator('.game-board')).toBeVisible()
+}
 
 test('desktop app fills the viewport width', async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== 'desktop-chrome')
@@ -72,6 +88,134 @@ test('mobile game board page has no horizontal overflow', async ({ page }, testI
   }))
 
   expect(dimensions.documentWidth).toBeLessThanOrEqual(dimensions.viewportWidth)
+})
+
+test('mobile settings return to the top when advancing a step', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'mobile-chrome')
+
+  await enterDefaultSettings(page)
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+  expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+
+  await page.locator('.page-actions .btn-primary').click()
+
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
+  await expect(page.getByRole('heading', { name: '惩罚设置' })).toBeVisible()
+})
+
+test('mobile floating controls do not cover settings actions', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'mobile-chrome')
+
+  await enterDefaultSettings(page)
+  await page.locator('.page-actions .btn-primary').click()
+  await page.locator('.page-actions .btn-primary').click()
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+
+  const overlaps = await page.evaluate(() => {
+    const rect = (selector: string) => {
+      const element = document.querySelector(selector)
+      if (!element) return null
+      const bounds = element.getBoundingClientRect()
+      return {
+        left: bounds.left,
+        top: bounds.top,
+        right: bounds.right,
+        bottom: bounds.bottom,
+      }
+    }
+    const intersects = (first: ReturnType<typeof rect>, second: ReturnType<typeof rect>): boolean =>
+      Boolean(
+        first &&
+          second &&
+          first.left < second.right &&
+          first.right > second.left &&
+          first.top < second.bottom &&
+          first.bottom > second.top
+      )
+
+    const primary = rect('.page-actions .btn-primary')
+    const secondary = rect('.page-actions .btn-secondary')
+    return {
+      helpOverPrimary: intersects(rect('.guide-btn'), primary),
+      settingsOverSecondary: intersects(rect('.settings-toggle'), secondary),
+    }
+  })
+
+  expect(overlaps).toEqual({
+    helpOverPrimary: false,
+    settingsOverSecondary: false,
+  })
+})
+
+test('mobile dice is an accessible touch-sized button', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'mobile-chrome')
+
+  await startDefaultGame(page)
+
+  const diceButton = page.getByRole('button', { name: '投掷骰子' })
+  await expect(diceButton).toBeVisible()
+  const bounds = await diceButton.boundingBox()
+
+  expect(bounds).not.toBeNull()
+  expect(bounds?.width).toBeGreaterThanOrEqual(44)
+  expect(bounds?.height).toBeGreaterThanOrEqual(44)
+})
+
+test('mobile punishment actions stay visible without a competing pause button', async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'mobile-chrome')
+
+  await startDefaultGame(page)
+  await page.evaluate(() => {
+    const debugWindow = window as typeof window & {
+      gameState: {
+        gameStatus: string
+        players: Array<{
+          id: number
+          name: string
+          color: string
+          position: number
+          isWinner: boolean
+          hasTakenOff: boolean
+        }>
+      }
+      currentPunishment: { value: unknown }
+      currentPunishmentTarget: { value: unknown }
+      currentPunishmentExecutor: { value: unknown }
+    }
+
+    debugWindow.currentPunishment.value = {
+      tool: { name: '测试工具', intensity: 3, ratio: 100 },
+      bodyPart: { name: '测试部位', sensitivity: 5, ratio: 100 },
+      position: {
+        name: '测试姿势',
+        ratio: 100,
+        compatibleBodyParts: ['测试部位'],
+      },
+      strikes: 20,
+      description: '移动端惩罚弹窗测试',
+    }
+    debugWindow.currentPunishmentTarget.value = debugWindow.gameState.players[1]
+    debugWindow.currentPunishmentExecutor.value = debugWindow.gameState.players[0]
+    debugWindow.gameState.gameStatus = 'configuring'
+  })
+
+  const actionButtons = page.locator('.punishment-actions button')
+  await expect(actionButtons).toHaveCount(3)
+  const viewportHeight = page.viewportSize()?.height ?? 0
+  const actionBounds = await actionButtons.evaluateAll(buttons =>
+    buttons.map(button => {
+      const bounds = button.getBoundingClientRect()
+      return { top: bounds.top, bottom: bounds.bottom }
+    })
+  )
+
+  for (const bounds of actionBounds) {
+    expect(bounds.top).toBeGreaterThanOrEqual(0)
+    expect(bounds.bottom).toBeLessThanOrEqual(viewportHeight)
+  }
+  await expect(page.getByRole('button', { name: '暂停本局' })).toBeHidden()
 })
 
 test('total cell changes update the generated board', async ({ page }, testInfo) => {


### PR DESCRIPTION
## 变更内容

- 设置步骤切换后在移动端自动回到页面顶部
- 避免悬浮帮助控件和暂停按钮遮挡移动端主操作
- 将骰子改为语义化按钮并扩大触控区域
- 让惩罚弹窗内容独立滚动，操作按钮保持可见
- 新增四项移动端 Playwright 回归测试
- 将版本升级到 v1.7.3

## 原因与用户影响

此前移动端存在步骤切换后滚动位置残留、悬浮控件遮挡、骰子触控区域偏小，以及惩罚操作按钮可能落在视口外等问题。本次修复提升手机端的可操作性和可访问性，不改变玩法规则、惩罚规则或现场工具配置。

## 验证

- `npm test`：76 passed
- `npm run type-check`：passed
- `npm run lint:check`：0 errors，8 existing warnings
- `npm run build`：passed
- `npm run test:e2e`：17 passed，17 project-specific skipped