### PR TITLE
fix: v1.9.1 bugfixes — dice-0, double-fire modals, prediction timeout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -230,7 +230,7 @@
   // 起飞惩罚显示状态
   const showTakeoffPunishmentDisplay = ref(false)
   const currentTakeoffPunishment = ref<PunishmentAction | null>(null)
-  const currentTakeoffDiceValue = ref(0)
+  const currentTakeoffDiceValue = ref(1)
   const currentTakeoffExecutorIndex = ref(0)
 
   // 执行惩罚的玩家状态
@@ -531,7 +531,7 @@
       // 当玩家尚未起飞(仍停留在起点)且出现惩罚时，视为未起飞惩罚
       if (!currentPlayer.hasTakenOff) {
         currentTakeoffPunishment.value = displayAction
-        currentTakeoffDiceValue.value = diceValue ?? gameState.diceValue ?? 0
+        currentTakeoffDiceValue.value = diceValue ?? gameState.diceValue ?? 1
         currentTakeoffExecutorIndex.value = punishmentResolution.executorIndex ?? -1
         mercyRequested.value = false
         showTakeoffPunishmentDisplay.value = true
@@ -613,7 +613,7 @@
         effect: resolvedCellEffect,
       })
       bounceFromPosition.value = fromPosition
-      bounceTargetPosition.value = fromPosition + (diceValue ?? gameState.diceValue ?? 0)
+      bounceTargetPosition.value = fromPosition + (diceValue ?? gameState.diceValue ?? 1)
       bounceFinalPosition.value = newPosition
       bounceOverflowSteps.value = resolvedCellEffect.value
       showBounceDisplay.value = true
@@ -1513,7 +1513,7 @@
     try {
       const currentPlayer = gameState.players[gameState.currentPlayerIndex]
       const diceValue = gameState.diceValue
-      if (!diceValue) {
+      if (diceValue == null) {
         // 如果没有骰子值，重置状态并返回
         gameState.gameStatus = 'waiting'
         return
@@ -3167,7 +3167,7 @@
     <PartyDiceDecision
       :visible="partyDiceDecisionVisible"
       :player-name="gameState.players[gameState.currentPlayerIndex]?.name ?? '当前玩家'"
-      :dice-value="gameState.diceValue ?? 0"
+      :dice-value="gameState.diceValue ?? 1"
       :tokens-remaining="currentPartyTokens"
       :can-reroll="canCurrentPlayerReroll"
       :paused="sessionPaused"

--- a/src/components/CoolDice.vue
+++ b/src/components/CoolDice.vue
@@ -45,7 +45,7 @@
 
   // 根据当前值确定显示的面
   const getCurrentFaceClass = () => {
-    if (!props.value) return 'show-face-1'
+    if (props.value == null) return 'show-face-1'
     return `show-face-${props.value}`
   }
 </script>

--- a/src/components/DareDisplay.vue
+++ b/src/components/DareDisplay.vue
@@ -12,8 +12,15 @@
     (e: 'confirm'): void
   }
 
-  defineProps<Props>()
+  import { ref, watch } from 'vue'
+
+  const props = defineProps<Props>()
   const emit = defineEmits<Emits>()
+
+  const submitted = ref(false)
+  watch(() => props.show, (visible) => { if (visible) submitted.value = false })
+
+  const confirm = () => { if (submitted.value) return; submitted.value = true; emit('confirm') }
 </script>
 
 <template>
@@ -37,7 +44,7 @@
       </div>
 
       <div class="dare-actions">
-        <button class="btn dare-confirm-btn" @click="emit('confirm')">
+        <button class="btn dare-confirm-btn" :disabled="submitted" @click="confirm">
           <Check :size="18" />
           <span>已完成</span>
         </button>

--- a/src/components/GameBoard.vue
+++ b/src/components/GameBoard.vue
@@ -190,7 +190,7 @@
   }
 
   const locateCurrentPlayer = () => {
-    const position = currentPlayer.value?.position || 1
+    const position = currentPlayer.value?.position ?? 1
     focusCell(position)
   }
 
@@ -231,7 +231,7 @@
   watch(
     () => props.selectedPosition,
     position => {
-      if (!position) return
+      if (position == null) return
       focusedPosition.value = position
       nextTick(() => scrollToCell(position))
     }

--- a/src/components/IntroPage.vue
+++ b/src/components/IntroPage.vue
@@ -126,27 +126,25 @@
     loadAndApplyPlayerSettings()
   }
 
+  // 显示清空成功提示
+  const showClearSuccess = ref(false)
+  let clearSuccessTimer: ReturnType<typeof setTimeout> | undefined
+
   // 清空缓存功能
   const clearCache = () => {
     try {
       clearAllLocalGameData()
-
-      // 显示成功提示
       showClearSuccess.value = true
-
-      // 3秒后隐藏提示
-      setTimeout(() => {
+      if (clearSuccessTimer !== undefined) clearTimeout(clearSuccessTimer)
+      clearSuccessTimer = setTimeout(() => {
         showClearSuccess.value = false
+        clearSuccessTimer = undefined
       }, 3000)
-
       devLog('本地游戏数据已清空')
     } catch (error) {
       console.error('清空缓存时出错:', error)
     }
   }
-
-  // 显示清空成功提示
-  const showClearSuccess = ref(false)
 
   // 粒子系统
   const particles = ref<
@@ -167,6 +165,10 @@
   onUnmounted(() => {
     if (animationId.value) {
       cancelAnimationFrame(animationId.value)
+    }
+    if (clearSuccessTimer !== undefined) {
+      clearTimeout(clearSuccessTimer)
+      clearSuccessTimer = undefined
     }
 
     // 移除事件监听器

--- a/src/components/PartyDiceDecision.vue
+++ b/src/components/PartyDiceDecision.vue
@@ -22,6 +22,7 @@
 
   const secondsRemaining = ref(PARTY_DECISION_TIMEOUT_SECONDS)
   let timer: number | undefined
+  let submitted = false
 
   const clearTimer = () => {
     if (timer !== undefined) {
@@ -32,11 +33,14 @@
 
   const startTimer = (resetCountdown: boolean) => {
     clearTimer()
+    submitted = false
     if (resetCountdown) secondsRemaining.value = PARTY_DECISION_TIMEOUT_SECONDS
     timer = window.setInterval(() => {
       secondsRemaining.value -= 1
       if (secondsRemaining.value <= 0) {
         clearTimer()
+        if (submitted) return
+        submitted = true
         emit(PARTY_DEFAULT_DICE_DECISION)
       }
     }, 1000)
@@ -56,6 +60,8 @@
   onBeforeUnmount(clearTimer)
 
   const choose = (event: 'reroll' | 'continue') => {
+    if (submitted) return
+    submitted = true
     clearTimer()
     if (event === 'reroll') emit('reroll')
     else emit('continue')

--- a/src/components/PartyReactionOverlay.vue
+++ b/src/components/PartyReactionOverlay.vue
@@ -22,7 +22,8 @@
   }>()
 
   const secondsRemaining = ref(PARTY_DECISION_TIMEOUT_SECONDS)
-  let decisionTimer: number | undefined
+  let activeTimer: number | undefined
+  let submitted = false
 
   const reactorName = computed(
     () => props.players[props.reaction?.reactorPlayerIndex ?? -1]?.name ?? '反应者'
@@ -31,21 +32,39 @@
     () => props.players[props.reaction?.targetPlayerIndex ?? -1]?.name ?? '当前玩家'
   )
 
-  const clearDecisionTimer = () => {
-    if (decisionTimer !== undefined) {
-      window.clearInterval(decisionTimer)
-      decisionTimer = undefined
+  const clearActiveTimer = () => {
+    if (activeTimer !== undefined) {
+      window.clearInterval(activeTimer)
+      activeTimer = undefined
     }
   }
 
-  const startDecisionTimer = (resetCountdown: boolean) => {
-    clearDecisionTimer()
+  const startTimer = (resetCountdown: boolean) => {
+    clearActiveTimer()
+    submitted = false
     if (resetCountdown) secondsRemaining.value = PARTY_DECISION_TIMEOUT_SECONDS
-    decisionTimer = window.setInterval(() => {
+    activeTimer = window.setInterval(() => {
       secondsRemaining.value -= 1
       if (secondsRemaining.value <= 0) {
-        clearDecisionTimer()
+        clearActiveTimer()
+        if (submitted) return
+        submitted = true
         emit('decide', PARTY_DEFAULT_REACTION_DECISION)
+      }
+    }, 1000)
+  }
+
+  const startPredictionTimer = (resetCountdown: boolean) => {
+    clearActiveTimer()
+    submitted = false
+    if (resetCountdown) secondsRemaining.value = PARTY_DECISION_TIMEOUT_SECONDS
+    activeTimer = window.setInterval(() => {
+      secondsRemaining.value -= 1
+      if (secondsRemaining.value <= 0) {
+        clearActiveTimer()
+        if (submitted) return
+        submitted = true
+        emit('predict', 'low')
       }
     }, 1000)
   }
@@ -53,19 +72,34 @@
   watch(
     () => [props.reaction?.status, props.paused] as const,
     ([status, paused], previous) => {
-      if (status === 'awaiting_decision' && !paused) {
-        startDecisionTimer(previous?.[0] !== 'awaiting_decision')
+      if (paused) {
+        clearActiveTimer()
+        return
+      }
+      if (status === 'awaiting_prediction') {
+        startPredictionTimer(previous?.[0] !== 'awaiting_prediction')
+      } else if (status === 'awaiting_decision') {
+        startTimer(previous?.[0] !== 'awaiting_decision')
       } else {
-        clearDecisionTimer()
+        clearActiveTimer()
       }
     },
     { immediate: true }
   )
 
-  onBeforeUnmount(clearDecisionTimer)
+  onBeforeUnmount(clearActiveTimer)
+
+  const predict = (prediction: PartyPrediction) => {
+    if (submitted) return
+    submitted = true
+    clearActiveTimer()
+    emit('predict', prediction)
+  }
 
   const decide = (decision: PartyReactionDecision) => {
-    clearDecisionTimer()
+    if (submitted) return
+    submitted = true
+    clearActiveTimer()
     emit('decide', decision)
   }
 </script>
@@ -87,13 +121,16 @@
 
       <template v-if="reaction.status === 'awaiting_prediction'">
         <h2>{{ reactorName }}，预测 {{ targetName }} 的骰子范围</h2>
-        <p>猜中后，你可以保留点数，或把它改成 7 − 当前点数。</p>
+        <p class="party-countdown">
+          <Timer :size="16" />
+          {{ secondsRemaining }} 秒后自动预测 1–3
+        </p>
         <div class="party-reaction-actions">
           <button
             type="button"
             class="party-action party-action--low"
             data-testid="predict-low"
-            @click="emit('predict', 'low')"
+            @click="predict('low')"
           >
             预测 1–3
           </button>
@@ -101,7 +138,7 @@
             type="button"
             class="party-action party-action--high"
             data-testid="predict-high"
-            @click="emit('predict', 'high')"
+            @click="predict('high')"
           >
             预测 4–6
           </button>
@@ -119,6 +156,7 @@
             type="button"
             class="party-action party-action--keep"
             data-testid="reaction-keep"
+            :disabled="submitted"
             @click="decide('keep')"
           >
             保留 {{ reaction.rolledValue }}
@@ -127,6 +165,7 @@
             type="button"
             class="party-action party-action--mirror"
             data-testid="reaction-mirror"
+            :disabled="submitted"
             @click="decide('mirror')"
           >
             <RefreshCw :size="17" />

--- a/src/components/PartyTieBreak.vue
+++ b/src/components/PartyTieBreak.vue
@@ -41,13 +41,24 @@
     { immediate: true, deep: true }
   )
 
+  const resolved = ref(false)
+
+  watch(
+    () => props.visible,
+    (visible) => { if (visible) resolved.value = false }
+  )
+
   const roll = () => {
+    if (resolved.value) return
     const currentState = state.value
     const playerIndex = currentPlayerIndex.value
     if (!currentState || playerIndex === undefined) return
     const result = rollPartyTieBreak(currentState, playerIndex, SecureRandom.randomInt(1, 6))
     state.value = result.state
-    if (result.winnerPlayerIndex !== undefined) emit('winner', result.winnerPlayerIndex)
+    if (result.winnerPlayerIndex !== undefined) {
+      resolved.value = true
+      emit('winner', result.winnerPlayerIndex)
+    }
   }
 </script>
 
@@ -68,7 +79,7 @@
         </div>
       </div>
 
-      <button type="button" class="tie-roll-button" data-testid="party-tie-roll" @click="roll">
+      <button type="button" class="tie-roll-button" :disabled="resolved" data-testid="party-tie-roll" @click="roll">
         <Dices :size="20" />
         掷骰
       </button>

--- a/src/components/QADisplay.vue
+++ b/src/components/QADisplay.vue
@@ -13,8 +13,16 @@
     (e: 'refuse'): void
   }
 
-  defineProps<Props>()
+  import { ref, watch } from 'vue'
+
+  const props = defineProps<Props>()
   const emit = defineEmits<Emits>()
+
+  const submitted = ref(false)
+  watch(() => props.show, (visible) => { if (visible) submitted.value = false })
+
+  const answer = () => { if (submitted.value) return; submitted.value = true; emit('answer') }
+  const refuse = () => { if (submitted.value) return; submitted.value = true; emit('refuse') }
 </script>
 
 <template>
@@ -38,11 +46,11 @@
       </div>
 
       <div class="qa-actions">
-        <button class="btn qa-answer-btn" @click="emit('answer')">
+        <button class="btn qa-answer-btn" :disabled="submitted" @click="answer">
           <Check :size="18" />
           <span>已回答</span>
         </button>
-        <button class="btn qa-refuse-btn" @click="emit('refuse')">
+        <button class="btn qa-refuse-btn" :disabled="submitted" @click="refuse">
           <Zap :size="18" />
           <span>拒绝回答（接受惩罚）</span>
         </button>

--- a/src/components/TrapChoiceDisplay.vue
+++ b/src/components/TrapChoiceDisplay.vue
@@ -17,8 +17,16 @@
     (e: 'confirm'): void
   }
 
-  defineProps<Props>()
+  import { ref, watch } from 'vue'
+
+  const props = defineProps<Props>()
   const emit = defineEmits<Emits>()
+
+  const submitted = ref(false)
+  watch(() => props.show, (visible) => { if (visible) submitted.value = false })
+
+  const choose = (choice: 'A' | 'B') => { if (submitted.value) return; submitted.value = true; emit('choose', choice) }
+  const confirmTrap = () => { if (submitted.value) return; submitted.value = true; emit('confirm') }
 </script>
 
 <template>
@@ -55,19 +63,19 @@
         </div>
 
         <div v-if="choiceA && choiceB" class="choice-options">
-          <button class="choice-btn choice-a" @click="emit('choose', 'A')">
+          <button class="choice-btn choice-a" :disabled="submitted" @click="choose('A')">
             <span class="choice-label">A</span>
             <span class="choice-text">{{ choiceA }}</span>
           </button>
           <span class="choice-or">或</span>
-          <button class="choice-btn choice-b" @click="emit('choose', 'B')">
+          <button class="choice-btn choice-b" :disabled="submitted" @click="choose('B')">
             <span class="choice-label">B</span>
             <span class="choice-text">{{ choiceB }}</span>
           </button>
         </div>
 
         <div v-else class="trap-confirm-section">
-          <button class="btn trap-confirm-btn" @click="emit('confirm')">确认执行</button>
+          <button class="btn trap-confirm-btn" :disabled="submitted" @click="confirmTrap">确认执行</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **骰子显示 0 点**：将 `?? 0` fallback 改为 `?? 1`，falsy check 改为 null check，防止升温模式下出现"掷出了 0"
- **预测阶段无超时**：为 `PartyReactionOverlay` 的 `awaiting_prediction` 阶段新增倒计时，防止游戏永久卡住
- **模态框双击 race condition**：为 `PartyDiceDecision`、`QADisplay`、`DareDisplay`、`TrapChoiceDisplay`、`PartyTieBreak` 添加 submitted/resolved guard，防止 timer+click 双重触发
- **IntroPage timer 泄漏**：`clearCache` 的 setTimeout 现在会在 unmount 时清理
- **GameBoard position 0**：`locateCurrentPlayer` 和 `selectedPosition` watcher 使用 `?? / == null` 替代 `|| / !`

## Test plan

- [ ] 升温模式下掷骰，确认不再出现"掷出了 0"
- [ ] 升温模式反应阶段，等待不点预测按钮，确认超时后自动预测并继续
- [ ] 快速双击各模态框按钮（问答/执行指令/机关/决胜），确认不会重复触发
- [ ] 清空缓存后立即开始游戏，确认无报错
- [ ] 玩家在起飞区(position 0)时点击"定位玩家"，确认滚动正确


Made with [Cursor](https://cursor.com)