### PR TITLE
feat: add v1.7.4 anonymous Umami telemetry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,58 +13,71 @@ permissions:
 
 # 允许一个并发部署
 concurrency:
-  group: "pages"
+  group: 'pages'
   cancel-in-progress: false
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
-        cache: 'npm'
-        
-    - name: Install dependencies
-      run: npm ci
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Lint
-      run: npm run lint:check
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
 
-    - name: Type check
-      run: npm run type-check
+      - name: Install dependencies
+        run: npm ci
 
-    - name: Test
-      run: npm run test
-      
-    - name: Extract version from tag
-      id: version
-      run: |
-        VERSION=${GITHUB_REF#refs/tags/}
-        VERSION=${VERSION#v}
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-        echo "📦 提取版本号: $VERSION"
-      
-    - name: Build
-      env:
-        VITE_APP_VERSION: ${{ steps.version.outputs.version }}
-      run: npm run build
-      
-    - name: Setup Pages
-      uses: actions/configure-pages@v4
-      with:
-        enablement: true
-      
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: './dist'
-        
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4 
+      - name: Lint
+        run: npm run lint:check
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Test
+        run: npm run test
+
+      - name: Validate Umami configuration
+        env:
+          UMAMI_WEBSITE_ID: ${{ vars.UMAMI_WEBSITE_ID }}
+          UMAMI_SCRIPT_URL: ${{ vars.UMAMI_SCRIPT_URL }}
+        run: |
+          if [ -z "$UMAMI_WEBSITE_ID" ] || [ -z "$UMAMI_SCRIPT_URL" ]; then
+            echo "::error::UMAMI_WEBSITE_ID and UMAMI_SCRIPT_URL repository variables are required"
+            exit 1
+          fi
+          node -e "if (!/^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(process.env.UMAMI_WEBSITE_ID || '')) { console.error('UMAMI_WEBSITE_ID must be a UUID'); process.exit(1) }"
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${VERSION#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "📦 提取版本号: $VERSION"
+
+      - name: Build
+        env:
+          VITE_APP_VERSION: ${{ steps.version.outputs.version }}
+          VITE_UMAMI_WEBSITE_ID: ${{ vars.UMAMI_WEBSITE_ID }}
+          VITE_UMAMI_SCRIPT_URL: ${{ vars.UMAMI_SCRIPT_URL }}
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        with:
+          enablement: true
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎲 惩罚飞行棋（Ludo Punishment Game）
 
-一个基于 **Vue 3 + TypeScript** 的创新飞行棋游戏，支持自定义惩罚机制、机关陷阱、详细统计和多端适配。适合聚会、娱乐和“自律”场景。
+一个基于 **Vue 3 + TypeScript** 的创新飞行棋游戏，支持自定义惩罚机制、机关陷阱、匿名统计和多端适配。适合聚会、娱乐和“自律”场景。
 
 ---
 
@@ -9,7 +9,7 @@
 - **自定义惩罚系统**：支持多种工具、身体部位、受罚姿势的自由组合，自动生成惩罚方案。
 - **机关陷阱**：棋盘可配置机关格，触发特殊事件或惩罚。
 - **3D 骰子动画**：真实 3D 效果，动画可自定义。
-- **详细统计**：本地/云端统计游玩次数、会话、胜率等，支持 Supabase 云同步。
+- **匿名统计**：生产环境使用无 Cookie 的 Umami 统计关键游戏流程，不上传玩家姓名或配置内容。
 - **多端适配**：响应式设计，适配桌面和移动端。
 - **版本号与构建时间显示**：右上角实时显示版本号，支持 Git Tag 自动注入。
 - **新手引导**：内置可重置的新手引导，帮助快速上手。
@@ -42,12 +42,15 @@
   - 惩罚次数范围、步长
   - 机关格、奖励格、后退格等数量和分布
 
-### 统计功能
+### 匿名统计
 
-- 配置文件：`src/config/statistics.ts`
-- 支持本地统计和 Supabase 云端统计（需配置环境变量）
-- 统计内容包括：累计游玩次数、最后游玩时间、会话数据等
-- 可在 UI 中查看和重置统计数据
+- 遥测逻辑集中在 `src/services/gameTelemetry.ts`，生产环境通过 Umami Cloud 的
+  `script.js` 上报，本地开发默认禁用。
+- 自定义事件只包含应用版本、经典模式、设备类型以及玩家数、局长、回合数的宽分桶。
+- 不上传玩家姓名、惩罚内容、导入配置、原始玩家数、原始时长、原始回合数或任何自定义标识符。
+- 不调用 `umami.identify()`，不加载 `recorder.js`，不启用录屏、热力图或性能采集。
+- 生产构建从 GitHub Actions 仓库变量 `UMAMI_WEBSITE_ID` 和 `UMAMI_SCRIPT_URL`
+  注入配置；Website ID 必须是 UUID。
 
 ### 版本号与构建时间
 
@@ -59,14 +62,14 @@
 
 ## 📊 统计与分析
 
-- 游戏内置统计弹窗（点击界面按钮可查看）
-- 支持本地和云端（Supabase）两种统计模式
-- 统计内容包括：
-  - 累计游玩次数
-  - 最后游玩时间
-  - 记录起始时间
-  - 惩罚组合分布（工具/部位/姿势统计）
-- 可一键重置统计数据
+- v1.7.4 仅记录 `app_open`、`setup_started`、`game_started`、`game_completed`、
+  `game_ended` 和 `play_again` 六类自定义事件，模式固定为 `classic`。
+- Umami 保留标准匿名页面和会话元数据；跟踪器限制域名为 `atang-sp.github.io`，尊重
+  Do Not Track，并排除 URL 查询参数与 Hash。
+- 统计基线从 v1.7.4 成功部署后开始，历史游戏不会补算。
+- 广告拦截、Do Not Track、离线、关闭或刷新页面、脚本加载失败和换设备都会造成少算。
+  应用不使用指纹、持久化队列、离线补传或重试来提高上报率。
+- 仓库没有 Supabase 统计后端，也没有本地统计弹窗或统计重置入口。
 
 ---
 
@@ -74,7 +77,7 @@
 
 ### 环境要求
 
-- Node.js 16+
+- Node.js 18+
 - npm 或 yarn
 
 ### 安装步骤
@@ -125,6 +128,8 @@ npm install primevue primeicons
 ## 🚀 部署
 
 - **GitHub Pages**：支持自动/手动部署，详见 `deploy.sh` 和 `.github/workflows/deploy.yml`
+- **Umami Cloud**：生产网站名为 `flying-chess-production`，域名为
+  `atang-sp.github.io`；Replays、Heatmaps、Performance 与公开 Share URL 必须保持关闭。
 - **Vercel/Netlify**：直接连接仓库，构建命令 `npm run build`，输出目录 `dist`
 - **自定义服务器**：将 `dist` 目录部署到任意静态服务器
 
@@ -150,7 +155,7 @@ npm install primevue primeicons
 - **前端框架**：Vue 3 + TypeScript
 - **构建工具**：Vite
 - **UI/动画**：CSS3 + 3D 变换
-- **统计后端**：可选 Supabase
+- **匿名统计**：Umami Cloud（仅生产环境）
 - **PWA 支持**：可安装为桌面/移动应用
 
 ---
@@ -158,7 +163,7 @@ npm install primevue primeicons
 ## 📚 相关文档
 
 - 游戏参数与惩罚机制详见 `src/config/gameConfig.ts`
-- 统计功能配置详见 `src/config/statistics.ts`
+- 匿名统计事件契约与隐私边界见 `src/services/gameTelemetry.ts`
 - 版本号注入逻辑见 `vite-plugin-version.ts`
 - 详细开发路线、更新日志请见 [ROADMAP.md] 和 [RELEASE_NOTES.md]（如有）
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "0.1.0",
+  "version": "1.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "0.1.0",
+      "version": "1.7.4",
       "dependencies": {
         "@lucide/vue": "^1.24.0",
         "@primevue/themes": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
   /* eslint-disable @typescript-eslint/ban-ts-comment */
   import { ref, reactive, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
   import { GameService } from './services/gameService'
+  import { gameTelemetry } from './services/gameTelemetry'
   import {
     applyTurnConsequence,
     consumePendingSkippedTurn,
@@ -127,6 +128,18 @@
   const currentPunishment = ref<PunishmentAction | null>(null)
   const currentPunishmentTarget = ref<Player | null>(null)
   const pendingRuleResolution = ref<ResolvedRuleResult | null>(null)
+
+  watch(gameStarted, (started, wasStarted) => {
+    if (started && !wasStarted) {
+      gameTelemetry.startGame(gameState.players.length)
+    }
+  })
+
+  watch(gameFinished, (finished, wasFinished) => {
+    if (finished && !wasFinished) {
+      gameTelemetry.finishGame('completed', turnCount.value)
+    }
+  })
 
   // 惩罚组合确认状态
   const punishmentCombinations = ref<PunishmentCombination[]>([])
@@ -689,6 +702,7 @@
   }
 
   onMounted(() => {
+    gameTelemetry.openApp()
     audioService.init()
     audioEnabled.value = audioService.enabled
 
@@ -1052,6 +1066,7 @@
 
   const endPausedSession = () => {
     sessionPaused.value = false
+    gameTelemetry.finishGame('user_ended', turnCount.value)
     resetGame()
   }
 
@@ -1634,6 +1649,7 @@
 
   // 修改IntroPage组件的调用，使其能够接收玩家配置信息并传递给startGame方法
   const handleIntroStart = (playerConfig?: { count: number; names: string[] }) => {
+    gameTelemetry.startSetup(playerConfig?.count ?? gameState.players.length)
     startGame(playerConfig)
   }
 
@@ -1735,8 +1751,11 @@
 
   // 处理胜利结算画面的"再来一局"按钮
   const handleVictoryPlayAgain = () => {
+    const playerCount = gameState.players.length
+    gameTelemetry.playAgain()
     showVictoryScreen.value = false
     resetGame()
+    gameTelemetry.startSetup(playerCount)
   }
 
   const showTakeoffReliefDisplay = ref(false)
@@ -2093,6 +2112,9 @@
 
   const handleImportSuccess = async (message: string) => {
     devLog(`配置导入成功: ${message}`)
+    if (gameStarted.value) {
+      gameTelemetry.finishGame('config_import', turnCount.value)
+    }
 
     // 重新加载玩家设置
     const playerSettings = loadPlayerSettings()
@@ -2444,7 +2466,7 @@
               label="再来一局"
               icon="pi pi-refresh"
               class="p-button-info p-button-sm"
-              @click="resetGame"
+              @click="handleVictoryPlayAgain"
             />
             <button
               class="audio-toggle-btn"

--- a/src/components/IntroPage.vue
+++ b/src/components/IntroPage.vue
@@ -342,6 +342,11 @@
           </div>
         </div>
 
+        <p class="privacy-note">
+          本应用使用无 Cookie
+          的匿名统计改进体验；不会上传玩家姓名、游戏配置内容，也不启用录屏或页面回放。
+        </p>
+
         <!-- 清空缓存选项 -->
         <div class="cache-controls">
           <button
@@ -886,6 +891,19 @@
   .info-icon {
     color: var(--color-accent-light);
     flex-shrink: 0;
+  }
+
+  .privacy-note {
+    max-width: 620px;
+    margin: 0;
+    padding: 0.75rem 1rem;
+    color: var(--text-muted);
+    font-size: clamp(0.72rem, 2vw, 0.82rem);
+    line-height: 1.6;
+    text-align: center;
+    background: rgba(15, 23, 42, 0.38);
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    border-radius: var(--radius-md);
   }
 
   /* 背景装饰 */

--- a/src/services/gameTelemetry.ts
+++ b/src/services/gameTelemetry.ts
@@ -1,0 +1,337 @@
+export type GameEndOutcome = 'completed' | 'user_ended' | 'config_import'
+
+export interface GameTelemetry {
+  openApp(): void
+  startSetup(playerCount: number): void
+  startGame(playerCount: number): void
+  finishGame(outcome: GameEndOutcome, turnCount: number): void
+  playAgain(): void
+}
+
+export type TelemetryEventName =
+  | 'app_open'
+  | 'setup_started'
+  | 'game_started'
+  | 'game_completed'
+  | 'game_ended'
+  | 'play_again'
+
+type DeviceType = 'mobile' | 'desktop'
+
+export type TelemetryEventData = Readonly<Record<string, string>>
+
+export interface TelemetryEvent {
+  readonly name: TelemetryEventName
+  readonly data: TelemetryEventData
+}
+
+export interface TelemetryAdapter {
+  track(name: TelemetryEventName, data: TelemetryEventData): void | Promise<void>
+}
+
+declare global {
+  interface Window {
+    __GAME_TELEMETRY_TEST_ADAPTER__?: TelemetryAdapter
+  }
+}
+
+interface GameTelemetryOptions {
+  readonly adapter: TelemetryAdapter
+  readonly now?: () => number
+  readonly getViewportWidth?: () => number
+}
+
+interface UmamiTracker {
+  track(name: TelemetryEventName, data: TelemetryEventData): void | Promise<void>
+}
+
+export interface UmamiScriptLoadOptions {
+  readonly src: string
+  readonly attributes: Readonly<Record<string, string>>
+  readonly onLoad: () => void
+  readonly onError: () => void
+}
+
+interface UmamiAdapterOptions {
+  readonly websiteId: string
+  readonly scriptUrl: string
+  readonly domain?: string
+  readonly loadScript?: (options: UmamiScriptLoadOptions) => void
+  readonly getTracker?: () => UmamiTracker | undefined
+}
+
+const APP_VERSION = '1.7.4'
+const MODE_ID = 'classic'
+const MAX_BUFFERED_EVENTS = 20
+const COMMON_FIELDS = ['app_version', 'mode_id', 'device_type'] as const
+const EVENT_FIELDS: Record<TelemetryEventName, readonly string[]> = {
+  app_open: COMMON_FIELDS,
+  setup_started: [...COMMON_FIELDS, 'player_count_bucket'],
+  game_started: [...COMMON_FIELDS, 'player_count_bucket'],
+  game_completed: [
+    ...COMMON_FIELDS,
+    'player_count_bucket',
+    'duration_bucket',
+    'turn_count_bucket',
+    'end_type',
+  ],
+  game_ended: [
+    ...COMMON_FIELDS,
+    'player_count_bucket',
+    'duration_bucket',
+    'turn_count_bucket',
+    'end_type',
+  ],
+  play_again: [
+    ...COMMON_FIELDS,
+    'player_count_bucket',
+    'duration_bucket',
+    'turn_count_bucket',
+    'end_type',
+  ],
+}
+
+function bucketPlayerCount(playerCount: number): string {
+  if (playerCount <= 1) return '1'
+  if (playerCount === 2) return '2'
+  if (playerCount <= 4) return '3_4'
+  return '5_plus'
+}
+
+function bucketDuration(elapsedMs: number): string {
+  if (elapsedMs < 10 * 60_000) return 'lt_10m'
+  if (elapsedMs < 20 * 60_000) return '10_20m'
+  if (elapsedMs < 40 * 60_000) return '20_40m'
+  return '40m_plus'
+}
+
+function bucketTurnCount(turnCount: number): string {
+  if (turnCount <= 10) return '1_10'
+  if (turnCount <= 20) return '11_20'
+  if (turnCount <= 40) return '21_40'
+  return '41_plus'
+}
+
+function sanitizeEventData(
+  name: TelemetryEventName,
+  candidate: Record<string, unknown>
+): TelemetryEventData {
+  return Object.fromEntries(
+    EVENT_FIELDS[name]
+      .filter(key => typeof candidate[key] === 'string')
+      .map(key => [key, candidate[key] as string])
+  )
+}
+
+function loadBrowserScript(options: UmamiScriptLoadOptions): void {
+  const script = document.createElement('script')
+  script.src = options.src
+  script.defer = true
+  Object.entries(options.attributes).forEach(([name, value]) => script.setAttribute(name, value))
+  script.addEventListener('load', options.onLoad, { once: true })
+  script.addEventListener('error', options.onError, { once: true })
+  document.head.appendChild(script)
+}
+
+export function createUmamiAdapter({
+  websiteId,
+  scriptUrl,
+  domain = 'atang-sp.github.io',
+  loadScript = loadBrowserScript,
+  getTracker = () => (window as typeof window & { umami?: UmamiTracker }).umami,
+}: UmamiAdapterOptions): TelemetryAdapter {
+  const queuedEvents: TelemetryEvent[] = []
+  let state: 'loading' | 'ready' | 'failed' = 'loading'
+  let tracker: UmamiTracker | undefined
+
+  const discardQueue = (): void => {
+    queuedEvents.splice(0, queuedEvents.length)
+  }
+
+  const dispatch = (event: TelemetryEvent): void => {
+    if (!tracker) return
+    try {
+      const result = tracker.track(event.name, event.data)
+      void Promise.resolve(result).catch(() => undefined)
+    } catch {
+      // Transport failures are intentionally ignored.
+    }
+  }
+
+  const fail = (): void => {
+    if (state !== 'loading') return
+    state = 'failed'
+    tracker = undefined
+    discardQueue()
+  }
+
+  try {
+    loadScript({
+      src: scriptUrl,
+      attributes: {
+        'data-website-id': websiteId,
+        'data-domains': domain,
+        'data-do-not-track': 'true',
+        'data-exclude-search': 'true',
+        'data-exclude-hash': 'true',
+        'data-performance': 'false',
+      },
+      onLoad: () => {
+        if (state !== 'loading') return
+        try {
+          tracker = getTracker()
+        } catch {
+          fail()
+          return
+        }
+        if (!tracker) {
+          fail()
+          return
+        }
+        state = 'ready'
+        queuedEvents.splice(0, queuedEvents.length).forEach(dispatch)
+      },
+      onError: fail,
+    })
+  } catch {
+    fail()
+  }
+
+  return {
+    track(name: TelemetryEventName, data: TelemetryEventData): void {
+      if (state === 'failed') return
+      const event = { name, data }
+      if (state === 'ready') {
+        dispatch(event)
+        return
+      }
+      if (queuedEvents.length < MAX_BUFFERED_EVENTS) {
+        queuedEvents.push(event)
+      }
+    },
+  }
+}
+
+export class MemoryTelemetryAdapter implements TelemetryAdapter {
+  readonly events: TelemetryEvent[] = []
+
+  track(name: TelemetryEventName, data: TelemetryEventData): void {
+    this.events.push({ name, data })
+  }
+}
+
+export function createGameTelemetry({
+  adapter,
+  now = () => performance.now(),
+  getViewportWidth = () => window.innerWidth,
+}: GameTelemetryOptions): GameTelemetry {
+  let appOpened = false
+  let activeGame: { readonly playerCount: number; readonly startedAt: number } | undefined
+  let lastCompletedGame: Record<string, string> | undefined
+
+  const getDeviceType = (): DeviceType => (getViewportWidth() <= 768 ? 'mobile' : 'desktop')
+
+  const commonData = (): Record<string, unknown> => ({
+    app_version: APP_VERSION,
+    mode_id: MODE_ID,
+    device_type: getDeviceType(),
+  })
+
+  const track = (name: TelemetryEventName, candidate: Record<string, unknown>): void => {
+    try {
+      const data = sanitizeEventData(name, candidate)
+      const result = adapter.track(name, data)
+      void Promise.resolve(result).catch(() => undefined)
+    } catch {
+      // Telemetry must never interrupt game play.
+    }
+  }
+
+  const safely = (action: () => void): void => {
+    try {
+      action()
+    } catch {
+      // All telemetry failures are fail-open for the game.
+    }
+  }
+
+  return {
+    openApp(): void {
+      safely(() => {
+        if (appOpened) return
+        appOpened = true
+        track('app_open', commonData())
+      })
+    },
+    startSetup(playerCount: number): void {
+      safely(() => {
+        track('setup_started', {
+          ...commonData(),
+          player_count_bucket: bucketPlayerCount(playerCount),
+        })
+      })
+    },
+    startGame(playerCount: number): void {
+      safely(() => {
+        if (activeGame) return
+        lastCompletedGame = undefined
+        activeGame = { playerCount, startedAt: now() }
+        track('game_started', {
+          ...commonData(),
+          player_count_bucket: bucketPlayerCount(playerCount),
+        })
+      })
+    },
+    finishGame(outcome: GameEndOutcome, turnCount: number): void {
+      safely(() => {
+        if (!activeGame) return
+
+        const summary = {
+          player_count_bucket: bucketPlayerCount(activeGame.playerCount),
+          duration_bucket: bucketDuration(Math.max(0, now() - activeGame.startedAt)),
+          turn_count_bucket: bucketTurnCount(turnCount),
+          end_type: outcome,
+        }
+        activeGame = undefined
+        lastCompletedGame = outcome === 'completed' ? summary : undefined
+
+        track(outcome === 'completed' ? 'game_completed' : 'game_ended', {
+          ...commonData(),
+          ...summary,
+        })
+      })
+    },
+    playAgain(): void {
+      safely(() => {
+        if (!lastCompletedGame) return
+        const summary = lastCompletedGame
+        lastCompletedGame = undefined
+        track('play_again', {
+          ...commonData(),
+          ...summary,
+        })
+      })
+    },
+  }
+}
+
+const disabledAdapter: TelemetryAdapter = {
+  track: () => undefined,
+}
+
+function createDefaultAdapter(): TelemetryAdapter {
+  if (import.meta.env.DEV && typeof window !== 'undefined') {
+    return window.__GAME_TELEMETRY_TEST_ADAPTER__ ?? disabledAdapter
+  }
+  if (!import.meta.env.PROD) return disabledAdapter
+
+  const websiteId = import.meta.env.VITE_UMAMI_WEBSITE_ID?.trim()
+  const scriptUrl = import.meta.env.VITE_UMAMI_SCRIPT_URL?.trim()
+  if (!websiteId || !scriptUrl) return disabledAdapter
+
+  return createUmamiAdapter({ websiteId, scriptUrl })
+}
+
+export const gameTelemetry: GameTelemetry = createGameTelemetry({
+  adapter: createDefaultAdapter(),
+})

--- a/src/tests/gameTelemetry.test.ts
+++ b/src/tests/gameTelemetry.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createGameTelemetry,
+  createUmamiAdapter,
+  MemoryTelemetryAdapter,
+  type TelemetryEvent,
+} from '../services/gameTelemetry'
+
+describe('gameTelemetry', () => {
+  it('emits app_open once with only the common anonymous fields', () => {
+    const adapter = new MemoryTelemetryAdapter()
+    const telemetry = createGameTelemetry({
+      adapter,
+      getViewportWidth: () => 768,
+    })
+
+    telemetry.openApp()
+    telemetry.openApp()
+
+    expect(adapter.events).toEqual<TelemetryEvent[]>([
+      {
+        name: 'app_open',
+        data: {
+          app_version: '1.7.4',
+          mode_id: 'classic',
+          device_type: 'mobile',
+        },
+      },
+    ])
+  })
+
+  it.each([
+    [1, '1'],
+    [2, '2'],
+    [3, '3_4'],
+    [4, '3_4'],
+    [5, '5_plus'],
+    [12, '5_plus'],
+  ])('buckets setup player count %i as %s without sending the raw count', (playerCount, bucket) => {
+    const adapter = new MemoryTelemetryAdapter()
+    const telemetry = createGameTelemetry({
+      adapter,
+      getViewportWidth: () => 769,
+    })
+
+    telemetry.startSetup(playerCount)
+
+    expect(adapter.events).toEqual([
+      {
+        name: 'setup_started',
+        data: {
+          app_version: '1.7.4',
+          mode_id: 'classic',
+          device_type: 'desktop',
+          player_count_bucket: bucket,
+        },
+      },
+    ])
+    expect(adapter.events[0].data).not.toHaveProperty('player_count')
+  })
+
+  it('records setup before one game start and suppresses duplicate starts', () => {
+    const adapter = new MemoryTelemetryAdapter()
+    const telemetry = createGameTelemetry({ adapter, getViewportWidth: () => 1280 })
+
+    telemetry.startSetup(4)
+    telemetry.startGame(4)
+    telemetry.startGame(4)
+
+    expect(adapter.events.map(event => event.name)).toEqual(['setup_started', 'game_started'])
+    expect(adapter.events[1].data).toMatchObject({
+      player_count_bucket: '3_4',
+    })
+  })
+
+  it.each([
+    [0, 1, 'lt_10m', '1_10'],
+    [599_999, 10, 'lt_10m', '1_10'],
+    [600_000, 11, '10_20m', '11_20'],
+    [1_199_999, 20, '10_20m', '11_20'],
+    [1_200_000, 21, '20_40m', '21_40'],
+    [2_399_999, 40, '20_40m', '21_40'],
+    [2_400_000, 41, '40m_plus', '41_plus'],
+  ])(
+    'buckets a completed game at %i ms and %i turns as %s / %s',
+    (elapsedMs, turns, durationBucket, turnBucket) => {
+      const adapter = new MemoryTelemetryAdapter()
+      let currentTime = 0
+      const telemetry = createGameTelemetry({
+        adapter,
+        now: () => currentTime,
+        getViewportWidth: () => 1280,
+      })
+
+      telemetry.startGame(2)
+      currentTime = elapsedMs
+      telemetry.finishGame('completed', turns)
+
+      expect(adapter.events[1]).toEqual({
+        name: 'game_completed',
+        data: {
+          app_version: '1.7.4',
+          mode_id: 'classic',
+          device_type: 'desktop',
+          player_count_bucket: '2',
+          duration_bucket: durationBucket,
+          turn_count_bucket: turnBucket,
+          end_type: 'completed',
+        },
+      })
+      expect(adapter.events[1].data).not.toHaveProperty('duration_ms')
+      expect(adapter.events[1].data).not.toHaveProperty('turn_count')
+    }
+  )
+
+  it.each(['user_ended', 'config_import'] as const)('records %s as game_ended once', outcome => {
+    const adapter = new MemoryTelemetryAdapter()
+    const telemetry = createGameTelemetry({
+      adapter,
+      now: () => 60_000,
+      getViewportWidth: () => 1280,
+    })
+
+    telemetry.startGame(3)
+    telemetry.finishGame(outcome, 8)
+    telemetry.finishGame('completed', 99)
+
+    expect(adapter.events.map(event => event.name)).toEqual(['game_started', 'game_ended'])
+    expect(adapter.events[1].data.end_type).toBe(outcome)
+  })
+
+  it('reuses the completed-game summary for play_again and emits it only once', () => {
+    const adapter = new MemoryTelemetryAdapter()
+    let currentTime = 100
+    const telemetry = createGameTelemetry({
+      adapter,
+      now: () => currentTime,
+      getViewportWidth: () => 390,
+    })
+
+    telemetry.playAgain()
+    telemetry.startGame(3)
+    currentTime += 1_300_000
+    telemetry.finishGame('completed', 22)
+    telemetry.playAgain()
+    telemetry.playAgain()
+
+    expect(adapter.events.map(event => event.name)).toEqual([
+      'game_started',
+      'game_completed',
+      'play_again',
+    ])
+    expect(adapter.events[2]).toEqual({
+      name: 'play_again',
+      data: {
+        app_version: '1.7.4',
+        mode_id: 'classic',
+        device_type: 'mobile',
+        player_count_bucket: '3_4',
+        duration_bucket: '20_40m',
+        turn_count_bucket: '21_40',
+        end_type: 'completed',
+      },
+    })
+  })
+
+  it('swallows both synchronous throws and asynchronous rejections from the adapter', async () => {
+    let callCount = 0
+    const telemetry = createGameTelemetry({
+      adapter: {
+        track: () => {
+          callCount += 1
+          if (callCount === 1) throw new Error('sync transport failure')
+          return Promise.reject(new Error('async transport failure'))
+        },
+      },
+      getViewportWidth: () => 1280,
+    })
+
+    expect(() => telemetry.openApp()).not.toThrow()
+    expect(() => telemetry.startSetup(2)).not.toThrow()
+    await Promise.resolve()
+
+    expect(callCount).toBe(2)
+  })
+
+  it('keeps every public method non-throwing when clock or viewport access fails', () => {
+    let clockReads = 0
+    const telemetry = createGameTelemetry({
+      adapter: new MemoryTelemetryAdapter(),
+      now: () => {
+        clockReads += 1
+        if (clockReads > 1) throw new Error('clock unavailable')
+        return 0
+      },
+      getViewportWidth: () => {
+        throw new Error('viewport unavailable')
+      },
+    })
+
+    expect(() => telemetry.openApp()).not.toThrow()
+    expect(() => telemetry.startSetup(2)).not.toThrow()
+    expect(() => telemetry.startGame(2)).not.toThrow()
+    expect(() => telemetry.finishGame('completed', 1)).not.toThrow()
+    expect(() => telemetry.playAgain()).not.toThrow()
+  })
+
+  it('buffers at most 20 events until the Umami script loads and then flushes in order', () => {
+    const tracked: string[] = []
+    let completeLoad: () => void = () => undefined
+    const adapter = createUmamiAdapter({
+      websiteId: '123e4567-e89b-12d3-a456-426614174000',
+      scriptUrl: 'https://cloud.umami.is/script.js',
+      loadScript: options => {
+        expect(options.attributes).toEqual({
+          'data-website-id': '123e4567-e89b-12d3-a456-426614174000',
+          'data-domains': 'atang-sp.github.io',
+          'data-do-not-track': 'true',
+          'data-exclude-search': 'true',
+          'data-exclude-hash': 'true',
+          'data-performance': 'false',
+        })
+        completeLoad = options.onLoad
+      },
+      getTracker: () => ({
+        track: (_name, data) => {
+          tracked.push(data.sequence)
+        },
+      }),
+    })
+
+    for (let sequence = 0; sequence < 25; sequence += 1) {
+      adapter.track('app_open', { sequence: String(sequence) })
+    }
+    completeLoad()
+
+    expect(tracked).toEqual(Array.from({ length: 20 }, (_, index) => String(index)))
+  })
+
+  it('drops queued and future events after the Umami script fails to load', () => {
+    const tracked: string[] = []
+    let failLoad: () => void = () => undefined
+    let completeLoad: () => void = () => undefined
+    const adapter = createUmamiAdapter({
+      websiteId: '123e4567-e89b-12d3-a456-426614174000',
+      scriptUrl: 'https://cloud.umami.is/script.js',
+      loadScript: options => {
+        failLoad = options.onError
+        completeLoad = options.onLoad
+      },
+      getTracker: () => ({
+        track: name => {
+          tracked.push(name)
+        },
+      }),
+    })
+
+    adapter.track('app_open', {})
+    failLoad()
+    adapter.track('setup_started', {})
+    completeLoad()
+
+    expect(tracked).toEqual([])
+  })
+})

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,15 @@
 /// <reference types="vite/client" />
 /* eslint-disable @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any */
 
+interface ImportMetaEnv {
+  readonly VITE_UMAMI_WEBSITE_ID?: string
+  readonly VITE_UMAMI_SCRIPT_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
   const component: DefineComponent<{}, {}, any>

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -1,8 +1,34 @@
 import { expect, test } from '@playwright/test'
 import type { Page } from '@playwright/test'
 
+interface BrowserTelemetryEvent {
+  name: string
+  data: Record<string, string>
+}
+
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
+    const telemetryWindow = window as typeof window & {
+      __GAME_TELEMETRY_EVENTS__: BrowserTelemetryEvent[]
+      __GAME_TELEMETRY_FAILURE__: 'none' | 'throw' | 'reject'
+      __GAME_TELEMETRY_TEST_ADAPTER__: {
+        track: (name: string, data: Record<string, string>) => void | Promise<void>
+      }
+    }
+    telemetryWindow.__GAME_TELEMETRY_EVENTS__ = []
+    telemetryWindow.__GAME_TELEMETRY_FAILURE__ = 'none'
+    telemetryWindow.__GAME_TELEMETRY_TEST_ADAPTER__ = {
+      track: (name, data) => {
+        if (telemetryWindow.__GAME_TELEMETRY_FAILURE__ === 'throw') {
+          throw new Error('telemetry transport failed synchronously')
+        }
+        if (telemetryWindow.__GAME_TELEMETRY_FAILURE__ === 'reject') {
+          return Promise.reject(new Error('telemetry transport failed asynchronously'))
+        }
+        telemetryWindow.__GAME_TELEMETRY_EVENTS__.push({ name, data })
+      },
+    }
+
     localStorage.clear()
     localStorage.setItem('autoGuideEnabled', 'false')
     localStorage.setItem(
@@ -26,6 +52,163 @@ async function startDefaultGame(page: Page) {
   await page.getByRole('button', { name: /开始游戏/ }).click()
   await expect(page.locator('.game-board')).toBeVisible()
 }
+
+async function getTelemetryEvents(page: Page): Promise<BrowserTelemetryEvent[]> {
+  return page.evaluate(() => {
+    return (
+      window as typeof window & {
+        __GAME_TELEMETRY_EVENTS__: BrowserTelemetryEvent[]
+      }
+    ).__GAME_TELEMETRY_EVENTS__
+  })
+}
+
+async function completeGameForTelemetry(page: Page) {
+  await page.evaluate(() => {
+    const debugWindow = window as typeof window & {
+      gameState: {
+        gameStatus: string
+        winner: unknown
+        players: unknown[]
+      }
+      gameFinished: { value: boolean }
+    }
+    debugWindow.gameState.winner = debugWindow.gameState.players[0]
+    debugWindow.gameState.gameStatus = 'finished'
+    debugWindow.gameFinished.value = true
+  })
+}
+
+test('tracks the anonymous completed-game lifecycle and play again in order', async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await page.goto('/flying-chess/')
+  await page.locator('.name-input').first().fill('机密玩家姓名')
+  await page.locator('.start-btn').click()
+  await page.locator('.page-actions .btn-primary').click()
+  await page.locator('.page-actions .btn-primary').click()
+  await page.getByRole('button', { name: /生成惩罚组合/ }).click()
+  await page.getByRole('button', { name: /开始游戏/ }).click()
+  await completeGameForTelemetry(page)
+  await page.locator('.header-actions').getByRole('button', { name: '再来一局' }).click()
+
+  await expect(page.getByRole('heading', { name: '游戏设置' })).toBeVisible()
+  await expect
+    .poll(async () => (await getTelemetryEvents(page)).map(event => event.name))
+    .toEqual([
+      'app_open',
+      'setup_started',
+      'game_started',
+      'game_completed',
+      'play_again',
+      'setup_started',
+    ])
+
+  const events = await getTelemetryEvents(page)
+  const serializedEvents = JSON.stringify(events)
+  const eventDataKeys = events.flatMap(event => Object.keys(event.data))
+  expect(serializedEvents).not.toContain('机密玩家姓名')
+  expect(eventDataKeys).not.toContain('player_count')
+  expect(eventDataKeys).not.toContain('turn_count')
+  expect(eventDataKeys).not.toContain('duration_ms')
+})
+
+test('tracks ending a paused game as user_ended', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await startDefaultGame(page)
+  await page.getByRole('button', { name: '暂停本局' }).click()
+  await page.getByRole('button', { name: '结束本局' }).click()
+
+  await expect(page.getByRole('heading', { name: '游戏设置' })).toBeVisible()
+  await expect
+    .poll(async () => (await getTelemetryEvents(page)).find(event => event.name === 'game_ended'))
+    .toBeTruthy()
+  expect(
+    (await getTelemetryEvents(page)).find(event => event.name === 'game_ended')?.data.end_type
+  ).toBe('user_ended')
+})
+
+test('tracks a successful in-game configuration import as config_import', async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+
+  await startDefaultGame(page)
+  await page.locator('.guide-controls .export-btn').click()
+  await page.getByRole('button', { name: '导入', exact: true }).click()
+  await page.locator('.json-textarea').fill(
+    JSON.stringify({
+      version: '1.0.0',
+      exportedAt: '2026-07-28T00:00:00.000Z',
+      gameTitle: '机密配置内容',
+      data: {
+        playerSettings: {
+          playerCount: 2,
+          playerNames: ['导入姓名甲', '导入姓名乙'],
+        },
+      },
+    })
+  )
+  await page.locator('.import-text-btn').click()
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as typeof window & { gameStarted: { value: boolean } }).gameStarted.value
+      )
+    )
+    .toBe(false)
+  await expect
+    .poll(
+      async () =>
+        (await getTelemetryEvents(page)).find(event => event.name === 'game_ended')?.data.end_type
+    )
+    .toBe('config_import')
+  const serializedEvents = JSON.stringify(await getTelemetryEvents(page))
+  expect(serializedEvents).not.toContain('导入姓名甲')
+  expect(serializedEvents).not.toContain('机密配置内容')
+})
+
+test('telemetry transport failures do not block setup, play, dice, or completion', async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chrome')
+  const pageErrors: string[] = []
+  page.on('pageerror', error => pageErrors.push(error.message))
+
+  await page.goto('/flying-chess/')
+  await page.evaluate(() => {
+    const telemetryWindow = window as typeof window & {
+      __GAME_TELEMETRY_FAILURE__: 'throw'
+    }
+    telemetryWindow.__GAME_TELEMETRY_FAILURE__ = 'throw'
+  })
+  await page.locator('.start-btn').click()
+  await expect(page.getByRole('heading', { name: '游戏设置' })).toBeVisible()
+
+  await page.evaluate(() => {
+    const telemetryWindow = window as typeof window & {
+      __GAME_TELEMETRY_FAILURE__: 'reject'
+    }
+    telemetryWindow.__GAME_TELEMETRY_FAILURE__ = 'reject'
+  })
+  await page.locator('.page-actions .btn-primary').click()
+  await page.locator('.page-actions .btn-primary').click()
+  await page.getByRole('button', { name: /生成惩罚组合/ }).click()
+  await page.getByRole('button', { name: /开始游戏/ }).click()
+  await expect(page.getByRole('button', { name: '投掷骰子' })).toBeEnabled()
+  await page.getByRole('button', { name: '投掷骰子' }).click({ force: true })
+  await expect(page.locator('.game-board')).toBeVisible()
+
+  await completeGameForTelemetry(page)
+  await expect(
+    page.locator('.header-actions').getByRole('button', { name: '再来一局' })
+  ).toBeVisible()
+  expect(pageErrors).toEqual([])
+})
 
 test('desktop app fills the viewport width', async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== 'desktop-chrome')


### PR DESCRIPTION
## 变更

- 新增 `gameTelemetry` 深模块，统一 Umami 动态加载、匿名事件白名单、分桶、单调时钟、生命周期去重与失败吞并
- 接入 `app_open`、配置开始、真实开局、完局、用户结束、配置导入结束和再来一局流程
- 首页增加无 Cookie 匿名统计说明，并修正 README 中不存在的 Supabase/本地统计描述
- 将根版本同步到 `1.7.4`，在标签部署前校验并注入 Umami GitHub Actions 变量
- 新增单元和 Playwright fake-adapter 覆盖，不新增依赖

## 影响

本地开发默认不加载统计。生产环境只发送宽分桶后的匿名属性，不上传玩家姓名、惩罚内容、导入配置、原始计数或标识符；不使用持久化队列、重试、录屏、热力图或 identify。

## 验证

- `npm test`：98 passed
- `npm run type-check`：passed
- `npm run lint:check`：0 errors，保留 8 条既有 warnings
- `npm run build`：passed
- `npm run test:e2e`：21 passed，21 skipped
- Standards / Spec 双轴审查：0 findings
