### PR TITLE
feat: v1.9.0 升温局内容迭代（破冰 + 三幕绑定）

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@
   import {
     applyTurnConsequence,
     consumePendingSkippedTurn,
+    createCompatiblePunishmentAction,
     finalizePunishmentCount,
     resolveRule,
     scaleResolvedPunishmentCount,
@@ -37,6 +38,8 @@
     TrapAction,
     ResolvedPunishmentAction,
     ResolvedRuleResult,
+    PartyScenePreset,
+    PunishmentConstraints,
   } from './types/game'
   import IntroPage from './components/IntroPage.vue'
   import PartyReactionOverlay from './components/PartyReactionOverlay.vue'
@@ -55,6 +58,9 @@
   import EffectDisplay from './components/EffectDisplay.vue'
   import TakeoffPunishmentDisplay from './components/TakeoffPunishmentDisplay.vue'
   import TrapDisplay from './components/TrapDisplay.vue'
+  import TrapChoiceDisplay from './components/TrapChoiceDisplay.vue'
+  import QADisplay from './components/QADisplay.vue'
+  import DareDisplay from './components/DareDisplay.vue'
   import VictoryScreen from './components/VictoryScreen.vue'
   import TakeoffReliefDisplay from './components/TakeoffReliefDisplay.vue'
   import BounceDisplay from './components/BounceDisplay.vue'
@@ -85,6 +91,8 @@
   import { type GameMode } from './config/modes'
   import {
     createPartyPunishmentChoices,
+    getActConstraints,
+    getActDoublePunishmentChance,
     getPartyTimeLimitLeaders,
     isPartyPunishmentChoiceEligible,
     type PartyPrediction,
@@ -260,8 +268,20 @@
 
   // 机关陷阱弹窗状态
   const showTrapDisplay = ref(false)
+  const showTrapChoiceDisplay = ref(false)
   const currentTrapPunishment = ref<PunishmentAction | null>(null)
   const currentTrapDescription = ref<string>('')
+  const currentTrapChoiceA = ref('')
+  const currentTrapChoiceB = ref('')
+  const currentTrapVariant = ref<string | undefined>()
+  const currentTrapRouletteTarget = ref<Player | null>(null)
+
+  // 升温局问答 / 指令格弹窗
+  const showQADisplay = ref(false)
+  const currentQAQuestion = ref('')
+  const showDareDisplay = ref(false)
+  const currentDareInstruction = ref('')
+  const selectedPartyScene = ref<PartyScenePreset | 'default'>('default')
 
   // 反弹效果弹窗状态
   const showBounceDisplay = ref(false)
@@ -433,6 +453,14 @@
 
     if (resolvedPunishment) {
       const partySessionSnapshot = partySession.value
+      const actConstraints =
+        isPartyGame.value && partySessionSnapshot
+          ? getActConstraints(partySessionSnapshot.act)
+          : undefined
+      const actAwarePunishment =
+        actConstraints !== undefined
+          ? createCompatiblePunishmentAction(gameState.punishmentConfig, undefined, actConstraints)
+          : resolvedPunishment
       const partyChoiceSource = currentPlayer.hasTakenOff ? 'board_punishment' : 'takeoff_failure'
       const partyChoiceCellType =
         resolvedCellEffect?.type === 'chain_punishment' ? 'chain_punishment' : 'punishment'
@@ -448,16 +476,20 @@
         isPartyPunishmentChoiceEligible({
           source: partyChoiceSource,
           cellType: partyChoiceCellType,
-          action: resolvedPunishment,
+          action: actAwarePunishment,
         })
       ) {
         try {
-          partyPunishmentChoices.value = createPartyPunishmentChoices(gameState.punishmentConfig)
+          partyPunishmentChoices.value = createPartyPunishmentChoices(
+            gameState.punishmentConfig,
+            undefined,
+            actConstraints
+          )
           pendingPartyLanding.value = {
             currentPlayer,
             fromPosition,
             newPosition,
-            punishment,
+            punishment: actAwarePunishment,
             cellEffect,
             diceValue,
           }
@@ -474,16 +506,16 @@
             actorIndex,
             players: gameState.players,
             punishmentConfig: gameState.punishmentConfig,
+            punishmentAction: actAwarePunishment,
             diceValue: diceValue ?? gameState.diceValue ?? undefined,
-            punishmentAction: resolvedPunishment,
           })
         : resolveRule({
             source: 'board_punishment',
             actorIndex,
             players: gameState.players,
             punishmentConfig: gameState.punishmentConfig,
+            boardAction: actAwarePunishment,
             diceValue: diceValue ?? gameState.diceValue ?? undefined,
-            boardAction: resolvedPunishment,
           })
       const targetPlayer = gameState.players[punishmentResolution.targetPlayerIndex]
       const executorPlayer =
@@ -526,8 +558,50 @@
       })
       pendingRuleResolution.value = trapResolution
       currentTrapDescription.value = trapResolution.description || '未知机关'
-      showTrapDisplay.value = true
+      currentTrapVariant.value = trapResolution.trapVariant
+      currentTrapChoiceA.value = trapResolution.choiceA ?? ''
+      currentTrapChoiceB.value = trapResolution.choiceB ?? ''
+      currentTrapRouletteTarget.value =
+        trapResolution.rouletteTargetIndex !== undefined
+          ? (gameState.players[trapResolution.rouletteTargetIndex] ?? null)
+          : null
+
+      const usesChoiceOverlay =
+        trapResolution.trapVariant === 'choice' ||
+        trapResolution.trapVariant === 'roulette' ||
+        trapResolution.trapVariant === 'all_players'
+      if (usesChoiceOverlay) {
+        showTrapChoiceDisplay.value = true
+      } else {
+        showTrapDisplay.value = true
+      }
       audioService.play('trap')
+      return
+    }
+
+    if (resolvedCellEffect && resolvedCellEffect.type === 'qa') {
+      const qaResolution = resolveRule({
+        source: 'qa',
+        actorIndex: gameState.currentPlayerIndex,
+        players: gameState.players,
+        effect: resolvedCellEffect,
+      })
+      pendingRuleResolution.value = qaResolution
+      currentQAQuestion.value = qaResolution.question
+      showQADisplay.value = true
+      return
+    }
+
+    if (resolvedCellEffect && resolvedCellEffect.type === 'dare') {
+      const dareResolution = resolveRule({
+        source: 'dare',
+        actorIndex: gameState.currentPlayerIndex,
+        players: gameState.players,
+        effect: resolvedCellEffect,
+      })
+      pendingRuleResolution.value = dareResolution
+      currentDareInstruction.value = dareResolution.instruction
+      showDareDisplay.value = true
       return
     }
 
@@ -634,6 +708,9 @@
       !currentPunishment.value &&
       !showTakeoffPunishmentDisplay.value &&
       !showTrapDisplay.value &&
+      !showTrapChoiceDisplay.value &&
+      !showQADisplay.value &&
+      !showDareDisplay.value &&
       !showDoublePunishmentReveal.value &&
       !showChainPunishmentRoll.value &&
       !partyInteractionBlocking.value
@@ -645,6 +722,9 @@
       Boolean(currentPunishment.value) ||
       showTakeoffPunishmentDisplay.value ||
       showTrapDisplay.value ||
+      showTrapChoiceDisplay.value ||
+      showQADisplay.value ||
+      showDareDisplay.value ||
       showBounceDisplay.value ||
       showDoublePunishmentReveal.value ||
       showChainPunishmentRoll.value ||
@@ -760,7 +840,11 @@
   const checkGameStateHealth = () => {
     const blockingOverlays: BlockingOverlayState = {
       takeoffPunishment: showTakeoffPunishmentDisplay.value,
-      trap: showTrapDisplay.value,
+      trap:
+        showTrapDisplay.value ||
+        showTrapChoiceDisplay.value ||
+        showQADisplay.value ||
+        showDareDisplay.value,
       bounce: showBounceDisplay.value,
       takeoffRelief: showTakeoffReliefDisplay.value,
       doublePunishmentReveal: showDoublePunishmentReveal.value,
@@ -1083,21 +1167,46 @@
 
   const cloneConfig = <T,>(value: T): T => JSON.parse(JSON.stringify(value)) as T
 
-  const startPartyGame = (playerConfig: { count: number; names: string[]; mode: 'party' }) => {
+  const startPartyGame = (playerConfig: {
+    count: number
+    names: string[]
+    mode: 'party'
+    scenePreset?: PartyScenePreset | 'default'
+  }) => {
     classicConfigSnapshot.value = {
       boardConfig: cloneConfig(gameState.boardConfig),
       punishmentConfig: cloneConfig(gameState.punishmentConfig),
       trapConfig: cloneConfig(trapConfig.value),
     }
     activeMode.value = 'party'
+    selectedPartyScene.value = playerConfig.scenePreset ?? 'default'
     gameState.players = GameService.createCustomPlayers(playerConfig.count, playerConfig.names)
     gameState.currentPlayerIndex = 0
     gameState.diceValue = null
     gameState.winner = null
     gameState.pendingEffect = null
     gameState.punishmentConfig = GameService.createPunishmentConfig()
-    gameState.boardConfig = GameService.createBoardConfig()
-    trapConfig.value = GameService.trapsToArray(GAME_CONFIG.DEFAULT_TRAPS)
+
+    const sceneKey = selectedPartyScene.value
+    const scene = sceneKey !== 'default' ? GAME_CONFIG.PARTY_SCENE_PRESETS[sceneKey] : undefined
+    gameState.boardConfig = {
+      ...(scene?.boardConfig ?? GAME_CONFIG.PARTY_BOARD_CONFIG),
+    } as BoardConfig
+
+    const partyTraps =
+      sceneKey === 'intimate'
+        ? GAME_CONFIG.PARTY_TRAPS.filter(trap => trap.trapVariant !== 'all_players')
+        : [...GAME_CONFIG.PARTY_TRAPS]
+    trapConfig.value = partyTraps
+
+    const warmupConstraints: PunishmentConstraints = {
+      ...getActConstraints('warmup'),
+      ...(scene?.actConstraintsOverride?.warmup ?? {}),
+    }
+    if (warmupConstraints.doublePunishmentChance !== undefined) {
+      gameState.punishmentConfig.doublePunishmentChance = warmupConstraints.doublePunishmentChance
+    }
+
     gameState.board = GameService.createBoard(
       gameState.punishmentConfig,
       gameState.boardConfig,
@@ -1219,8 +1328,18 @@
 
     // 清除所有强制结算弹层，结束本局后不残留旧流程
     showTrapDisplay.value = false
+    showTrapChoiceDisplay.value = false
     currentTrapPunishment.value = null
     currentTrapDescription.value = ''
+    currentTrapChoiceA.value = ''
+    currentTrapChoiceB.value = ''
+    currentTrapVariant.value = undefined
+    currentTrapRouletteTarget.value = null
+    showQADisplay.value = false
+    currentQAQuestion.value = ''
+    showDareDisplay.value = false
+    currentDareInstruction.value = ''
+    selectedPartyScene.value = 'default'
     showDoublePunishmentReveal.value = false
     isDoublePunishment.value = false
     pendingDoublePunishment.value = null
@@ -1718,7 +1837,9 @@
 
       // 翻倍陷阱：如果当前不是翻倍状态，检查是否触发翻倍
       if (!isDoublePunishment.value && currentPunishment.value) {
-        const chance = gameState.punishmentConfig.doublePunishmentChance ?? 0
+        const chance = isPartyGame.value
+          ? getActDoublePunishmentChance(partySession.value?.act ?? 'warmup')
+          : (gameState.punishmentConfig.doublePunishmentChance ?? 0)
         if (chance > 0 && SecureRandom.randomInt(1, 100) <= chance) {
           pendingDoublePunishment.value = { ...currentPunishment.value }
           currentPunishment.value = null
@@ -1950,14 +2071,23 @@
   }
 
   // 修改IntroPage组件的调用，使其能够接收玩家配置信息并传递给startGame方法
-  const handleIntroStart = (playerConfig: { count: number; names: string[]; mode: GameMode }) => {
+  const handleIntroStart = (playerConfig: {
+    count: number
+    names: string[]
+    mode: GameMode
+    scenePreset?: PartyScenePreset | 'default'
+  }) => {
     selectedMode.value = playerConfig.mode
     saveGameMode(playerConfig.mode)
     gameTelemetry.setMode(playerConfig.mode)
     gameTelemetry.startSetup(playerConfig.count)
 
     if (playerConfig.mode === 'party') {
-      startPartyGame({ ...playerConfig, mode: 'party' })
+      startPartyGame({
+        ...playerConfig,
+        mode: 'party',
+        scenePreset: playerConfig.scenePreset ?? 'default',
+      })
       return
     }
 
@@ -2006,22 +2136,80 @@
       }
 
       showTrapDisplay.value = false
+      showTrapChoiceDisplay.value = false
       currentTrapPunishment.value = null
       currentTrapDescription.value = ''
+      currentTrapChoiceA.value = ''
+      currentTrapChoiceB.value = ''
+      currentTrapVariant.value = undefined
+      currentTrapRouletteTarget.value = null
       pendingRuleResolution.value = null
       gameState.gameStatus = 'waiting'
 
-      // 继续游戏流程
       await continueAfterMove()
     } catch (error) {
       console.error('确认机关陷阱时发生错误:', error)
-      // 确保在发生错误时重置游戏状态
       gameState.gameStatus = 'waiting'
       showTrapDisplay.value = false
+      showTrapChoiceDisplay.value = false
       currentTrapPunishment.value = null
       currentTrapDescription.value = ''
       pendingRuleResolution.value = null
     }
+  }
+
+  const confirmTrapChoice = async (_choice: 'A' | 'B') => {
+    await confirmTrap()
+  }
+
+  const confirmQAAnswer = async () => {
+    showQADisplay.value = false
+    currentQAQuestion.value = ''
+    pendingRuleResolution.value = null
+    gameState.gameStatus = 'waiting'
+    await continueAfterMove()
+  }
+
+  const confirmQARefuse = async () => {
+    showQADisplay.value = false
+    currentQAQuestion.value = ''
+    pendingRuleResolution.value = null
+
+    const actConstraints = partySession.value
+      ? getActConstraints(partySession.value.act)
+      : undefined
+    const punishment = createCompatiblePunishmentAction(
+      gameState.punishmentConfig,
+      undefined,
+      actConstraints
+    )
+    const punishmentResolution = resolveRule({
+      source: 'board_punishment',
+      actorIndex: gameState.currentPlayerIndex,
+      players: gameState.players,
+      punishmentConfig: gameState.punishmentConfig,
+      boardAction: punishment,
+    })
+    const targetPlayer = gameState.players[punishmentResolution.targetPlayerIndex]
+    const executorPlayer =
+      punishmentResolution.executorIndex === undefined
+        ? null
+        : (gameState.players[punishmentResolution.executorIndex] ?? null)
+    pendingRuleResolution.value = punishmentResolution
+    currentPunishment.value = toMutablePunishmentAction(punishmentResolution.action)
+    currentPunishmentTarget.value = targetPlayer
+    currentPunishmentExecutor.value = executorPlayer
+    mercyRequested.value = false
+    audioService.play('punishment')
+    gameState.gameStatus = 'configuring'
+  }
+
+  const confirmDare = async () => {
+    showDareDisplay.value = false
+    currentDareInstruction.value = ''
+    pendingRuleResolution.value = null
+    gameState.gameStatus = 'waiting'
+    await continueAfterMove()
   }
 
   // 确认反弹效果
@@ -2073,7 +2261,12 @@
 
     if (completedMode === 'party') {
       await nextTick()
-      startPartyGame({ count: playerCount, names: playerNames, mode: 'party' })
+      startPartyGame({
+        count: playerCount,
+        names: playerNames,
+        mode: 'party',
+        scenePreset: selectedPartyScene.value,
+      })
       return
     }
 
@@ -2917,6 +3110,33 @@
       :show="showTrapDisplay"
       :trap-description="currentTrapDescription"
       @confirm="confirmTrap"
+    />
+
+    <TrapChoiceDisplay
+      :show="showTrapChoiceDisplay"
+      :description="currentTrapDescription"
+      :choice-a="currentTrapChoiceA"
+      :choice-b="currentTrapChoiceB"
+      :player="gameState.players[gameState.currentPlayerIndex]"
+      :roulette-target="currentTrapRouletteTarget"
+      :trap-variant="currentTrapVariant"
+      @choose="confirmTrapChoice"
+      @confirm="confirmTrap"
+    />
+
+    <QADisplay
+      :show="showQADisplay"
+      :question="currentQAQuestion"
+      :player="gameState.players[gameState.currentPlayerIndex]"
+      @answer="confirmQAAnswer"
+      @refuse="confirmQARefuse"
+    />
+
+    <DareDisplay
+      :show="showDareDisplay"
+      :instruction="currentDareInstruction"
+      :player="gameState.players[gameState.currentPlayerIndex]"
+      @confirm="confirmDare"
     />
 
     <!-- 反弹效果弹窗 -->

--- a/src/components/DareDisplay.vue
+++ b/src/components/DareDisplay.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+  import { Flame, Check } from '@lucide/vue'
+  import type { Player } from '../types/game'
+
+  interface Props {
+    show: boolean
+    instruction: string
+    player?: Player | null
+  }
+
+  interface Emits {
+    (e: 'confirm'): void
+  }
+
+  defineProps<Props>()
+  const emit = defineEmits<Emits>()
+</script>
+
+<template>
+  <div v-if="show" class="modal-overlay dare-overlay" @click.stop>
+    <div class="dare-modal" @click.stop>
+      <div class="dare-header">
+        <div class="dare-icon">
+          <Flame :size="48" />
+        </div>
+        <h2 class="dare-title">执行指令</h2>
+        <p v-if="player" class="dare-player">
+          <span class="player-dot" :style="{ backgroundColor: player.color }"></span>
+          {{ player.name }}，请执行：
+        </p>
+      </div>
+
+      <div class="dare-content">
+        <div class="dare-instruction">
+          <p>{{ instruction }}</p>
+        </div>
+      </div>
+
+      <div class="dare-actions">
+        <button class="btn dare-confirm-btn" @click="emit('confirm')">
+          <Check :size="18" />
+          <span>已完成</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .dare-overlay {
+    background: rgba(0, 0, 0, 0.85);
+  }
+
+  .dare-modal {
+    background: rgba(20, 15, 5, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid rgba(245, 158, 11, 0.4);
+    border-radius: var(--radius-xl);
+    padding: 30px;
+    max-width: 500px;
+    width: 90%;
+    text-align: center;
+    box-shadow:
+      var(--glass-shadow-lg),
+      var(--glow-md) rgba(245, 158, 11, 0.2);
+    animation: slideIn var(--transition-normal) ease-out;
+  }
+
+  .dare-header {
+    margin-bottom: 20px;
+  }
+
+  .dare-icon {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 10px;
+    color: var(--color-dare, #f59e0b);
+    animation: pulse 2s infinite;
+  }
+
+  .dare-title {
+    color: var(--color-dare, #f59e0b);
+    font-size: 1.8em;
+    margin: 0 0 8px 0;
+    text-shadow: var(--glow-sm) rgba(245, 158, 11, 0.5);
+    font-weight: bold;
+  }
+
+  .dare-player {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    color: var(--text-secondary);
+    margin: 0;
+    font-size: 1.1rem;
+  }
+
+  .player-dot {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.25);
+    flex-shrink: 0;
+  }
+
+  .dare-content {
+    margin-bottom: 25px;
+  }
+
+  .dare-instruction {
+    background: rgba(245, 158, 11, 0.1);
+    border: 1px solid rgba(245, 158, 11, 0.3);
+    border-radius: var(--radius-md);
+    padding: 20px;
+  }
+
+  .dare-instruction p {
+    color: var(--text-primary);
+    font-size: 1.3em;
+    font-weight: bold;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  .dare-actions {
+    display: flex;
+    justify-content: center;
+  }
+
+  .dare-confirm-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: linear-gradient(135deg, #b45309, #f59e0b);
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-full);
+    padding: 12px 30px;
+    font-size: 1.1em;
+    font-weight: bold;
+    box-shadow: 0 4px 15px rgba(245, 158, 11, 0.4);
+  }
+
+  .dare-confirm-btn:not(:disabled):hover {
+    background: linear-gradient(135deg, #f59e0b, #fbbf24);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(245, 158, 11, 0.6);
+  }
+
+  @keyframes slideIn {
+    from {
+      transform: translateY(-50px) scale(0.9);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0) scale(1);
+      opacity: 1;
+    }
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      transform: scale(1);
+    }
+    50% {
+      transform: scale(1.1);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .dare-modal {
+      padding: 20px;
+      margin: 20px;
+    }
+
+    .dare-icon :deep(svg) {
+      width: 40px;
+      height: 40px;
+    }
+
+    .dare-title {
+      font-size: 1.5em;
+    }
+
+    .dare-instruction p {
+      font-size: 1.1em;
+    }
+  }
+</style>

--- a/src/components/EffectDisplay.vue
+++ b/src/components/EffectDisplay.vue
@@ -3,7 +3,16 @@
   import { Gift, ArrowLeft, RotateCcw, Moon, Sparkles } from '@lucide/vue'
 
   interface Effect {
-    type: 'move' | 'skip' | 'reverse' | 'restart' | 'rest' | 'bounce' | 'chain_punishment'
+    type:
+      | 'move'
+      | 'skip'
+      | 'reverse'
+      | 'restart'
+      | 'rest'
+      | 'bounce'
+      | 'chain_punishment'
+      | 'qa'
+      | 'dare'
     value: number
     description: string
   }

--- a/src/components/GameBoard.vue
+++ b/src/components/GameBoard.vue
@@ -3,9 +3,11 @@
   import type { Component } from 'vue'
   import {
     Circle,
+    Flame,
     Gift,
     Link,
     LocateFixed,
+    MessageCircleQuestion,
     Moon,
     Rocket,
     RotateCcw,
@@ -52,8 +54,10 @@
 
   const iconComponents: Record<CellIconName, Component> = {
     Circle,
+    Flame,
     Gift,
     Link,
+    MessageCircleQuestion,
     Moon,
     Rocket,
     RotateCcw,
@@ -793,6 +797,32 @@
       #302a25 5px,
       #a54149 5px,
       #a54149 10px
+    );
+  }
+
+  .cell-qa {
+    --cell-accent: #3b82f6;
+    --cell-paper: #dce8f8;
+    --cell-ink: #1e3a5f;
+    --cell-pattern: repeating-linear-gradient(
+      90deg,
+      #3b6fb5 0,
+      #3b6fb5 6px,
+      #8fb4e0 6px,
+      #8fb4e0 8px
+    );
+  }
+
+  .cell-dare {
+    --cell-accent: #f59e0b;
+    --cell-paper: #f8ecd4;
+    --cell-ink: #5c3d0e;
+    --cell-pattern: repeating-linear-gradient(
+      135deg,
+      #d97706 0,
+      #d97706 5px,
+      #fbbf24 5px,
+      #fbbf24 10px
     );
   }
 

--- a/src/components/IntroPage.vue
+++ b/src/components/IntroPage.vue
@@ -22,11 +22,21 @@
   import { SecureRandom } from '../utils/secureRandom'
   import { devLog } from '../utils/logger'
   import VersionDisplay from './VersionDisplay.vue'
+  import PartySceneSelector from './PartySceneSelector.vue'
   import type { GameMode } from '../config/modes'
+  import type { PartyScenePreset } from '../types/game'
   import { PARTY_MIN_PLAYERS } from '../services/partyMode'
 
   interface Emits {
-    (e: 'start', playerConfig: { count: number; names: string[]; mode: GameMode }): void
+    (
+      e: 'start',
+      playerConfig: {
+        count: number
+        names: string[]
+        mode: GameMode
+        scenePreset?: PartyScenePreset | 'default'
+      }
+    ): void
     (e: 'mode-selected', mode: GameMode): void
   }
 
@@ -37,6 +47,7 @@
   const playerCount = ref(2)
   const playerNames = ref<string[]>(['玩家1', '玩家2'])
   const selectedMode = ref<GameMode>(props.initialMode)
+  const selectedScenePreset = ref<PartyScenePreset | 'default'>('default')
   const canStart = computed(
     () => selectedMode.value === 'classic' || playerCount.value >= PARTY_MIN_PLAYERS
   )
@@ -96,12 +107,17 @@
       count: playerCount.value,
       names: playerNames.value,
       mode: selectedMode.value,
+      scenePreset: selectedMode.value === 'party' ? selectedScenePreset.value : undefined,
     })
   }
 
   const selectMode = (mode: GameMode) => {
     selectedMode.value = mode
     emit('mode-selected', mode)
+  }
+
+  const selectScenePreset = (preset: PartyScenePreset | 'default') => {
+    selectedScenePreset.value = preset
   }
 
   // 监听玩家设置更新事件
@@ -328,6 +344,12 @@
             <span class="mode-card__badge mode-card__badge--party">party_v1</span>
           </button>
         </div>
+
+        <PartySceneSelector
+          v-if="selectedMode === 'party'"
+          :selected="selectedScenePreset"
+          @select="selectScenePreset"
+        />
       </section>
 
       <!-- 玩家设置区域 -->

--- a/src/components/PartySceneSelector.vue
+++ b/src/components/PartySceneSelector.vue
@@ -1,0 +1,217 @@
+<script setup lang="ts">
+  import { Snowflake, Flame, Heart, Users } from '@lucide/vue'
+  import { GAME_CONFIG } from '../config/gameConfig'
+  import type { PartyScenePreset } from '../types/game'
+
+  interface Props {
+    selected?: PartyScenePreset | 'default'
+  }
+
+  interface Emits {
+    (e: 'select', preset: PartyScenePreset | 'default'): void
+  }
+
+  withDefaults(defineProps<Props>(), {
+    selected: 'default',
+  })
+  const emit = defineEmits<Emits>()
+
+  const presets = GAME_CONFIG.PARTY_SCENE_PRESETS
+
+  const iconMap: Record<string, typeof Snowflake> = {
+    icebreaker: Snowflake,
+    hardcore: Flame,
+    intimate: Heart,
+    group_fun: Users,
+  }
+</script>
+
+<template>
+  <div class="scene-selector">
+    <h3 class="scene-title">选择场景</h3>
+    <p class="scene-subtitle">每个场景为升温局提供不同的内容组合和节奏</p>
+
+    <div class="scene-grid">
+      <button
+        class="scene-card scene-default"
+        :class="{ 'scene-card--selected': selected === 'default' }"
+        @click="emit('select', 'default')"
+      >
+        <div class="scene-card-icon">
+          <Flame :size="32" />
+        </div>
+        <div class="scene-card-body">
+          <h4>默认升温</h4>
+          <p>标准升温局配置</p>
+        </div>
+      </button>
+
+      <button
+        v-for="(config, key) in presets"
+        :key="key"
+        class="scene-card"
+        :class="[`scene-${key}`, { 'scene-card--selected': selected === key }]"
+        @click="emit('select', key as PartyScenePreset)"
+      >
+        <div class="scene-card-icon">
+          <component :is="iconMap[key as string] || Flame" :size="32" />
+        </div>
+        <div class="scene-card-body">
+          <h4>{{ config.name }}</h4>
+          <p>{{ config.description }}</p>
+        </div>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .scene-selector {
+    padding: 1rem 0;
+  }
+
+  .scene-title {
+    color: var(--text-primary);
+    font-size: 1.3rem;
+    margin: 0 0 0.5rem 0;
+    text-align: center;
+  }
+
+  .scene-subtitle {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    margin: 0 0 1.5rem 0;
+    text-align: center;
+  }
+
+  .scene-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+
+  .scene-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 16px 12px;
+    border-radius: var(--radius-md);
+    border: 2px solid rgba(255, 255, 255, 0.1);
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-align: center;
+    color: var(--text-primary);
+  }
+
+  .scene-card:hover {
+    transform: translateY(-2px);
+    border-color: rgba(255, 255, 255, 0.3);
+  }
+
+  .scene-card--selected {
+    border-color: rgba(255, 255, 255, 0.55);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .scene-card-icon {
+    opacity: 0.8;
+  }
+
+  .scene-card-body h4 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+  }
+
+  .scene-card-body p {
+    margin: 4px 0 0;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    line-height: 1.3;
+  }
+
+  .scene-default {
+    border-color: rgba(245, 158, 11, 0.3);
+  }
+
+  .scene-default:hover {
+    border-color: rgba(245, 158, 11, 0.6);
+    box-shadow: 0 4px 15px rgba(245, 158, 11, 0.2);
+  }
+
+  .scene-default .scene-card-icon {
+    color: #f59e0b;
+  }
+
+  .scene-icebreaker {
+    border-color: rgba(59, 130, 246, 0.3);
+  }
+
+  .scene-icebreaker:hover {
+    border-color: rgba(59, 130, 246, 0.6);
+    box-shadow: 0 4px 15px rgba(59, 130, 246, 0.2);
+  }
+
+  .scene-icebreaker .scene-card-icon {
+    color: #3b82f6;
+  }
+
+  .scene-hardcore {
+    border-color: rgba(220, 38, 38, 0.3);
+  }
+
+  .scene-hardcore:hover {
+    border-color: rgba(220, 38, 38, 0.6);
+    box-shadow: 0 4px 15px rgba(220, 38, 38, 0.2);
+  }
+
+  .scene-hardcore .scene-card-icon {
+    color: #dc2626;
+  }
+
+  .scene-intimate {
+    border-color: rgba(236, 72, 153, 0.3);
+  }
+
+  .scene-intimate:hover {
+    border-color: rgba(236, 72, 153, 0.6);
+    box-shadow: 0 4px 15px rgba(236, 72, 153, 0.2);
+  }
+
+  .scene-intimate .scene-card-icon {
+    color: #ec4899;
+  }
+
+  .scene-group_fun {
+    border-color: rgba(34, 197, 94, 0.3);
+  }
+
+  .scene-group_fun:hover {
+    border-color: rgba(34, 197, 94, 0.6);
+    box-shadow: 0 4px 15px rgba(34, 197, 94, 0.2);
+  }
+
+  .scene-group_fun .scene-card-icon {
+    color: #22c55e;
+  }
+
+  @media (max-width: 480px) {
+    .scene-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .scene-card {
+      flex-direction: row;
+      text-align: left;
+      padding: 14px;
+    }
+
+    .scene-card-body h4 {
+      font-size: 0.95rem;
+    }
+  }
+</style>

--- a/src/components/QADisplay.vue
+++ b/src/components/QADisplay.vue
@@ -1,0 +1,223 @@
+<script setup lang="ts">
+  import { MessageCircleQuestion, Check, Zap } from '@lucide/vue'
+  import type { Player } from '../types/game'
+
+  interface Props {
+    show: boolean
+    question: string
+    player?: Player | null
+  }
+
+  interface Emits {
+    (e: 'answer'): void
+    (e: 'refuse'): void
+  }
+
+  defineProps<Props>()
+  const emit = defineEmits<Emits>()
+</script>
+
+<template>
+  <div v-if="show" class="modal-overlay qa-overlay" @click.stop>
+    <div class="qa-modal" @click.stop>
+      <div class="qa-header">
+        <div class="qa-icon">
+          <MessageCircleQuestion :size="48" />
+        </div>
+        <h2 class="qa-title">问答时间</h2>
+        <p v-if="player" class="qa-player">
+          <span class="player-dot" :style="{ backgroundColor: player.color }"></span>
+          {{ player.name }}，请回答：
+        </p>
+      </div>
+
+      <div class="qa-content">
+        <div class="qa-question">
+          <p>{{ question }}</p>
+        </div>
+      </div>
+
+      <div class="qa-actions">
+        <button class="btn qa-answer-btn" @click="emit('answer')">
+          <Check :size="18" />
+          <span>已回答</span>
+        </button>
+        <button class="btn qa-refuse-btn" @click="emit('refuse')">
+          <Zap :size="18" />
+          <span>拒绝回答（接受惩罚）</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .qa-overlay {
+    background: rgba(0, 0, 0, 0.85);
+  }
+
+  .qa-modal {
+    background: rgba(10, 15, 30, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid rgba(59, 130, 246, 0.4);
+    border-radius: var(--radius-xl);
+    padding: 30px;
+    max-width: 500px;
+    width: 90%;
+    text-align: center;
+    box-shadow:
+      var(--glass-shadow-lg),
+      var(--glow-md) rgba(59, 130, 246, 0.2);
+    animation: slideIn var(--transition-normal) ease-out;
+  }
+
+  .qa-header {
+    margin-bottom: 20px;
+  }
+
+  .qa-icon {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 10px;
+    color: var(--color-qa, #3b82f6);
+    animation: pulse 2s infinite;
+  }
+
+  .qa-title {
+    color: var(--color-qa, #3b82f6);
+    font-size: 1.8em;
+    margin: 0 0 8px 0;
+    text-shadow: var(--glow-sm) rgba(59, 130, 246, 0.5);
+    font-weight: bold;
+  }
+
+  .qa-player {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    color: var(--text-secondary);
+    margin: 0;
+    font-size: 1.1rem;
+  }
+
+  .player-dot {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.25);
+    flex-shrink: 0;
+  }
+
+  .qa-content {
+    margin-bottom: 25px;
+  }
+
+  .qa-question {
+    background: rgba(59, 130, 246, 0.1);
+    border: 1px solid rgba(59, 130, 246, 0.3);
+    border-radius: var(--radius-md);
+    padding: 20px;
+  }
+
+  .qa-question p {
+    color: var(--text-primary);
+    font-size: 1.3em;
+    font-weight: bold;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  .qa-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+  }
+
+  .qa-answer-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: linear-gradient(135deg, #1d4ed8, #3b82f6);
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-full);
+    padding: 12px 30px;
+    font-size: 1.1em;
+    font-weight: bold;
+    box-shadow: 0 4px 15px rgba(59, 130, 246, 0.4);
+    width: 100%;
+    max-width: 300px;
+  }
+
+  .qa-answer-btn:not(:disabled):hover {
+    background: linear-gradient(135deg, #3b82f6, #60a5fa);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(59, 130, 246, 0.6);
+  }
+
+  .qa-refuse-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: linear-gradient(135deg, #7f1d1d, var(--color-punishment, #dc2626));
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-full);
+    padding: 10px 24px;
+    font-size: 0.95em;
+    font-weight: bold;
+    box-shadow: 0 4px 15px rgba(220, 38, 38, 0.3);
+    width: 100%;
+    max-width: 300px;
+  }
+
+  .qa-refuse-btn:not(:disabled):hover {
+    background: linear-gradient(135deg, var(--color-punishment, #dc2626), #ef4444);
+    transform: translateY(-2px);
+  }
+
+  @keyframes slideIn {
+    from {
+      transform: translateY(-50px) scale(0.9);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0) scale(1);
+      opacity: 1;
+    }
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      transform: scale(1);
+    }
+    50% {
+      transform: scale(1.1);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .qa-modal {
+      padding: 20px;
+      margin: 20px;
+    }
+
+    .qa-icon :deep(svg) {
+      width: 40px;
+      height: 40px;
+    }
+
+    .qa-title {
+      font-size: 1.5em;
+    }
+
+    .qa-question p {
+      font-size: 1.1em;
+    }
+  }
+</style>

--- a/src/components/TrapChoiceDisplay.vue
+++ b/src/components/TrapChoiceDisplay.vue
@@ -1,0 +1,289 @@
+<script setup lang="ts">
+  import { Skull } from '@lucide/vue'
+  import type { Player } from '../types/game'
+
+  interface Props {
+    show: boolean
+    description: string
+    choiceA: string
+    choiceB: string
+    player?: Player | null
+    rouletteTarget?: Player | null
+    trapVariant?: string
+  }
+
+  interface Emits {
+    (e: 'choose', choice: 'A' | 'B'): void
+    (e: 'confirm'): void
+  }
+
+  defineProps<Props>()
+  const emit = defineEmits<Emits>()
+</script>
+
+<template>
+  <div v-if="show" class="modal-overlay trap-choice-overlay" @click.stop>
+    <div class="trap-choice-modal" @click.stop>
+      <div class="trap-choice-header">
+        <div class="trap-choice-icon">
+          <Skull :size="48" />
+        </div>
+        <h2 class="trap-choice-title">
+          {{
+            trapVariant === 'roulette'
+              ? '命运轮盘！'
+              : trapVariant === 'all_players'
+                ? '全员机关！'
+                : '机关触发！'
+          }}
+        </h2>
+        <p v-if="player" class="trap-choice-player">
+          <span class="player-dot" :style="{ backgroundColor: player.color }"></span>
+          {{ player.name }}
+        </p>
+      </div>
+
+      <div class="trap-choice-content">
+        <p class="trap-choice-desc">{{ description }}</p>
+
+        <div v-if="rouletteTarget" class="roulette-target">
+          <p>命运选中了：</p>
+          <div class="target-info">
+            <span class="player-dot" :style="{ backgroundColor: rouletteTarget.color }"></span>
+            <strong>{{ rouletteTarget.name }}</strong>
+          </div>
+        </div>
+
+        <div v-if="choiceA && choiceB" class="choice-options">
+          <button class="choice-btn choice-a" @click="emit('choose', 'A')">
+            <span class="choice-label">A</span>
+            <span class="choice-text">{{ choiceA }}</span>
+          </button>
+          <span class="choice-or">或</span>
+          <button class="choice-btn choice-b" @click="emit('choose', 'B')">
+            <span class="choice-label">B</span>
+            <span class="choice-text">{{ choiceB }}</span>
+          </button>
+        </div>
+
+        <div v-else class="trap-confirm-section">
+          <button class="btn trap-confirm-btn" @click="emit('confirm')">确认执行</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .trap-choice-overlay {
+    background: rgba(0, 0, 0, 0.85);
+  }
+
+  .trap-choice-modal {
+    background: rgba(20, 10, 10, 0.95);
+    backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid rgba(220, 38, 38, 0.4);
+    border-radius: var(--radius-xl);
+    padding: 30px;
+    max-width: 500px;
+    width: 90%;
+    text-align: center;
+    box-shadow:
+      var(--glass-shadow-lg),
+      var(--glow-md) rgba(220, 38, 38, 0.2);
+    animation: slideIn var(--transition-normal) ease-out;
+  }
+
+  .trap-choice-header {
+    margin-bottom: 20px;
+  }
+
+  .trap-choice-icon {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 10px;
+    color: var(--color-trap);
+    animation: pulse 2s infinite;
+  }
+
+  .trap-choice-title {
+    color: var(--color-trap);
+    font-size: 1.8em;
+    margin: 0 0 8px 0;
+    text-shadow: var(--glow-sm) rgba(220, 38, 38, 0.5);
+    font-weight: bold;
+  }
+
+  .trap-choice-player {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    color: var(--text-secondary);
+    margin: 0;
+    font-size: 1.1rem;
+  }
+
+  .player-dot {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.25);
+    flex-shrink: 0;
+  }
+
+  .trap-choice-content {
+    margin-bottom: 10px;
+  }
+
+  .trap-choice-desc {
+    color: var(--text-secondary);
+    font-size: 1.1em;
+    margin: 0 0 20px 0;
+  }
+
+  .roulette-target {
+    background: rgba(220, 38, 38, 0.15);
+    border: 1px solid rgba(220, 38, 38, 0.4);
+    border-radius: var(--radius-md);
+    padding: 15px;
+    margin-bottom: 20px;
+  }
+
+  .roulette-target p {
+    color: var(--text-secondary);
+    margin: 0 0 8px 0;
+  }
+
+  .target-info {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    font-size: 1.3em;
+    color: var(--text-primary);
+  }
+
+  .choice-options {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+  }
+
+  .choice-or {
+    color: var(--text-muted);
+    font-size: 1.1em;
+    font-weight: bold;
+  }
+
+  .choice-btn {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 20px;
+    border-radius: var(--radius-md);
+    border: 2px solid rgba(255, 255, 255, 0.15);
+    font-size: 1.05em;
+    font-weight: bold;
+    color: white;
+    text-align: left;
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+
+  .choice-a {
+    background: linear-gradient(135deg, #7f1d1d, #991b1b);
+  }
+
+  .choice-a:hover {
+    background: linear-gradient(135deg, #991b1b, #b91c1c);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px rgba(220, 38, 38, 0.4);
+  }
+
+  .choice-b {
+    background: linear-gradient(135deg, #1e3a5f, #1e40af);
+  }
+
+  .choice-b:hover {
+    background: linear-gradient(135deg, #1e40af, #2563eb);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px rgba(37, 99, 235, 0.4);
+  }
+
+  .choice-label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.15);
+    font-size: 1.2em;
+    flex-shrink: 0;
+  }
+
+  .choice-text {
+    flex: 1;
+  }
+
+  .trap-confirm-section {
+    margin-top: 20px;
+  }
+
+  .trap-confirm-btn {
+    background: linear-gradient(135deg, #7f1d1d, var(--color-trap));
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-full);
+    padding: 12px 30px;
+    font-size: 1.1em;
+    font-weight: bold;
+    box-shadow: 0 4px 15px rgba(220, 38, 38, 0.4);
+  }
+
+  .trap-confirm-btn:not(:disabled):hover {
+    background: linear-gradient(135deg, var(--color-trap), #ef4444);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(220, 38, 38, 0.6);
+  }
+
+  @keyframes slideIn {
+    from {
+      transform: translateY(-50px) scale(0.9);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0) scale(1);
+      opacity: 1;
+    }
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      transform: scale(1);
+    }
+    50% {
+      transform: scale(1.1);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .trap-choice-modal {
+      padding: 20px;
+      margin: 20px;
+    }
+
+    .trap-choice-title {
+      font-size: 1.5em;
+    }
+
+    .choice-btn {
+      padding: 14px 16px;
+      font-size: 1em;
+    }
+  }
+</style>

--- a/src/config/gameConfig.ts
+++ b/src/config/gameConfig.ts
@@ -191,6 +191,203 @@ export const GAME_CONFIG = {
         '由上一个被惩罚的玩家使用任意工具惩罚屁股，必须自己请罚，大声说出"请xxx打我的屁股"',
     },
   },
+
+  // --- 升温局专属配置 ---
+
+  PARTY_BOARD_CONFIG: {
+    punishmentCells: 20,
+    chainPunishmentCells: 2,
+    bonusCells: 1,
+    reverseCells: 1,
+    restCells: 1,
+    restartCells: 2,
+    trapCells: 3,
+    totalCells: 40,
+    qaCells: 5,
+    dareCells: 3,
+  },
+
+  PARTY_ACT_CONSTRAINTS: {
+    warmup: { maxToolIntensity: 3, minStrikes: 5, maxStrikes: 15, doublePunishmentChance: 0 },
+    heating: { maxToolIntensity: 7, minStrikes: 10, maxStrikes: 25, doublePunishmentChance: 15 },
+    finale: { maxToolIntensity: 10, minStrikes: 15, maxStrikes: 30, doublePunishmentChance: 25 },
+  } as const,
+
+  PARTY_QA_QUESTIONS: {
+    warmup: [
+      '你的安全词是什么？',
+      '你觉得最疼的工具是什么？',
+      '你第一次接触 SP 是什么时候？',
+      '你被打的时候会叫出声吗？',
+      '你更怕疼还是更怕痒？',
+      '你能承受的最高强度工具是什么？',
+      '你有没有一个特别想尝试的惩罚姿势？',
+      '你觉得被打之前的等待和被打本身哪个更紧张？',
+    ],
+    heating: [
+      '描述一次印象最深的惩罚经历',
+      '你最不能接受的惩罚方式是什么？',
+      '你被打哭过吗？是什么情况？',
+      '你有被罚站或罚跪过吗？感受如何？',
+      '你被惩罚后需要多长时间恢复？',
+      '你有没有在惩罚中途想喊安全词的时候？',
+      '你觉得惩罚前的"数罪"环节有必要吗？',
+    ],
+    finale: [
+      '你更喜欢被惩罚还是惩罚别人？',
+      '你理想中的 SP 关系是什么样的？',
+      '你希望日常相处中也有惩罚元素吗？',
+      '你愿意为对方破例的底线是什么？',
+      '你觉得惩罚中最重要的是疼痛感还是仪式感？',
+      '如果可以设计一个完美的惩罚场景，你会怎么设计？',
+    ],
+  },
+
+  PARTY_DARE_INSTRUCTIONS: {
+    warmup: [
+      '闭眼，让任意一人用一种工具轻触你的手背，猜是什么工具',
+      '模仿被打时最常有的表情，保持 10 秒',
+      '给左边的人按摩肩膀 30 秒',
+      '用最严厉的语气对右边的人说"你给我过来"',
+      '站起来展示一个受罚姿势，保持 15 秒',
+    ],
+    heating: [
+      '让右边的人选择你下一轮的受罚姿势',
+      '闭眼伸出手心，让任意一人用手掌轻拍 3 下，猜是谁',
+      '选一个人，互相对视 30 秒不许笑',
+      '模仿求饶的样子，要足够真诚让其他人满意',
+      '跟右边的人交换棋盘位置',
+    ],
+    finale: [
+      '让所有人投票选出本局"最能忍"的玩家',
+      '选一个人，用你选择的工具在对方手背上轻敲 5 下',
+      '做一次标准的请罚礼仪：主动说出自己想被用什么工具打哪里',
+      '让左边的人用手掌轻打你手心 3 下，你不能缩手',
+      '描述你心目中最完美的惩罚，其他人投票要不要现在执行',
+    ],
+  },
+
+  PARTY_TRAPS: [
+    { name: '晾臀机关', description: '晾臀5分钟', trapVariant: 'text' as const },
+    {
+      name: '请罚机关',
+      description: '必须自己请罚，大声说出"请打我的屁股"',
+      trapVariant: 'text' as const,
+    },
+    {
+      name: '全员机关',
+      description: '所有人站成一排，由踩到机关的人依次用手掌打每人屁股 3 下',
+      trapVariant: 'all_players' as const,
+    },
+    {
+      name: '全员猜拳',
+      description: '所有人和踩到机关的人猜拳，输的人被踩到机关的人用手掌打屁股 5 下',
+      trapVariant: 'all_players' as const,
+    },
+    {
+      name: '二选一',
+      description: '选择你的命运',
+      trapVariant: 'choice' as const,
+      choiceA: '用手掌打屁股 15 下',
+      choiceB: '保持跪趴姿势 2 分钟',
+    },
+    {
+      name: '高风险二选一',
+      description: '选择你的命运',
+      trapVariant: 'choice' as const,
+      choiceA: '用藤条打屁股 10 下',
+      choiceB: '后退 5 格',
+    },
+    {
+      name: '轮盘机关',
+      description: '命运轮盘！随机选一名玩家接受惩罚——不一定是你哦',
+      trapVariant: 'roulette' as const,
+    },
+    {
+      name: '共难轮盘',
+      description: '命运轮盘！随机选一名玩家，和你一起用手掌互打屁股 5 下',
+      trapVariant: 'roulette' as const,
+    },
+  ],
+
+  PARTY_SCENE_PRESETS: {
+    icebreaker: {
+      name: '初见破冰',
+      description: '问答多、惩罚轻，适合第一次见面',
+      boardConfig: {
+        punishmentCells: 16,
+        chainPunishmentCells: 1,
+        bonusCells: 1,
+        reverseCells: 1,
+        restCells: 1,
+        restartCells: 2,
+        trapCells: 2,
+        totalCells: 40,
+        qaCells: 8,
+        dareCells: 4,
+      },
+      actConstraintsOverride: {
+        warmup: { maxToolIntensity: 2, maxStrikes: 10 },
+        heating: { maxToolIntensity: 5, maxStrikes: 20 },
+        finale: { maxToolIntensity: 7, maxStrikes: 25 },
+      },
+    },
+    hardcore: {
+      name: '老友加码',
+      description: '惩罚密集、强度高，适合熟悉的玩伴',
+      boardConfig: {
+        punishmentCells: 24,
+        chainPunishmentCells: 4,
+        bonusCells: 1,
+        reverseCells: 1,
+        restCells: 0,
+        restartCells: 2,
+        trapCells: 3,
+        totalCells: 40,
+        qaCells: 1,
+        dareCells: 0,
+      },
+      actConstraintsOverride: {
+        warmup: { maxToolIntensity: 5, minStrikes: 10, maxStrikes: 20 },
+        heating: { maxToolIntensity: 9, minStrikes: 15, maxStrikes: 30 },
+        finale: { maxToolIntensity: 10, minStrikes: 20, maxStrikes: 40 },
+      },
+    },
+    intimate: {
+      name: '一对一私密',
+      description: '指令格亲密、节奏缓慢，适合两人',
+      boardConfig: {
+        punishmentCells: 18,
+        chainPunishmentCells: 2,
+        bonusCells: 1,
+        reverseCells: 1,
+        restCells: 1,
+        restartCells: 2,
+        trapCells: 2,
+        totalCells: 40,
+        qaCells: 5,
+        dareCells: 4,
+      },
+      actConstraintsOverride: undefined,
+    },
+    group_fun: {
+      name: '多人欢乐',
+      description: '全员机关多、互动密集，适合 3 人以上聚会',
+      boardConfig: {
+        punishmentCells: 18,
+        chainPunishmentCells: 2,
+        bonusCells: 1,
+        reverseCells: 1,
+        restCells: 1,
+        restartCells: 2,
+        trapCells: 5,
+        totalCells: 40,
+        qaCells: 4,
+        dareCells: 3,
+      },
+      actConstraintsOverride: undefined,
+    },
+  },
 }
 
 // Lucide icon component name mapping for cell types
@@ -204,6 +401,8 @@ export const CELL_ICON_NAMES: Record<string, string> = {
   trap: 'Skull',
   start: 'Rocket',
   normal: 'Circle',
+  qa: 'MessageCircleQuestion',
+  dare: 'Flame',
 }
 
 // Legacy emoji mapping (kept for fallback/compatibility)
@@ -216,7 +415,7 @@ export const CELL_ICONS: Record<string, string> = {
 }
 
 // Cell type color tokens (dark theme)
-export const CELL_COLORS = {
+export const CELL_COLORS: Record<string, { color: string; border: string }> = {
   punishment: {
     color: 'var(--color-punishment)',
     border: 'var(--color-punishment)',
@@ -240,5 +439,13 @@ export const CELL_COLORS = {
   trap: {
     color: 'var(--color-trap)',
     border: 'var(--color-trap)',
+  },
+  qa: {
+    color: 'var(--color-qa, #3b82f6)',
+    border: 'var(--color-qa, #3b82f6)',
+  },
+  dare: {
+    color: 'var(--color-dare, #f59e0b)',
+    border: 'var(--color-dare, #f59e0b)',
   },
 }

--- a/src/services/gameService.ts
+++ b/src/services/gameService.ts
@@ -149,6 +149,16 @@ export class GameService {
     const trapPositions = availablePositions.slice(currentIndex, currentIndex + trapCount)
     currentIndex += trapCount
 
+    // 问答格子（升温局专属）
+    const qaCount = Math.min(boardConf.qaCells ?? 0, availableCount - currentIndex)
+    const qaPositions = availablePositions.slice(currentIndex, currentIndex + qaCount)
+    currentIndex += qaCount
+
+    // 指令格子（升温局专属）
+    const dareCount = Math.min(boardConf.dareCells ?? 0, availableCount - currentIndex)
+    const darePositions = availablePositions.slice(currentIndex, currentIndex + dareCount)
+    currentIndex += dareCount
+
     // 填充惩罚格子
     punishmentPositions.forEach(pos => {
       const punishment = createCompatiblePunishmentAction(config)
@@ -253,8 +263,11 @@ export class GameService {
 
     // 机关格子
     trapPositions.forEach(pos => {
-      // 从机关中随机选择一个
-      const randomTrap = SecureRandom.choice(traps)
+      const randomTrap = SecureRandom.choice(traps) as TrapAction & {
+        trapVariant?: string
+        choiceA?: string
+        choiceB?: string
+      }
 
       cellMap.set(pos, {
         id: pos,
@@ -264,9 +277,61 @@ export class GameService {
           type: 'trap',
           value: 0,
           description: randomTrap.description,
+          trapVariant: randomTrap.trapVariant as
+            | 'text'
+            | 'all_players'
+            | 'choice'
+            | 'roulette'
+            | undefined,
+          choiceA: randomTrap.choiceA,
+          choiceB: randomTrap.choiceB,
         },
       })
     })
+
+    // 问答格子（升温局专属）
+    if (qaPositions.length > 0) {
+      const allQuestions = [
+        ...GAME_CONFIG.PARTY_QA_QUESTIONS.warmup,
+        ...GAME_CONFIG.PARTY_QA_QUESTIONS.heating,
+        ...GAME_CONFIG.PARTY_QA_QUESTIONS.finale,
+      ]
+      qaPositions.forEach(pos => {
+        const question = SecureRandom.choice(allQuestions)
+        cellMap.set(pos, {
+          id: pos,
+          type: 'qa',
+          position: pos,
+          effect: {
+            type: 'qa',
+            value: 0,
+            description: question,
+          },
+        })
+      })
+    }
+
+    // 指令格子（升温局专属）
+    if (darePositions.length > 0) {
+      const allDares = [
+        ...GAME_CONFIG.PARTY_DARE_INSTRUCTIONS.warmup,
+        ...GAME_CONFIG.PARTY_DARE_INSTRUCTIONS.heating,
+        ...GAME_CONFIG.PARTY_DARE_INSTRUCTIONS.finale,
+      ]
+      darePositions.forEach(pos => {
+        const dare = SecureRandom.choice(allDares)
+        cellMap.set(pos, {
+          id: pos,
+          type: 'dare',
+          position: pos,
+          effect: {
+            type: 'dare',
+            value: 0,
+            description: dare,
+          },
+        })
+      })
+    }
 
     // 为剩余的空位置创建普通格子（无效果）
     for (let i = 1; i <= totalCells; i++) {
@@ -297,7 +362,6 @@ export class GameService {
     return randomBoard
   }
 
-  // 打印棋盘统计信息
   private static logBoardStats(board: BoardCell[], title: string): void {
     const punishmentCount = board.filter(c => c.type === 'punishment').length
     const chainPunishmentCount = board.filter(c => c.type === 'chain_punishment').length
@@ -308,6 +372,8 @@ export class GameService {
     const restCount = board.filter(c => c.type === 'special' && c.effect?.type === 'rest').length
     const restartCount = board.filter(c => c.type === 'restart').length
     const trapCount = board.filter(c => c.type === 'trap').length
+    const qaCount = board.filter(c => c.type === 'qa').length
+    const dareCount = board.filter(c => c.type === 'dare').length
 
     devLog(title, {
       totalCells: board.length,
@@ -318,6 +384,8 @@ export class GameService {
       restCount,
       restartCount,
       trapCount,
+      qaCount,
+      dareCount,
       totalAssigned:
         punishmentCount +
         chainPunishmentCount +
@@ -325,7 +393,9 @@ export class GameService {
         reverseCount +
         restCount +
         restartCount +
-        trapCount,
+        trapCount +
+        qaCount +
+        dareCount,
     })
 
     // 输出每个格子
@@ -422,6 +492,8 @@ export class GameService {
       config.restCells,
       config.restartCells,
       config.trapCells,
+      config.qaCells ?? 0,
+      config.dareCells ?? 0,
     ]
     const totalUsed = assignedCounts.reduce((sum, count) => sum + count, 0)
 
@@ -727,6 +799,14 @@ export class GameService {
         case 'rest':
           effect = `移动到第${newPosition}格，休息${targetCell.effect.value}回合`
           break
+
+        case 'qa':
+          effect = `❓ 问答时间！`
+          break
+
+        case 'dare':
+          effect = `🔥 执行指令！`
+          break
       }
     }
 
@@ -806,6 +886,14 @@ export class GameService {
         newPosition = player.position
         effect = cellEffect.description || '触发机关'
         break
+      case 'qa':
+        newPosition = player.position
+        effect = cellEffect.description || '问答时间'
+        break
+      case 'dare':
+        newPosition = player.position
+        effect = cellEffect.description || '执行指令'
+        break
       default:
         newPosition = player.position
         effect = '未知效果'
@@ -877,10 +965,7 @@ export class GameService {
   }
 
   // 获取格子类型
-  static getCellType(
-    position: number,
-    board: BoardCell[] = this.latestBoard
-  ): 'punishment' | 'bonus' | 'special' | 'restart' | 'trap' | 'chain_punishment' {
+  static getCellType(position: number, board: BoardCell[] = this.latestBoard): BoardCell['type'] {
     const cell = this.getBoardCellByPosition(position, board)
     if (!cell) {
       return 'bonus'

--- a/src/services/partyMode.ts
+++ b/src/services/partyMode.ts
@@ -1,8 +1,19 @@
-import type { PunishmentAction, PunishmentConfig } from '../types/game'
+import type { PunishmentAction, PunishmentConfig, PunishmentConstraints } from '../types/game'
+import { GAME_CONFIG } from '../config/gameConfig'
 import { createCompatiblePunishmentAction, type RuleRandomSource } from './ruleResolution'
 
 export type PartyAct = 'warmup' | 'heating' | 'finale'
-export type PartyTokenAction = 'reroll' | 'punishment_choice'
+export type PartyTokenAction = 'reroll' | 'punishment_choice' | 'transfer' | 'amplify' | 'immunity'
+
+/** Returns act-specific punishment constraints from config */
+export function getActConstraints(act: PartyAct): PunishmentConstraints {
+  return GAME_CONFIG.PARTY_ACT_CONSTRAINTS[act]
+}
+
+/** Returns act-specific double punishment chance */
+export function getActDoublePunishmentChance(act: PartyAct): number {
+  return GAME_CONFIG.PARTY_ACT_CONSTRAINTS[act].doublePunishmentChance ?? 20
+}
 export type PartyPrediction = 'low' | 'high'
 export type PartyReactionDecision = 'keep' | 'mirror'
 export type PartyDiceDecision = 'continue'
@@ -148,13 +159,14 @@ function punishmentFingerprint(action: PunishmentAction): string {
 
 export function createPartyPunishmentChoices(
   config: PunishmentConfig,
-  randomSource?: RuleRandomSource
+  randomSource?: RuleRandomSource,
+  constraints?: PunishmentConstraints
 ): readonly [PunishmentAction, PunishmentAction] {
   const choices: PunishmentAction[] = []
   const fingerprints = new Set<string>()
 
   for (let attempt = 0; attempt < 8 && choices.length < 2; attempt += 1) {
-    const candidate = createCompatiblePunishmentAction(config, randomSource)
+    const candidate = createCompatiblePunishmentAction(config, randomSource, constraints)
     const fingerprint = punishmentFingerprint(candidate)
     if (fingerprints.has(fingerprint)) continue
     fingerprints.add(fingerprint)
@@ -192,7 +204,13 @@ export function createPartySession({
     reactionUsedThisRound: false,
     diceChangedThisTurn: false,
     successfulReactionCount: 0,
-    interventionCounts: Object.freeze({ reroll: 0, punishment_choice: 0 }),
+    interventionCounts: Object.freeze({
+      reroll: 0,
+      punishment_choice: 0,
+      transfer: 0,
+      amplify: 0,
+      immunity: 0,
+    }),
     longestChain: 0,
   })
 }
@@ -342,13 +360,27 @@ export function recordPartyChain(session: PartySession, chainLength: number): Pa
 }
 
 export function createPartyHighlight(session: PartySession): PartyHighlight {
-  const { reroll, punishment_choice: punishmentChoice } = session.interventionCounts
-  const keyDecision =
-    punishmentChoice >= reroll && punishmentChoice > 0
-      ? `随机二选一使用 ${punishmentChoice} 次`
-      : reroll > 0
-        ? `重掷使用 ${reroll} 次`
-        : '本局未使用干预筹码'
+  const {
+    reroll,
+    punishment_choice: punishmentChoice,
+    transfer,
+    amplify,
+    immunity,
+  } = session.interventionCounts
+  const totalUsed = reroll + punishmentChoice + transfer + amplify + immunity
+
+  let keyDecision: string
+  if (totalUsed === 0) {
+    keyDecision = '本局未使用干预筹码'
+  } else {
+    const parts: string[] = []
+    if (reroll > 0) parts.push(`重掷 ${reroll}`)
+    if (punishmentChoice > 0) parts.push(`二选一 ${punishmentChoice}`)
+    if (transfer > 0) parts.push(`转嫁 ${transfer}`)
+    if (amplify > 0) parts.push(`加码 ${amplify}`)
+    if (immunity > 0) parts.push(`免疫 ${immunity}`)
+    keyDecision = `筹码使用: ${parts.join('、')} 次`
+  }
 
   return Object.freeze({
     act: session.act,

--- a/src/services/ruleResolution.ts
+++ b/src/services/ruleResolution.ts
@@ -4,11 +4,15 @@ import type {
   PunishmentAction,
   PunishmentBodyPart,
   PunishmentConfig,
+  PunishmentConstraints,
   PunishmentPosition,
   PunishmentTool,
+  PunishmentVariant,
   ResolvedCellEffectResult,
+  ResolvedDareResult,
   ResolvedPunishmentAction,
   ResolvedPunishmentResult,
+  ResolvedQAResult,
   ResolvedRuleResult,
   ResolvedTrapResult,
   TurnConsequence,
@@ -49,7 +53,26 @@ export interface TrapRuleInput {
   effect: NonNullable<BoardCell['effect']>
 }
 
-export type RuleInput = PunishmentRuleInput | CellEffectRuleInput | TrapRuleInput
+export interface QARuleInput {
+  source: 'qa'
+  actorIndex: number
+  players: readonly Player[]
+  effect: NonNullable<BoardCell['effect']>
+}
+
+export interface DareRuleInput {
+  source: 'dare'
+  actorIndex: number
+  players: readonly Player[]
+  effect: NonNullable<BoardCell['effect']>
+}
+
+export type RuleInput =
+  | PunishmentRuleInput
+  | CellEffectRuleInput
+  | TrapRuleInput
+  | QARuleInput
+  | DareRuleInput
 
 export interface RuleRandomSource {
   weightedChoice<T>(entries: readonly T[], weights: readonly number[]): T
@@ -98,7 +121,8 @@ const hasCompatiblePosition = (
 
 export const createCompatiblePunishmentAction = (
   config: PunishmentConfig,
-  randomSource: RuleRandomSource = secureRandomSource
+  randomSource: RuleRandomSource = secureRandomSource,
+  constraints?: PunishmentConstraints
 ): PunishmentAction => {
   const tools = entriesWithNames<PunishmentTool>(config.tools)
   const bodyParts = entriesWithNames<PunishmentBodyPart>(config.bodyParts)
@@ -106,9 +130,12 @@ export const createCompatiblePunishmentAction = (
   const enabledBodyParts = bodyParts.filter(bodyPart => bodyPart.ratio > 0)
   const enabledPositions = positions.filter(position => position.ratio > 0)
 
+  const maxIntensity = constraints?.maxToolIntensity ?? Infinity
+
   const viableTools = tools.filter(
     tool =>
       tool.ratio > 0 &&
+      tool.intensity <= maxIntensity &&
       enabledBodyParts.some(
         bodyPart =>
           bodyPart.sensitivity >= tool.intensity &&
@@ -129,8 +156,8 @@ export const createCompatiblePunishmentAction = (
   const position = chooseWeighted(compatiblePositions, randomSource)
 
   const step = Math.max(1, config.step || 1)
-  const minimum = Math.max(1, config.minStrikes || step)
-  const maximum = Math.max(minimum, config.maxStrikes || minimum)
+  const minimum = Math.max(1, constraints?.minStrikes ?? config.minStrikes ?? step)
+  const maximum = Math.max(minimum, constraints?.maxStrikes ?? config.maxStrikes ?? minimum)
   const minimumMultiple = Math.ceil(minimum / step)
   const maximumMultiple = Math.floor(maximum / step)
   if (minimumMultiple > maximumMultiple) {
@@ -145,6 +172,26 @@ export const createCompatiblePunishmentAction = (
     strikes,
     description: `用${tool.name}打${bodyPart.name}${strikes}下，姿势：${position.name}`,
   }
+}
+
+/** Pick a random punishment variant for party mode based on act and probability */
+export const pickPunishmentVariant = (
+  act: 'warmup' | 'heating' | 'finale',
+  randomSource: RuleRandomSource = secureRandomSource
+): PunishmentVariant | undefined => {
+  const variantChances: Record<string, Partial<Record<PunishmentVariant, number>>> = {
+    warmup: {},
+    heating: { blindbox: 15, conditional: 10 },
+    finale: { blindbox: 15, conditional: 10, deferred: 10, mutual: 10 },
+  }
+  const chances = variantChances[act]
+  const roll = randomSource.randomInt(1, 100)
+  let cumulative = 0
+  for (const [variant, chance] of Object.entries(chances)) {
+    cumulative += chance!
+    if (roll <= cumulative) return variant as PunishmentVariant
+  }
+  return undefined
 }
 
 const copyAction = (
@@ -241,14 +288,46 @@ export const consumePendingSkippedTurn = (
 export function resolveRule(input: PunishmentRuleInput): ResolvedPunishmentResult
 export function resolveRule(input: CellEffectRuleInput): ResolvedCellEffectResult
 export function resolveRule(input: TrapRuleInput): ResolvedTrapResult
+export function resolveRule(input: QARuleInput): ResolvedQAResult
+export function resolveRule(input: DareRuleInput): ResolvedDareResult
 export function resolveRule(input: RuleInput): ResolvedRuleResult {
   if (input.actorIndex < 0 || input.actorIndex >= input.players.length) {
     throw new Error('规则解析需要有效的触发玩家索引')
   }
 
+  if (input.source === 'qa') {
+    return Object.freeze({
+      kind: 'qa',
+      source: 'qa',
+      actorIndex: input.actorIndex,
+      question: input.effect.description,
+      turnConsequence: Object.freeze({ kind: 'none' }),
+    })
+  }
+
+  if (input.source === 'dare') {
+    return Object.freeze({
+      kind: 'dare',
+      source: 'dare',
+      actorIndex: input.actorIndex,
+      instruction: input.effect.description,
+      turnConsequence: Object.freeze({ kind: 'none' }),
+    })
+  }
+
   if (input.source === 'trap') {
     if (input.effect.type !== 'trap') {
       throw new Error('机关规则需要 trap 类型效果')
+    }
+
+    const trapVariant = input.effect.trapVariant
+    let rouletteTargetIndex: number | undefined
+    if (trapVariant === 'roulette' && input.players.length > 1) {
+      const randomSource = secureRandomSource
+      const candidates = input.players.flatMap((_, index) =>
+        index === input.actorIndex ? [] : [index]
+      )
+      rouletteTargetIndex = candidates.length > 0 ? randomSource.choice(candidates) : undefined
     }
 
     return Object.freeze({
@@ -258,6 +337,10 @@ export function resolveRule(input: RuleInput): ResolvedRuleResult {
       acknowledgementRequired: true,
       description: input.effect.description,
       turnConsequence: Object.freeze({ kind: 'none' }),
+      trapVariant,
+      choiceA: input.effect.choiceA,
+      choiceB: input.effect.choiceB,
+      rouletteTargetIndex,
     })
   }
 

--- a/src/tests/partyMode.test.ts
+++ b/src/tests/partyMode.test.ts
@@ -291,7 +291,7 @@ describe('升温局阶段导演', () => {
 
     expect(createPartyHighlight(session)).toEqual({
       act: 'warmup',
-      keyDecision: '随机二选一使用 1 次',
+      keyDecision: '筹码使用: 二选一 1 次',
       reactionSummary: '成功反应 1 次',
       chainSummary: '最长连锁 4 次',
     })

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -62,7 +62,13 @@ export interface PunishmentAction {
   targetPlayer?: 'current' | 'previous' | 'next' | 'other'
 }
 
-export type RuleResolutionSource = 'takeoff_failure' | 'board_punishment' | 'trap' | 'cell_effect'
+export type RuleResolutionSource =
+  | 'takeoff_failure'
+  | 'board_punishment'
+  | 'trap'
+  | 'cell_effect'
+  | 'qa'
+  | 'dare'
 
 export type ResolvedPunishmentCount =
   | Readonly<{ kind: 'fixed'; value: number }>
@@ -98,6 +104,7 @@ export interface ResolvedPunishmentResult {
   readonly count: ResolvedPunishmentCount
   readonly countMultiplier?: number
   readonly turnConsequence: TurnConsequence
+  readonly variant?: PunishmentVariant
 }
 
 export interface ResolvedTrapResult {
@@ -107,6 +114,10 @@ export interface ResolvedTrapResult {
   readonly acknowledgementRequired: true
   readonly description: string
   readonly turnConsequence: TurnConsequence
+  readonly trapVariant?: TrapVariant
+  readonly choiceA?: string
+  readonly choiceB?: string
+  readonly rouletteTargetIndex?: number
 }
 
 export interface ResolvedCellEffectResult {
@@ -121,10 +132,12 @@ export type ResolvedRuleResult =
   | ResolvedPunishmentResult
   | ResolvedTrapResult
   | ResolvedCellEffectResult
+  | ResolvedQAResult
+  | ResolvedDareResult
 
 export interface BoardCell {
   id: number
-  type: 'punishment' | 'bonus' | 'special' | 'restart' | 'trap' | 'chain_punishment'
+  type: 'punishment' | 'bonus' | 'special' | 'restart' | 'trap' | 'chain_punishment' | 'qa' | 'dare'
   effect?: {
     type:
       | 'punishment'
@@ -135,30 +148,37 @@ export interface BoardCell {
       | 'trap'
       | 'bounce'
       | 'chain_punishment'
+      | 'qa'
+      | 'dare'
     value: number
     description: string
     punishment?: PunishmentAction
     dynamicType?: 'dice_multiplier' | 'previous_player' | 'next_player' | 'other_player_choice'
     multiplier?: number
+    trapVariant?: TrapVariant
+    choiceA?: string
+    choiceB?: string
   }
   position: number
 }
 
 export interface CellEffect {
-  type: 'move' | 'rest' | 'reverse' | 'restart' | 'bounce' | 'chain_punishment'
+  type: 'move' | 'rest' | 'reverse' | 'restart' | 'bounce' | 'chain_punishment' | 'qa' | 'dare'
   value: number
   description: string
 }
 
 export interface BoardConfig {
-  punishmentCells: number // 惩罚格子数量
-  chainPunishmentCells: number // 连锁惩罚格子数量
-  bonusCells: number // 奖励格子数量
-  reverseCells: number // 后退格子数量
-  restCells: number // 休息格子数量
-  restartCells: number // 回到起点格子数量
-  trapCells: number // 机关格子数量
-  totalCells: number // 总格子数量
+  punishmentCells: number
+  chainPunishmentCells: number
+  bonusCells: number
+  reverseCells: number
+  restCells: number
+  restartCells: number
+  trapCells: number
+  totalCells: number
+  qaCells?: number
+  dareCells?: number
 }
 
 export interface GameState {
@@ -191,3 +211,59 @@ export interface TrapAction {
   name: string
   description: string
 }
+
+// --- Party mode extensions (升温局专属) ---
+
+/** Constraints for act-aware punishment generation in party mode */
+export interface PunishmentConstraints {
+  readonly maxToolIntensity?: number
+  readonly minStrikes?: number
+  readonly maxStrikes?: number
+  readonly doublePunishmentChance?: number
+}
+
+/** Q&A question entry for party mode 问答格 */
+export interface QAQuestion {
+  readonly text: string
+  readonly act: 'warmup' | 'heating' | 'finale'
+}
+
+/** Dare instruction entry for party mode 指令格 */
+export interface DareInstruction {
+  readonly text: string
+  readonly act: 'warmup' | 'heating' | 'finale'
+}
+
+/** Structured trap type discriminator */
+export type TrapVariant = 'text' | 'all_players' | 'choice' | 'roulette'
+
+/** Extended trap with structured type */
+export interface StructuredTrapAction extends TrapAction {
+  readonly trapVariant: TrapVariant
+  readonly choiceA?: string
+  readonly choiceB?: string
+}
+
+/** Punishment variant for party mode */
+export type PunishmentVariant = 'blindbox' | 'conditional' | 'deferred' | 'mutual'
+
+/** Resolved QA result */
+export interface ResolvedQAResult {
+  readonly kind: 'qa'
+  readonly source: 'qa'
+  readonly actorIndex: number
+  readonly question: string
+  readonly turnConsequence: TurnConsequence
+}
+
+/** Resolved Dare result */
+export interface ResolvedDareResult {
+  readonly kind: 'dare'
+  readonly source: 'dare'
+  readonly actorIndex: number
+  readonly instruction: string
+  readonly turnConsequence: TurnConsequence
+}
+
+/** Party mode scene preset identifier */
+export type PartyScenePreset = 'icebreaker' | 'hardcore' | 'intimate' | 'group_fun'

--- a/src/utils/boardPresentation.ts
+++ b/src/utils/boardPresentation.ts
@@ -10,6 +10,8 @@ export type CellVisualKind =
   | 'rest'
   | 'restart'
   | 'trap'
+  | 'qa'
+  | 'dare'
   | 'finish'
 
 export type CellIconName =
@@ -23,6 +25,8 @@ export type CellIconName =
   | 'Trophy'
   | 'Undo2'
   | 'Zap'
+  | 'MessageCircleQuestion'
+  | 'Flame'
 
 export interface CellPresentationDetail {
   label: string
@@ -58,6 +62,8 @@ const CELL_META: Record<
   rest: { label: '休息格', shortLabel: '休息', iconName: 'Moon' },
   restart: { label: '回起点', shortLabel: '重置', iconName: 'RotateCcw' },
   trap: { label: '机关格', shortLabel: '机关', iconName: 'Skull' },
+  qa: { label: '问答格', shortLabel: '问答', iconName: 'MessageCircleQuestion' },
+  dare: { label: '指令格', shortLabel: '指令', iconName: 'Flame' },
   finish: { label: '终点', shortLabel: '终点', iconName: 'Trophy' },
 }
 
@@ -67,6 +73,8 @@ const getVisualKind = (cell: BoardCell, totalCells: number): CellVisualKind => {
   if (cell.type === 'punishment' || cell.effect?.type === 'punishment') return 'punishment'
   if (cell.type === 'chain_punishment' || cell.effect?.type === 'chain_punishment') return 'chain'
   if (cell.type === 'trap' || cell.effect?.type === 'trap') return 'trap'
+  if (cell.type === 'qa' || cell.effect?.type === 'qa') return 'qa'
+  if (cell.type === 'dare' || cell.effect?.type === 'dare') return 'dare'
   if (cell.type === 'restart' || cell.effect?.type === 'restart') return 'restart'
   if (cell.effect?.type === 'reverse') return 'reverse'
   if (cell.effect?.type === 'rest') return 'rest'
@@ -105,6 +113,10 @@ const getDetails = (cell: BoardCell, kind: CellVisualKind): CellPresentationDeta
       return [{ label: '效果', value: '回到起点' }]
     case 'trap':
       return [{ label: '效果', value: '触发随机机关' }]
+    case 'qa':
+      return [{ label: '效果', value: cell.effect?.description || '回答问题' }]
+    case 'dare':
+      return [{ label: '效果', value: cell.effect?.description || '执行指令' }]
     case 'start':
       return [{ label: '位置', value: '赛道起点' }]
     case 'finish':


### PR DESCRIPTION
## Summary
- 经典局完全冻结；升温局新增三幕强度约束、问答格/指令格、结构化机关（全员/二选一/轮盘）、场景包选择
- App 已接入：开局用 `PARTY_BOARD_CONFIG`/`PARTY_TRAPS`、踩格弹窗、拒绝问答触发幕内惩罚、翻倍概率按幕变化
- 版本 bump 至 `1.9.0`

## Test plan
- [ ] 经典局开局/惩罚/机关流程与 v1.8.1 一致
- [ ] 升温局首页可选场景（默认/破冰/加码/私密/欢乐）并开局
- [ ] 升温局棋盘出现问答格、指令格；踩到后弹出对应 UI
- [ ] 问答拒绝后触发当前幕强度范围内的惩罚
- [ ] 暖场幕惩罚工具强度低、翻倍概率为 0；升温/终局逐步升高
- [ ] 结构化机关（二选一/轮盘/全员）弹窗可确认并继续回合
- [ ] `npm test` / `npm run type-check` / `npm run build` 通过


Made with [Cursor](https://cursor.com)