### PR TITLE
feat: 多设备同步 — 手机当手柄（升温局）

### DIFF
--- a/controller.html
+++ b/controller.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="zh-CN" class="dark-mode">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <title>飞行棋 - 手柄</title>
+    <meta name="description" content="飞行棋多设备控制器" />
+    <meta name="theme-color" content="#0a0a1a" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="飞行棋手柄" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/controller/main.ts"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "1.8.1",
+      "version": "1.9.0",
       "dependencies": {
         "@lucide/vue": "^1.24.0",
         "@primevue/themes": "^4.3.6",
@@ -14,6 +14,7 @@
         "fflate": "^0.8.2",
         "file-saver": "^2.0.5",
         "jsqr": "^1.4.0",
+        "peerjs": "^1.5.5",
         "primeicons": "^7.0.0",
         "primevue": "^4.3.6",
         "qrcode": "^1.5.4",
@@ -2392,6 +2393,15 @@
       "license": "ISC",
       "peerDependencies": {
         "vue": ">=3.0.1"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7369,6 +7379,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/peerjs": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/peerjs/-/peerjs-1.5.5.tgz",
+      "integrity": "sha512-viMUCPDL6CSfOu0ZqVcFqbWRXNHIbv2lPqNbrBIjbFYrflebOjItJ4hPfhjnuUCstqciHVu9vVJ7jFqqKi/EuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@msgpack/msgpack": "^2.8.0",
+        "eventemitter3": "^4.0.7",
+        "peerjs-js-binarypack": "^2.1.0",
+        "webrtc-adapter": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/peer"
+      }
+    },
+    "node_modules/peerjs-js-binarypack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-2.1.0.tgz",
+      "integrity": "sha512-YIwCC+pTzp3Bi8jPI9UFKO0t0SLo6xALnHkiNt/iUFmUUZG0fEEmEyFKvjsDKweiFitzHRyhuh6NvyJZ4nNxMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/peer"
+      }
+    },
+    "node_modules/peerjs/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -8055,6 +8103,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -9663,6 +9717,19 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+      "integrity": "sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "fflate": "^0.8.2",
     "file-saver": "^2.0.5",
     "jsqr": "^1.4.0",
+    "peerjs": "^1.5.5",
     "primeicons": "^7.0.0",
     "primevue": "^4.3.6",
     "qrcode": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -88,6 +88,7 @@
   import { usePunishmentConfigNormalizer } from './composables/usePunishmentConfigNormalizer'
   import { useImportFeedbackDialog } from './composables/useImportFeedbackDialog'
   import { usePartyMode } from './composables/usePartyMode'
+  import { useMultiDeviceHost } from './composables/useMultiDeviceHost'
   import { type GameMode } from './config/modes'
   import {
     createPartyPunishmentChoices,
@@ -1318,6 +1319,7 @@
     pendingPartyLanding.value = null
     partyTieCandidates.value = []
     activeMode.value = null
+    multiDevice.stopHost()
 
     // 清除惩罚组合确认状态
     punishmentCombinations.value = []
@@ -1452,11 +1454,30 @@
       partyMode.session.value?.reaction?.status === 'awaiting_roll'
     ) {
       const resolvedSession = partyMode.resolveRoll(gameState.diceValue)
-      if (resolvedSession.reaction?.status === 'awaiting_decision') return
+      if (resolvedSession.reaction?.status === 'awaiting_decision') {
+        const reactorIdx = resolvedSession.reaction.reactorPlayerIndex
+        if (multiDevice.isRemotePlayer(reactorIdx)) {
+          multiDevice.requestAction(reactorIdx, {
+            type: 'reaction_decision',
+            rolledValue: resolvedSession.reaction.rolledValue!,
+            timeoutSeconds: 5,
+          })
+        }
+        return
+      }
       gameState.diceValue = resolvedSession.reaction?.finalDiceValue ?? gameState.diceValue
     }
 
     if (isPartyGame.value && !isReroll) {
+      const currentIdx = gameState.currentPlayerIndex
+      if (multiDevice.isRemotePlayer(currentIdx)) {
+        multiDevice.requestAction(currentIdx, {
+          type: 'dice_decision',
+          diceValue: gameState.diceValue ?? 1,
+          canReroll: canCurrentPlayerReroll.value,
+          timeoutSeconds: 5,
+        })
+      }
       partyDiceDecisionVisible.value = true
       return
     }
@@ -1502,7 +1523,15 @@
 
     if (isPartyGame.value) {
       const partyTurn = partyMode.beginTurn(currentPlayerIndex)
-      if (partyTurn.reaction?.status === 'awaiting_prediction') return
+      if (partyTurn.reaction?.status === 'awaiting_prediction') {
+        if (multiDevice.isRemotePlayer(partyTurn.reaction.reactorPlayerIndex)) {
+          multiDevice.requestAction(partyTurn.reaction.reactorPlayerIndex, {
+            type: 'predict',
+            timeoutSeconds: 5,
+          })
+        }
+        return
+      }
     }
 
     await performDiceRoll()
@@ -2071,11 +2100,12 @@
   }
 
   // 修改IntroPage组件的调用，使其能够接收玩家配置信息并传递给startGame方法
-  const handleIntroStart = (playerConfig: {
+  const handleIntroStart = async (playerConfig: {
     count: number
     names: string[]
     mode: GameMode
     scenePreset?: PartyScenePreset | 'default'
+    multiDevice?: boolean
   }) => {
     selectedMode.value = playerConfig.mode
     saveGameMode(playerConfig.mode)
@@ -2088,6 +2118,13 @@
         mode: 'party',
         scenePreset: playerConfig.scenePreset ?? 'default',
       })
+      if (playerConfig.multiDevice) {
+        try {
+          await multiDevice.startHost()
+        } catch (e) {
+          devLog('多设备模式启动失败:', e)
+        }
+      }
       return
     }
 
@@ -2281,6 +2318,58 @@
     gameState.gameStatus = 'waiting'
     await continueAfterMove()
   }
+
+  // --- 多设备同步（手柄模式） ---
+  const multiDevice = useMultiDeviceHost({
+    gameState,
+    partySession: partySession,
+    lastEffect,
+    gameStarted,
+    gameFinished,
+    isPartyGame,
+    sessionPaused,
+    overlayState: () => ({
+      currentPunishment: Boolean(currentPunishment.value),
+      showTakeoffPunishment: showTakeoffPunishmentDisplay.value,
+      showTrap: showTrapDisplay.value,
+      showTrapChoice: showTrapChoiceDisplay.value,
+      showQA: showQADisplay.value,
+      showDare: showDareDisplay.value,
+      showBounce: showBounceDisplay.value,
+      showEffect: gameState.gameStatus === 'showing_effect',
+      showTakeoffRelief: showTakeoffReliefDisplay.value,
+    }),
+    actions: {
+      handleDiceRoll,
+      performDiceRoll,
+      handlePartyReactionPrediction,
+      handlePartyReactionDecision,
+      handlePartyReroll,
+      continuePartyMove,
+      resolvePartyPunishmentChoice,
+      confirmPunishment,
+      confirmEffect,
+      handleTrapDismiss: () => confirmTrap(),
+      handleTrapChoiceDismiss: () => confirmTrap(),
+      handleQADismiss: () => {
+        showQADisplay.value = false
+        currentQAQuestion.value = ''
+        pendingRuleResolution.value = null
+        continueAfterMove()
+      },
+      handleDareDismiss: () => {
+        showDareDisplay.value = false
+        currentDareInstruction.value = ''
+        pendingRuleResolution.value = null
+        continueAfterMove()
+      },
+      handleBounceConfirm: () => confirmBounce(),
+      handleTakeoffPunishmentDismiss: handleTakeoffPunishmentDisplay,
+      handleTakeoffReliefDismiss: () => confirmTakeoffRelief(),
+    },
+  })
+
+  const multiDeviceEnabled = computed(() => multiDevice.enabled.value)
 
   // 用户指引
   const startGuide = () => {
@@ -2957,11 +3046,18 @@
             :total-cells="gameState.board.length"
             :party-act-label="isPartyGame ? partyActLabel : undefined"
             :party-round="isPartyGame ? partySession?.roundNumber : undefined"
-            :tokens-remaining="isPartyGame ? partySession?.tokensRemaining : undefined"
+            :tokens-remaining="isPartyGame && !multiDeviceEnabled ? partySession?.tokensRemaining : undefined"
             class="header-players"
           />
 
           <div class="header-actions">
+            <span
+              v-if="multiDeviceEnabled"
+              class="multi-device-badge"
+              :title="`多设备模式 - ${multiDevice.getConnectedPlayerCount()}/${gameState.players.length} 已连接`"
+            >
+              📱 {{ multiDevice.getConnectedPlayerCount() }}/{{ gameState.players.length }}
+            </span>
             <PButton
               v-if="!gameStarted"
               label="开始游戏"
@@ -3157,6 +3253,7 @@
     <ChainPunishmentRoll :visible="showChainPunishmentRoll" @result="handleChainRollResult" />
 
     <PartyReactionOverlay
+      v-if="!multiDeviceEnabled || !multiDevice.isRemotePlayer(partyReaction?.reactorPlayerIndex ?? -1)"
       :reaction="partyReaction"
       :players="gameState.players"
       :paused="sessionPaused"
@@ -3165,6 +3262,7 @@
     />
 
     <PartyDiceDecision
+      v-if="!multiDeviceEnabled || !multiDevice.isRemotePlayer(gameState.currentPlayerIndex)"
       :visible="partyDiceDecisionVisible"
       :player-name="gameState.players[gameState.currentPlayerIndex]?.name ?? '当前玩家'"
       :dice-value="gameState.diceValue ?? 1"
@@ -3176,6 +3274,7 @@
     />
 
     <PartyPunishmentChoice
+      v-if="!multiDeviceEnabled || !multiDevice.isRemotePlayer(gameState.currentPlayerIndex)"
       :visible="partyPunishmentChoices.length === 2"
       :choices="partyPunishmentChoices"
       :tokens-remaining="currentPartyTokens"
@@ -3207,6 +3306,33 @@
       :failed-count="failedTakeoffCountForMessage"
       @confirm="confirmTakeoffRelief"
     />
+
+    <!-- 多设备连接面板 -->
+    <div
+      v-if="multiDeviceEnabled && multiDevice.roomInfo.value && !multiDevice.allPlayersConnected.value"
+      class="multi-device-lobby"
+    >
+      <div class="multi-device-lobby-card">
+        <h2>等待玩家连接</h2>
+        <p class="room-code-label">房间码</p>
+        <p class="room-code">{{ multiDevice.roomInfo.value.roomId }}</p>
+        <p class="room-url">{{ multiDevice.roomInfo.value.gameUrl }}</p>
+        <div class="connection-list">
+          <div
+            v-for="player in gameState.players"
+            :key="player.id"
+            class="connection-item"
+            :class="{ connected: multiDevice.connectedPlayers.value.some(c => c.playerIndex === player.id - 1 && c.status === 'connected') }"
+          >
+            <span class="player-dot" :style="{ background: player.color }" />
+            <span>{{ player.name }}</span>
+            <span class="connection-status-icon">
+              {{ multiDevice.connectedPlayers.value.some(c => c.playerIndex === player.id - 1 && c.status === 'connected') ? '✓' : '...' }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
 
     <button
       v-if="canPauseSession && !sessionPaused"
@@ -4039,5 +4165,102 @@
       min-width: 180px;
       padding: 0.75rem;
     }
+  }
+
+  /* --- Multi-device lobby --- */
+  .multi-device-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    background: rgba(225, 194, 127, 0.15);
+    color: var(--color-accent, #e1c27f);
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+
+  .multi-device-lobby {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.75);
+    backdrop-filter: blur(4px);
+    padding: 1rem;
+  }
+
+  .multi-device-lobby-card {
+    background: var(--color-surface, #1a1a2e);
+    border-radius: var(--radius-lg, 12px);
+    padding: 2rem;
+    text-align: center;
+    max-width: 400px;
+    width: 100%;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  }
+
+  .multi-device-lobby-card h2 {
+    margin: 0 0 1.5rem;
+    font-size: 1.3rem;
+  }
+
+  .room-code-label {
+    font-size: 0.85rem;
+    color: var(--color-text-muted, #8a8780);
+    margin-bottom: 0.25rem;
+  }
+
+  .room-code {
+    font-size: 2.5rem;
+    font-weight: 800;
+    letter-spacing: 0.3em;
+    color: var(--color-accent, #e1c27f);
+    margin-bottom: 0.5rem;
+  }
+
+  .room-url {
+    font-size: 0.7rem;
+    color: var(--color-text-muted, #8a8780);
+    word-break: break-all;
+    margin-bottom: 1.5rem;
+  }
+
+  .connection-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .connection-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.04);
+    transition: all 0.3s;
+  }
+
+  .connection-item.connected {
+    background: rgba(52, 211, 153, 0.1);
+  }
+
+  .connection-item .player-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .connection-status-icon {
+    margin-left: auto;
+    font-size: 0.9rem;
+  }
+
+  .connection-item.connected .connection-status-icon {
+    color: #34d399;
   }
 </style>

--- a/src/components/IntroPage.vue
+++ b/src/components/IntroPage.vue
@@ -35,6 +35,7 @@
         names: string[]
         mode: GameMode
         scenePreset?: PartyScenePreset | 'default'
+        multiDevice?: boolean
       }
     ): void
     (e: 'mode-selected', mode: GameMode): void
@@ -48,6 +49,7 @@
   const playerNames = ref<string[]>(['玩家1', '玩家2'])
   const selectedMode = ref<GameMode>(props.initialMode)
   const selectedScenePreset = ref<PartyScenePreset | 'default'>('default')
+  const multiDeviceMode = ref(false)
   const canStart = computed(
     () => selectedMode.value === 'classic' || playerCount.value >= PARTY_MIN_PLAYERS
   )
@@ -108,6 +110,7 @@
       names: playerNames.value,
       mode: selectedMode.value,
       scenePreset: selectedMode.value === 'party' ? selectedScenePreset.value : undefined,
+      multiDevice: selectedMode.value === 'party' ? multiDeviceMode.value : undefined,
     })
   }
 
@@ -352,6 +355,18 @@
           :selected="selectedScenePreset"
           @select="selectScenePreset"
         />
+
+        <div v-if="selectedMode === 'party'" class="multi-device-toggle">
+          <button
+            class="mode-card"
+            :class="{ 'mode-card--active': multiDeviceMode }"
+            @click="multiDeviceMode = !multiDeviceMode"
+          >
+            <span class="mode-card__icon">📱</span>
+            <span class="mode-card__title">多设备模式</span>
+            <span class="mode-card__desc">每人用自己的手机操作</span>
+          </button>
+        </div>
       </section>
 
       <!-- 玩家设置区域 -->
@@ -1824,5 +1839,20 @@
       padding: 0.6rem 1.2rem;
       font-size: 0.85rem;
     }
+  }
+
+  .multi-device-toggle {
+    margin-top: 1rem;
+  }
+
+  .multi-device-toggle .mode-card {
+    width: 100%;
+    max-width: 320px;
+    margin: 0 auto;
+  }
+
+  .multi-device-toggle .mode-card__desc {
+    font-size: 0.8rem;
+    opacity: 0.6;
   }
 </style>

--- a/src/composables/useMultiDeviceController.ts
+++ b/src/composables/useMultiDeviceController.ts
@@ -1,0 +1,112 @@
+import { ref, computed, onUnmounted } from 'vue'
+import { ControllerNetworkManager } from '../services/networkService'
+import type {
+  ConnectionStatus,
+  HostMessage,
+  ControllerMessage,
+  PlayerView,
+  PublicPlayerInfo,
+} from '../types/network'
+import { devLog } from '../utils/logger'
+
+export function useMultiDeviceController() {
+  const status = ref<ConnectionStatus>('disconnected')
+  const playerView = ref<PlayerView | null>(null)
+  const assignedPlayerIndex = ref<number | null>(null)
+  const assignedPlayer = ref<PublicPlayerInfo | null>(null)
+  const errorMessage = ref<string | null>(null)
+  const gameEnded = ref(false)
+  const winnerName = ref<string | null>(null)
+
+  let network: ControllerNetworkManager | null = null
+
+  const isConnected = computed(() => status.value === 'connected')
+  const isReady = computed(
+    () => isConnected.value && assignedPlayerIndex.value !== null && playerView.value !== null
+  )
+
+  function handleMessage(msg: HostMessage): void {
+    switch (msg.type) {
+      case 'player_assigned':
+        assignedPlayerIndex.value = msg.playerIndex
+        assignedPlayer.value = msg.player
+        devLog('[Controller] Assigned as player', msg.playerIndex, msg.player.name)
+        break
+      case 'state_update':
+        playerView.value = msg.view
+        break
+      case 'game_ended':
+        gameEnded.value = true
+        winnerName.value = msg.winnerName
+        break
+      case 'room_closed':
+        errorMessage.value = '房间已关闭'
+        playerView.value = null
+        assignedPlayerIndex.value = null
+        break
+      case 'error':
+        errorMessage.value = msg.message
+        break
+    }
+  }
+
+  async function connect(roomId: string): Promise<void> {
+    errorMessage.value = null
+    gameEnded.value = false
+    winnerName.value = null
+
+    network = new ControllerNetworkManager({
+      onConnected: () => {
+        status.value = 'connected'
+        network?.send({ type: 'join' })
+      },
+      onDisconnected: () => {
+        status.value = 'disconnected'
+      },
+      onMessage: handleMessage,
+    })
+
+    network.onStatusChange((s) => {
+      status.value = s
+    })
+
+    try {
+      await network.connect(roomId)
+    } catch {
+      errorMessage.value = '无法连接到房间，请检查房间码是否正确'
+      status.value = 'disconnected'
+    }
+  }
+
+  function send(message: ControllerMessage): void {
+    network?.send(message)
+  }
+
+  function disconnect(): void {
+    network?.close()
+    network = null
+    status.value = 'disconnected'
+    playerView.value = null
+    assignedPlayerIndex.value = null
+    assignedPlayer.value = null
+  }
+
+  onUnmounted(() => {
+    disconnect()
+  })
+
+  return {
+    status,
+    playerView,
+    assignedPlayerIndex,
+    assignedPlayer,
+    errorMessage,
+    gameEnded,
+    winnerName,
+    isConnected,
+    isReady,
+    connect,
+    send,
+    disconnect,
+  }
+}

--- a/src/composables/useMultiDeviceHost.ts
+++ b/src/composables/useMultiDeviceHost.ts
@@ -1,0 +1,359 @@
+import { ref, computed, watch, onUnmounted, type Ref, type ComputedRef } from 'vue'
+import { HostNetworkManager } from '../services/networkService'
+import { projectPlayerView } from '../services/syncProtocol'
+import type {
+  ConnectionStatus,
+  ConnectedPlayer,
+  ControllerMessage,
+  RequiredAction,
+  RoomInfo,
+} from '../types/network'
+import type { GameState } from '../types/game'
+import type { PartySession } from '../services/partyMode'
+import { devLog } from '../utils/logger'
+
+export interface MultiDeviceHostActions {
+  handleDiceRoll: () => Promise<void>
+  performDiceRoll: (isReroll?: boolean) => Promise<void>
+  handlePartyReactionPrediction: (prediction: 'low' | 'high') => Promise<void>
+  handlePartyReactionDecision: (decision: 'keep' | 'mirror') => Promise<void>
+  handlePartyReroll: () => Promise<void>
+  continuePartyMove: () => Promise<void>
+  resolvePartyPunishmentChoice: (selectedIndex?: number) => Promise<void>
+  confirmPunishment: () => Promise<void>
+  confirmEffect: () => Promise<void>
+  handleTrapDismiss: () => void
+  handleTrapChoiceDismiss: () => void
+  handleQADismiss: () => void
+  handleDareDismiss: () => void
+  handleBounceConfirm: () => void
+  handleTakeoffPunishmentDismiss: () => void
+  handleTakeoffReliefDismiss: () => void
+}
+
+export interface MultiDeviceOverlayState {
+  currentPunishment: boolean
+  showTakeoffPunishment: boolean
+  showTrap: boolean
+  showTrapChoice: boolean
+  showQA: boolean
+  showDare: boolean
+  showBounce: boolean
+  showEffect: boolean
+  showTakeoffRelief: boolean
+}
+
+export interface MultiDeviceHostDeps {
+  gameState: GameState
+  partySession: ComputedRef<PartySession | null>
+  lastEffect: Ref<string>
+  gameStarted: Ref<boolean>
+  gameFinished: Ref<boolean>
+  isPartyGame: ComputedRef<boolean>
+  sessionPaused: Ref<boolean>
+  overlayState: () => MultiDeviceOverlayState
+  actions: MultiDeviceHostActions
+}
+
+export function useMultiDeviceHost(deps: MultiDeviceHostDeps) {
+  const enabled = ref(false)
+  const hostStatus = ref<ConnectionStatus>('disconnected')
+  const roomInfo = ref<RoomInfo | null>(null)
+  const connectedPlayers = ref<ConnectedPlayer[]>([])
+
+  const peerToPlayerIndex = new Map<string, number>()
+  const playerToPeer = new Map<number, string>()
+  const pendingActions = ref<Map<number, RequiredAction>>(new Map())
+
+  let network: HostNetworkManager | null = null
+  let broadcastTimer: ReturnType<typeof setInterval> | null = null
+
+  const isActive = computed(() => enabled.value && hostStatus.value === 'connected')
+  const allPlayersConnected = computed(() => {
+    if (!enabled.value) return false
+    const needed = deps.gameState.players.length
+    return connectedPlayers.value.filter((p) => p.status === 'connected').length >= needed
+  })
+
+  function isRemotePlayer(playerIndex: number): boolean {
+    return enabled.value && playerToPeer.has(playerIndex)
+  }
+
+  function getConnectedPlayerCount(): number {
+    return connectedPlayers.value.filter((p) => p.status === 'connected').length
+  }
+
+  function sendPlayerAssignment(peerId: string, playerIndex: number): void {
+    const player = deps.gameState.players[playerIndex]
+    if (!player) return
+    network?.sendTo(peerId, {
+      type: 'player_assigned',
+      playerIndex,
+      player: {
+        id: player.id,
+        name: player.name,
+        color: player.color,
+        position: player.position,
+        hasTakenOff: player.hasTakenOff ?? false,
+        isWinner: player.isWinner,
+      },
+    })
+  }
+
+  function assignPlayerIndex(peerId: string): number {
+    const existingIndex = peerToPlayerIndex.get(peerId)
+    if (existingIndex !== undefined) {
+      sendPlayerAssignment(peerId, existingIndex)
+      return existingIndex
+    }
+
+    // Check if any previously assigned player slot has a disconnected peer
+    // (reconnect scenario with new peerId)
+    for (const [oldPeerId, idx] of peerToPlayerIndex) {
+      if (!network?.isConnected(oldPeerId)) {
+        peerToPlayerIndex.delete(oldPeerId)
+        peerToPlayerIndex.set(peerId, idx)
+        playerToPeer.set(idx, peerId)
+        updateConnectedPlayers()
+        sendPlayerAssignment(peerId, idx)
+        return idx
+      }
+    }
+
+    const takenIndices = new Set(peerToPlayerIndex.values())
+    for (let i = 0; i < deps.gameState.players.length; i++) {
+      if (!takenIndices.has(i)) {
+        peerToPlayerIndex.set(peerId, i)
+        playerToPeer.set(i, peerId)
+        updateConnectedPlayers()
+        sendPlayerAssignment(peerId, i)
+        return i
+      }
+    }
+    network?.sendTo(peerId, { type: 'error', message: '房间已满' })
+    return -1
+  }
+
+  function updateConnectedPlayers(): void {
+    connectedPlayers.value = [...peerToPlayerIndex.entries()].map(([peerId, playerIndex]) => ({
+      playerIndex,
+      peerId,
+      status: network?.isConnected(peerId) ? 'connected' : 'disconnected',
+    }))
+  }
+
+  function handlePlayerMessage(peerId: string, msg: ControllerMessage): void {
+    const playerIndex = peerToPlayerIndex.get(peerId)
+
+    if (msg.type === 'join') {
+      assignPlayerIndex(peerId)
+      broadcastStateToAll()
+      return
+    }
+
+    if (playerIndex === undefined) {
+      devLog('[MultiDeviceHost] Message from unassigned peer:', peerId)
+      return
+    }
+
+    routeControllerAction(playerIndex, msg)
+  }
+
+  function routeControllerAction(playerIndex: number, msg: ControllerMessage): void {
+    switch (msg.type) {
+      case 'roll_dice':
+        if (deps.gameState.currentPlayerIndex === playerIndex) {
+          deps.actions.handleDiceRoll()
+        }
+        break
+      case 'predict':
+        deps.actions.handlePartyReactionPrediction(msg.prediction)
+        break
+      case 'reaction_decision':
+        deps.actions.handlePartyReactionDecision(msg.decision)
+        break
+      case 'reroll':
+        deps.actions.handlePartyReroll()
+        break
+      case 'continue_move':
+        deps.actions.continuePartyMove()
+        break
+      case 'select_punishment':
+        deps.actions.resolvePartyPunishmentChoice(msg.index)
+        break
+      case 'skip_punishment_choice':
+        deps.actions.resolvePartyPunishmentChoice()
+        break
+      case 'acknowledge':
+        handleRemoteAcknowledge(playerIndex)
+        break
+      case 'tiebreak_roll':
+        break
+      default:
+        devLog('[MultiDeviceHost] Unknown message type:', msg)
+    }
+  }
+
+  function handleRemoteAcknowledge(playerIndex: number): void {
+    if (deps.gameState.currentPlayerIndex !== playerIndex) return
+    const overlays = deps.overlayState()
+
+    if (overlays.currentPunishment) {
+      deps.actions.confirmPunishment()
+    } else if (overlays.showTakeoffPunishment) {
+      deps.actions.handleTakeoffPunishmentDismiss()
+    } else if (overlays.showTrap) {
+      deps.actions.handleTrapDismiss()
+    } else if (overlays.showTrapChoice) {
+      deps.actions.handleTrapChoiceDismiss()
+    } else if (overlays.showQA) {
+      deps.actions.handleQADismiss()
+    } else if (overlays.showDare) {
+      deps.actions.handleDareDismiss()
+    } else if (overlays.showBounce) {
+      deps.actions.handleBounceConfirm()
+    } else if (overlays.showEffect) {
+      deps.actions.confirmEffect()
+    } else if (overlays.showTakeoffRelief) {
+      deps.actions.handleTakeoffReliefDismiss()
+    }
+  }
+
+  function broadcastStateToAll(): void {
+    if (!network || !enabled.value) return
+
+    for (const [peerId, playerIndex] of peerToPlayerIndex) {
+      if (!network.isConnected(peerId)) continue
+
+      const action = pendingActions.value.get(playerIndex) ?? null
+      const view = projectPlayerView(
+        playerIndex,
+        deps.gameState,
+        deps.partySession.value,
+        action,
+        deps.lastEffect.value || null
+      )
+      network.sendTo(peerId, { type: 'state_update', view })
+    }
+  }
+
+  function requestAction(playerIndex: number, action: RequiredAction): void {
+    pendingActions.value.set(playerIndex, action)
+    broadcastStateToAll()
+  }
+
+  function clearPendingAction(playerIndex: number): void {
+    pendingActions.value.delete(playerIndex)
+  }
+
+  async function startHost(): Promise<RoomInfo> {
+    enabled.value = true
+
+    network = new HostNetworkManager({
+      onPlayerConnected: (peerId) => {
+        devLog('[MultiDeviceHost] Player connected:', peerId)
+        updateConnectedPlayers()
+      },
+      onPlayerDisconnected: (peerId) => {
+        devLog('[MultiDeviceHost] Player disconnected:', peerId)
+        updateConnectedPlayers()
+      },
+      onPlayerMessage: handlePlayerMessage,
+    })
+
+    network.onStatusChange((status) => {
+      hostStatus.value = status
+    })
+
+    const roomId = await network.open()
+    const gameUrl = `${window.location.origin}${window.location.pathname.replace(/index\.html$/, '')}controller.html?room=${roomId}`
+
+    roomInfo.value = {
+      roomId,
+      hostPeerId: network.hostPeerId,
+      gameUrl,
+    }
+
+    startBroadcastLoop()
+    return roomInfo.value
+  }
+
+  function startBroadcastLoop(): void {
+    if (broadcastTimer) clearInterval(broadcastTimer)
+    broadcastTimer = setInterval(() => {
+      if (deps.gameStarted.value && !deps.gameFinished.value) {
+        broadcastStateToAll()
+      }
+    }, 2000)
+  }
+
+  function stopHost(): void {
+    if (broadcastTimer) {
+      clearInterval(broadcastTimer)
+      broadcastTimer = null
+    }
+    network?.broadcast({ type: 'room_closed' })
+    network?.close()
+    network = null
+    enabled.value = false
+    hostStatus.value = 'disconnected'
+    roomInfo.value = null
+    connectedPlayers.value = []
+    peerToPlayerIndex.clear()
+    playerToPeer.clear()
+    pendingActions.value.clear()
+  }
+
+  watch(
+    () => [
+      deps.gameState.gameStatus,
+      deps.gameState.currentPlayerIndex,
+      deps.gameState.diceValue,
+      deps.gameState.players.map((p) => p.position),
+      deps.partySession.value?.reaction?.status,
+    ],
+    () => {
+      if (enabled.value) broadcastStateToAll()
+    },
+    { deep: true }
+  )
+
+  watch(
+    () => deps.gameFinished.value,
+    (finished) => {
+      if (finished && enabled.value && deps.gameState.winner) {
+        network?.broadcast({
+          type: 'game_ended',
+          winnerName: deps.gameState.winner.name,
+        })
+      }
+    }
+  )
+
+  watch(
+    () => deps.sessionPaused.value,
+    () => {
+      if (enabled.value) broadcastStateToAll()
+    }
+  )
+
+  onUnmounted(() => {
+    stopHost()
+  })
+
+  return {
+    enabled,
+    isActive,
+    hostStatus,
+    roomInfo,
+    connectedPlayers,
+    allPlayersConnected,
+    isRemotePlayer,
+    getConnectedPlayerCount,
+    requestAction,
+    clearPendingAction,
+    broadcastStateToAll,
+    startHost,
+    stopHost,
+  }
+}

--- a/src/controller/App.vue
+++ b/src/controller/App.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useMultiDeviceController } from '../composables/useMultiDeviceController'
+import type { ControllerMessage } from '../types/network'
+import ConnectionScreen from './components/ConnectionScreen.vue'
+import ControllerMain from './components/ControllerMain.vue'
+import GameEndScreen from './components/GameEndScreen.vue'
+
+const controller = useMultiDeviceController()
+
+function sendAction(action: { type: string; [key: string]: unknown }): void {
+  controller.send(action as ControllerMessage)
+}
+
+const showGame = computed(
+  () => controller.isReady.value && !controller.gameEnded.value
+)
+
+onMounted(() => {
+  const params = new URLSearchParams(window.location.search)
+  const roomParam = params.get('room')
+  if (roomParam) {
+    controller.connect(roomParam)
+  }
+})
+</script>
+
+<template>
+  <div class="controller-root">
+    <ConnectionScreen
+      v-if="!controller.isReady.value && !controller.gameEnded.value"
+      :status="controller.status.value"
+      :error="controller.errorMessage.value"
+      :room-id="controller.status.value === 'connected' ? '' : ''"
+      @connect="controller.connect"
+    />
+    <ControllerMain
+      v-else-if="showGame"
+      :view="controller.playerView.value!"
+      @action="sendAction"
+    />
+    <GameEndScreen
+      v-else-if="controller.gameEnded.value"
+      :winner-name="controller.winnerName.value"
+      :my-name="controller.assignedPlayer.value?.name"
+    />
+  </div>
+</template>
+
+<style scoped>
+.controller-root {
+  min-height: 100vh;
+  min-height: 100dvh;
+  background: var(--color-background, #0a0a1a);
+  color: var(--color-text, #e8e6e3);
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/src/controller/components/ActionPanel.vue
+++ b/src/controller/components/ActionPanel.vue
@@ -1,0 +1,172 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { PlayerView, RequiredAction } from '../../types/network'
+
+const props = defineProps<{
+  view: PlayerView
+}>()
+
+const emit = defineEmits<{
+  action: [payload: { type: string; [key: string]: unknown }]
+}>()
+
+const pending = computed<RequiredAction | null>(() => props.view.pendingAction)
+
+function send(payload: { type: string; [key: string]: unknown }): void {
+  if (navigator.vibrate) navigator.vibrate(30)
+  emit('action', payload)
+}
+</script>
+
+<template>
+  <div v-if="pending" class="action-panel">
+    <!-- Prediction: low / high -->
+    <div v-if="pending.type === 'predict'" class="action-group">
+      <p class="action-prompt">预测骰子范围</p>
+      <div class="action-buttons">
+        <button class="btn btn-secondary action-btn" @click="send({ type: 'predict', prediction: 'low' })">
+          ⬇️ 小 (1-3)
+        </button>
+        <button class="btn btn-secondary action-btn" @click="send({ type: 'predict', prediction: 'high' })">
+          ⬆️ 大 (4-6)
+        </button>
+      </div>
+    </div>
+
+    <!-- Reaction decision: keep / mirror -->
+    <div v-else-if="pending.type === 'reaction_decision'" class="action-group">
+      <p class="action-prompt">预测成功！骰子点数: {{ pending.rolledValue }}</p>
+      <div class="action-buttons">
+        <button class="btn btn-secondary action-btn" @click="send({ type: 'reaction_decision', decision: 'keep' })">
+          保留 {{ pending.rolledValue }}
+        </button>
+        <button class="btn btn-primary action-btn" @click="send({ type: 'reaction_decision', decision: 'mirror' })">
+          镜像 → {{ 7 - (pending.rolledValue ?? 0) }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Dice decision: continue / reroll -->
+    <div v-else-if="pending.type === 'dice_decision'" class="action-group">
+      <p class="action-prompt">骰子结果: <strong>{{ pending.diceValue }}</strong></p>
+      <div class="action-buttons">
+        <button class="btn btn-primary action-btn" @click="send({ type: 'continue_move' })">
+          继续移动
+        </button>
+        <button
+          v-if="pending.canReroll"
+          class="btn btn-secondary action-btn"
+          @click="send({ type: 'reroll' })"
+        >
+          🎫 重掷
+        </button>
+      </div>
+    </div>
+
+    <!-- Punishment choice -->
+    <div v-else-if="pending.type === 'punishment_choice'" class="action-group">
+      <p class="action-prompt">选择惩罚（消耗 1 筹码）</p>
+      <div class="action-buttons vertical">
+        <button class="btn btn-secondary action-btn" @click="send({ type: 'select_punishment', index: 0 })">
+          {{ pending.choiceA }}
+        </button>
+        <button class="btn btn-secondary action-btn" @click="send({ type: 'select_punishment', index: 1 })">
+          {{ pending.choiceB }}
+        </button>
+        <button class="btn-ghost" @click="send({ type: 'skip_punishment_choice' })">
+          跳过（不消耗筹码）
+        </button>
+      </div>
+    </div>
+
+    <!-- Acknowledge -->
+    <div v-else-if="pending.type === 'acknowledge'" class="action-group">
+      <p class="action-prompt">{{ pending.message }}</p>
+      <button class="btn btn-primary action-btn" @click="send({ type: 'acknowledge' })">
+        确认
+      </button>
+    </div>
+
+    <!-- Tiebreak roll -->
+    <div v-else-if="pending.type === 'tiebreak_roll'" class="action-group">
+      <p class="action-prompt">并列决胜</p>
+      <button class="btn btn-primary action-btn dice-btn" @click="send({ type: 'tiebreak_roll' })">
+        🎲 掷骰子
+      </button>
+    </div>
+
+    <!-- Roll dice (explicit action required) -->
+    <div v-else-if="pending.type === 'roll_dice'" class="action-group">
+      <button class="btn btn-primary action-btn dice-btn" @click="send({ type: 'roll_dice' })">
+        🎲 掷骰子
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.action-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1rem 0;
+  flex: 1;
+}
+
+.action-group {
+  width: 100%;
+  text-align: center;
+}
+
+.action-prompt {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.action-buttons.vertical {
+  flex-direction: column;
+  align-items: center;
+}
+
+.action-btn {
+  min-width: 120px;
+}
+
+.action-buttons.vertical .action-btn {
+  width: 100%;
+  max-width: 300px;
+}
+
+.dice-btn {
+  width: 100%;
+  max-width: 280px;
+  padding: 1.25rem 2rem;
+  font-size: 1.25rem;
+}
+
+.btn-ghost {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--color-text-muted, #8a8780);
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-md, 8px);
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 0.2s;
+  width: 100%;
+  max-width: 300px;
+}
+
+.btn-ghost:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+</style>

--- a/src/controller/components/ConnectionScreen.vue
+++ b/src/controller/components/ConnectionScreen.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { ConnectionStatus } from '../../types/network'
+
+defineProps<{
+  status: ConnectionStatus
+  error: string | null
+  roomId: string
+}>()
+
+const emit = defineEmits<{
+  connect: [roomId: string]
+}>()
+
+const inputRoomId = ref('')
+
+function handleConnect(): void {
+  const id = inputRoomId.value.trim().toUpperCase()
+  if (id.length >= 4) {
+    emit('connect', id)
+  }
+}
+</script>
+
+<template>
+  <div class="connection-screen">
+    <div class="connection-card">
+      <div class="logo-area">
+        <span class="logo-icon">🎮</span>
+        <h1>飞行棋手柄</h1>
+      </div>
+
+      <template v-if="status === 'disconnected'">
+        <p class="hint">输入房间码加入游戏</p>
+        <form class="room-form" @submit.prevent="handleConnect">
+          <input
+            v-model="inputRoomId"
+            type="text"
+            class="room-input"
+            placeholder="房间码"
+            maxlength="8"
+            autocomplete="off"
+            autofocus
+          />
+          <button type="submit" class="btn btn-primary connect-btn" :disabled="inputRoomId.trim().length < 4">
+            加入
+          </button>
+        </form>
+        <p v-if="error" class="error-text">{{ error }}</p>
+      </template>
+
+      <template v-else-if="status === 'connecting'">
+        <div class="connecting-indicator">
+          <div class="spinner" />
+          <p>正在连接到房间 {{ roomId }}...</p>
+        </div>
+      </template>
+
+      <template v-else-if="status === 'connected'">
+        <div class="connecting-indicator">
+          <div class="spinner" />
+          <p>已连接，等待分配玩家...</p>
+        </div>
+      </template>
+
+      <template v-else-if="status === 'reconnecting'">
+        <div class="connecting-indicator">
+          <div class="spinner" />
+          <p>连接中断，正在重连...</p>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.connection-screen {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.connection-card {
+  width: 100%;
+  max-width: 360px;
+  text-align: center;
+}
+
+.logo-area {
+  margin-bottom: 2rem;
+}
+
+.logo-icon {
+  font-size: 3rem;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.logo-area h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--color-heading, #f0ece4);
+}
+
+.hint {
+  color: var(--color-text-muted, #8a8780);
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.room-form {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.room-input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-align: center;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-md, 8px);
+  color: var(--color-text, #e8e6e3);
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.room-input:focus {
+  border-color: var(--color-accent, #e1c27f);
+}
+
+.connect-btn {
+  flex-shrink: 0;
+  padding: 0.75rem 1.25rem;
+}
+
+.error-text {
+  color: #ef4444;
+  margin-top: 1rem;
+  font-size: 0.9rem;
+}
+
+.connecting-indicator {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.connecting-indicator p {
+  color: var(--color-text-muted, #8a8780);
+  font-size: 0.95rem;
+}
+
+.spinner {
+  width: 36px;
+  height: 36px;
+  border: 3px solid rgba(255, 255, 255, 0.1);
+  border-top-color: var(--color-accent, #e1c27f);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/src/controller/components/ConnectionStatus.vue
+++ b/src/controller/components/ConnectionStatus.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import type { ConnectionStatus } from '../../types/network'
+
+defineProps<{
+  status: ConnectionStatus
+}>()
+
+const statusMap: Record<ConnectionStatus, { label: string; color: string }> = {
+  connected: { label: '已连接', color: '#34d399' },
+  connecting: { label: '连接中', color: '#fbbf24' },
+  reconnecting: { label: '重连中', color: '#f97316' },
+  disconnected: { label: '未连接', color: '#ef4444' },
+}
+</script>
+
+<template>
+  <div class="connection-status">
+    <span class="status-dot" :style="{ background: statusMap[status].color }" />
+    <span class="status-label">{{ statusMap[status].label }}</span>
+  </div>
+</template>
+
+<style scoped>
+.connection-status {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #8a8780);
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.connection-status:has(.status-dot[style*="34d399"]) .status-dot {
+  animation: status-pulse 2s ease-in-out infinite;
+}
+
+@keyframes status-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+</style>

--- a/src/controller/components/ControllerDice.vue
+++ b/src/controller/components/ControllerDice.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const props = defineProps<{
+  disabled: boolean
+  diceValue: number | null
+}>()
+
+const emit = defineEmits<{
+  roll: []
+}>()
+
+const isAnimating = ref(false)
+
+function handleRoll(): void {
+  if (props.disabled || isAnimating.value) return
+  isAnimating.value = true
+  if (navigator.vibrate) navigator.vibrate([30, 50, 30])
+  emit('roll')
+  setTimeout(() => {
+    isAnimating.value = false
+  }, 1200)
+}
+</script>
+
+<template>
+  <button
+    class="dice-area"
+    :class="{ disabled, animating: isAnimating }"
+    :disabled="disabled"
+    @click="handleRoll"
+  >
+    <div class="dice-face" :class="{ rolling: isAnimating }">
+      <span v-if="diceValue && !isAnimating" class="dice-value">{{ diceValue }}</span>
+      <span v-else class="dice-value">🎲</span>
+    </div>
+    <span class="dice-label">{{ disabled ? '等待中' : '点击掷骰子' }}</span>
+  </button>
+</template>
+
+<style scoped>
+.dice-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s;
+  color: inherit;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.dice-area:not(.disabled):active {
+  transform: scale(0.95);
+}
+
+.dice-area.disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.dice-face {
+  width: 80px;
+  height: 80px;
+  background: linear-gradient(145deg, #2a2a40, #1a1a2e);
+  border: 2px solid rgba(225, 194, 127, 0.3);
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  transition: all 0.3s;
+}
+
+.dice-face.rolling {
+  animation: dice-shake 0.6s ease-in-out 2;
+  border-color: var(--color-accent, #e1c27f);
+  box-shadow: 0 0 20px rgba(225, 194, 127, 0.3);
+}
+
+.dice-value {
+  font-size: 2.5rem;
+  font-weight: 800;
+  color: var(--color-accent, #e1c27f);
+  line-height: 1;
+}
+
+.dice-label {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #8a8780);
+  font-weight: 500;
+}
+
+@keyframes dice-shake {
+  0%, 100% { transform: rotate(0deg) scale(1); }
+  15% { transform: rotate(12deg) scale(1.05); }
+  30% { transform: rotate(-10deg) scale(1.02); }
+  45% { transform: rotate(8deg) scale(1.04); }
+  60% { transform: rotate(-6deg) scale(1.01); }
+  75% { transform: rotate(4deg) scale(1.03); }
+}
+</style>

--- a/src/controller/components/ControllerMain.vue
+++ b/src/controller/components/ControllerMain.vue
@@ -1,0 +1,206 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { PlayerView } from '../../types/network'
+import MiniBoard from './MiniBoard.vue'
+import ActionPanel from './ActionPanel.vue'
+import ControllerDice from './ControllerDice.vue'
+import ConnectionStatus from './ConnectionStatus.vue'
+
+const props = defineProps<{
+  view: PlayerView
+}>()
+
+const emit = defineEmits<{
+  action: [payload: { type: string; [key: string]: unknown }]
+}>()
+
+const myPlayer = computed(() => props.view.allPlayers[props.view.myIndex])
+
+const actLabel = computed(() => {
+  const map: Record<string, string> = { warmup: '暖场', heating: '升温', finale: '终局' }
+  return map[props.view.currentAct] ?? props.view.currentAct
+})
+
+const showDice = computed(
+  () => props.view.isMyTurn && !props.view.pendingAction && props.view.gameStatus === 'waiting'
+)
+
+const hasPendingAction = computed(() => props.view.pendingAction !== null)
+
+function handleAction(payload: { type: string; [key: string]: unknown }): void {
+  emit('action', payload)
+}
+</script>
+
+<template>
+  <div class="controller-main">
+    <header class="controller-header">
+      <div class="player-identity">
+        <span class="player-dot" :style="{ background: myPlayer?.color ?? '#888' }" />
+        <span class="player-name">{{ myPlayer?.name ?? '玩家' }}</span>
+        <ConnectionStatus status="connected" />
+      </div>
+      <div class="game-meta">
+        <span class="act-badge">{{ actLabel }}</span>
+        <span class="round-label">R{{ view.roundNumber }}</span>
+        <span class="token-badge" title="干预筹码">🎫 {{ view.tokensRemaining }}</span>
+      </div>
+    </header>
+
+    <MiniBoard
+      :players="view.allPlayers"
+      :my-index="view.myIndex"
+      :board-size="view.boardSize"
+    />
+
+    <div class="turn-indicator" :class="{ active: view.isMyTurn }">
+      {{ view.isMyTurn ? '你的回合' : '等待其他玩家...' }}
+    </div>
+
+    <!-- Dice area when it's my turn and no pending action -->
+    <div v-if="showDice" class="dice-section">
+      <ControllerDice
+        :disabled="false"
+        :dice-value="view.diceValue"
+        @roll="handleAction({ type: 'roll_dice' })"
+      />
+    </div>
+
+    <!-- Pending action panel -->
+    <ActionPanel
+      v-if="hasPendingAction"
+      :view="view"
+      @action="handleAction"
+    />
+
+    <!-- Dice result display when not my turn -->
+    <div v-if="!view.isMyTurn && view.diceValue" class="dice-result">
+      <span class="dice-result-value">🎲 {{ view.diceValue }}</span>
+    </div>
+
+    <div v-if="view.lastEffect" class="last-effect">
+      {{ view.lastEffect }}
+    </div>
+
+    <!-- Waiting state -->
+    <div v-if="!view.isMyTurn && !hasPendingAction && !view.lastEffect" class="waiting-idle">
+      <ControllerDice
+        :disabled="true"
+        :dice-value="view.diceValue"
+        @roll="() => {}"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.controller-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  gap: 0.5rem;
+  max-width: 480px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.controller-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.player-identity {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.player-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.game-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #8a8780);
+}
+
+.act-badge {
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.08);
+  font-weight: 600;
+}
+
+.token-badge {
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  background: rgba(225, 194, 127, 0.1);
+  font-weight: 600;
+}
+
+.turn-indicator {
+  text-align: center;
+  padding: 0.4rem;
+  border-radius: var(--radius-md, 8px);
+  font-weight: 600;
+  font-size: 0.9rem;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--color-text-muted, #8a8780);
+  transition: all 0.3s;
+}
+
+.turn-indicator.active {
+  background: rgba(225, 194, 127, 0.15);
+  color: var(--color-accent, #e1c27f);
+  animation: pulse-glow 2s ease-in-out infinite;
+}
+
+@keyframes pulse-glow {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(225, 194, 127, 0); }
+  50% { box-shadow: 0 0 12px 2px rgba(225, 194, 127, 0.2); }
+}
+
+.dice-section {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dice-result {
+  text-align: center;
+  padding: 0.75rem;
+}
+
+.dice-result-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.last-effect {
+  text-align: center;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #8a8780);
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: var(--radius-md, 8px);
+}
+
+.waiting-idle {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.5;
+}
+</style>

--- a/src/controller/components/GameEndScreen.vue
+++ b/src/controller/components/GameEndScreen.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+defineProps<{
+  winnerName: string | null
+  myName: string | undefined
+}>()
+</script>
+
+<template>
+  <div class="game-end-screen">
+    <div class="end-card">
+      <div class="trophy">🏆</div>
+      <h1>游戏结束</h1>
+      <p v-if="winnerName" class="winner-text">
+        {{ winnerName === myName ? '恭喜你获胜！' : `${winnerName} 获得了胜利` }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.game-end-screen {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.end-card {
+  text-align: center;
+}
+
+.trophy {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+}
+
+.end-card h1 {
+  font-size: 1.5rem;
+  margin: 0 0 0.75rem;
+}
+
+.winner-text {
+  color: var(--color-accent, #e1c27f);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+</style>

--- a/src/controller/components/MiniBoard.vue
+++ b/src/controller/components/MiniBoard.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { PublicPlayerInfo } from '../../types/network'
+
+const props = defineProps<{
+  players: readonly PublicPlayerInfo[]
+  myIndex: number
+  boardSize: number
+}>()
+
+const playerMarkers = computed(() =>
+  props.players.map((player, index) => ({
+    ...player,
+    index,
+    isMe: index === props.myIndex,
+    percent: props.boardSize > 0 ? (player.position / props.boardSize) * 100 : 0,
+  }))
+)
+</script>
+
+<template>
+  <div class="mini-board">
+    <div class="track">
+      <div class="track-fill" />
+      <div
+        v-for="marker in playerMarkers"
+        :key="marker.id"
+        class="player-marker"
+        :class="{ me: marker.isMe }"
+        :style="{
+          left: `${marker.percent}%`,
+          background: marker.color,
+          zIndex: marker.isMe ? 10 : 1,
+        }"
+        :title="`${marker.name}: ${marker.position}/${boardSize}`"
+      >
+        <span class="marker-label">{{ marker.name[0] }}</span>
+      </div>
+      <div class="track-start">起</div>
+      <div class="track-end">终</div>
+    </div>
+    <div class="position-labels">
+      <span
+        v-for="marker in playerMarkers"
+        :key="marker.id"
+        class="pos-label"
+        :class="{ me: marker.isMe }"
+        :style="{ color: marker.color }"
+      >
+        {{ marker.name }}: {{ marker.position }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.mini-board {
+  padding: 0.75rem 0.5rem;
+}
+
+.track {
+  position: relative;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  margin: 1.5rem 1rem 0.75rem;
+}
+
+.track-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: 4px;
+  background: linear-gradient(90deg, rgba(225, 194, 127, 0.1), rgba(225, 194, 127, 0.05));
+}
+
+.player-marker {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  transition: left 0.5s ease;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+}
+
+.player-marker.me {
+  width: 30px;
+  height: 30px;
+  font-size: 0.8rem;
+  border-color: rgba(255, 255, 255, 0.4);
+  box-shadow: 0 0 8px rgba(225, 194, 127, 0.4);
+}
+
+.track-start,
+.track-end {
+  position: absolute;
+  top: -6px;
+  font-size: 0.65rem;
+  color: var(--color-text-muted, #8a8780);
+}
+
+.track-start {
+  left: -1rem;
+}
+
+.track-end {
+  right: -1rem;
+}
+
+.position-labels {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.pos-label {
+  opacity: 0.6;
+}
+
+.pos-label.me {
+  opacity: 1;
+  font-weight: 600;
+}
+</style>

--- a/src/controller/main.ts
+++ b/src/controller/main.ts
@@ -1,0 +1,32 @@
+import { createApp } from 'vue'
+import ControllerApp from './App.vue'
+import '../assets/main.css'
+
+import PrimeVue from 'primevue/config'
+import Aura from '@primevue/themes/aura'
+import 'primeicons/primeicons.css'
+
+import Button from 'primevue/button'
+import ProgressBar from 'primevue/progressbar'
+import Badge from 'primevue/badge'
+import Tag from 'primevue/tag'
+
+const app = createApp(ControllerApp)
+
+app.use(PrimeVue, {
+  theme: {
+    preset: Aura,
+    options: {
+      prefix: 'p',
+      darkModeSelector: '.dark-mode',
+      cssLayer: false,
+    },
+  },
+})
+
+app.component('PButton', Button)
+app.component('ProgressBar', ProgressBar)
+app.component('Badge', Badge)
+app.component('Tag', Tag)
+
+app.mount('#app')

--- a/src/services/networkService.ts
+++ b/src/services/networkService.ts
@@ -1,0 +1,366 @@
+import Peer, { type DataConnection } from 'peerjs'
+import type { HostMessage, ControllerMessage, ConnectionStatus } from '../types/network'
+import {
+  serializeHostMessage,
+  deserializeHostMessage,
+  serializeControllerMessage,
+  deserializeControllerMessage,
+} from './syncProtocol'
+import { devLog } from '../utils/logger'
+
+const PEER_ID_PREFIX = 'flying-chess-'
+const HEARTBEAT_INTERVAL_MS = 5_000
+const HEARTBEAT_TIMEOUT_MS = 15_000
+
+function generateRoomId(): string {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+  let id = ''
+  const array = new Uint8Array(6)
+  crypto.getRandomValues(array)
+  for (const byte of array) {
+    id += chars[byte % chars.length]
+  }
+  return id
+}
+
+// --- Host-side network manager ---
+
+export interface HostConnectionCallbacks {
+  onPlayerConnected: (peerId: string) => void
+  onPlayerDisconnected: (peerId: string) => void
+  onPlayerMessage: (peerId: string, message: ControllerMessage) => void
+}
+
+export class HostNetworkManager {
+  private peer: Peer | null = null
+  private connections = new Map<string, DataConnection>()
+  private heartbeatTimers = new Map<string, ReturnType<typeof setInterval>>()
+  private lastPong = new Map<string, number>()
+  private callbacks: HostConnectionCallbacks
+  private _roomId = ''
+  private _status: ConnectionStatus = 'disconnected'
+  private statusListeners = new Set<(status: ConnectionStatus) => void>()
+
+  constructor(callbacks: HostConnectionCallbacks) {
+    this.callbacks = callbacks
+  }
+
+  get roomId(): string {
+    return this._roomId
+  }
+
+  get hostPeerId(): string {
+    return this.peer?.id ?? ''
+  }
+
+  get status(): ConnectionStatus {
+    return this._status
+  }
+
+  get connectedPeerIds(): string[] {
+    return [...this.connections.keys()]
+  }
+
+  onStatusChange(listener: (status: ConnectionStatus) => void): () => void {
+    this.statusListeners.add(listener)
+    return () => this.statusListeners.delete(listener)
+  }
+
+  private setStatus(status: ConnectionStatus): void {
+    this._status = status
+    for (const listener of this.statusListeners) listener(status)
+  }
+
+  async open(): Promise<string> {
+    this._roomId = generateRoomId()
+    const peerId = PEER_ID_PREFIX + this._roomId
+
+    return new Promise<string>((resolve, reject) => {
+      this.setStatus('connecting')
+      this.peer = new Peer(peerId)
+
+      this.peer.on('open', (id) => {
+        devLog('[Host] Peer opened with ID:', id)
+        this.setStatus('connected')
+        resolve(this._roomId)
+      })
+
+      this.peer.on('connection', (conn) => {
+        this.handleIncomingConnection(conn)
+      })
+
+      this.peer.on('error', (err) => {
+        devLog('[Host] Peer error:', err)
+        if (this._status === 'connecting') {
+          reject(err)
+        }
+      })
+
+      this.peer.on('disconnected', () => {
+        devLog('[Host] Peer disconnected from signaling, attempting reconnect...')
+        this.setStatus('reconnecting')
+        this.peer?.reconnect()
+      })
+    })
+  }
+
+  private handleIncomingConnection(conn: DataConnection): void {
+    devLog('[Host] Incoming connection from:', conn.peer)
+
+    conn.on('open', () => {
+      this.connections.set(conn.peer, conn)
+      this.startHeartbeat(conn.peer)
+      this.callbacks.onPlayerConnected(conn.peer)
+    })
+
+    conn.on('data', (rawData) => {
+      const data = typeof rawData === 'string' ? rawData : JSON.stringify(rawData)
+      if (data === '"pong"' || data === 'pong') {
+        this.lastPong.set(conn.peer, Date.now())
+        return
+      }
+      try {
+        const msg = deserializeControllerMessage(data)
+        this.callbacks.onPlayerMessage(conn.peer, msg)
+      } catch (e) {
+        devLog('[Host] Failed to parse message:', data, e)
+      }
+    })
+
+    conn.on('close', () => {
+      this.removeConnection(conn.peer)
+    })
+
+    conn.on('error', (err) => {
+      devLog('[Host] Connection error with', conn.peer, err)
+      this.removeConnection(conn.peer)
+    })
+  }
+
+  private startHeartbeat(peerId: string): void {
+    this.lastPong.set(peerId, Date.now())
+    const timer = setInterval(() => {
+      const conn = this.connections.get(peerId)
+      if (!conn || !conn.open) {
+        this.removeConnection(peerId)
+        return
+      }
+      const lastSeen = this.lastPong.get(peerId) ?? 0
+      if (Date.now() - lastSeen > HEARTBEAT_TIMEOUT_MS) {
+        devLog('[Host] Heartbeat timeout for', peerId)
+        this.removeConnection(peerId)
+        return
+      }
+      try {
+        conn.send('"ping"')
+      } catch {
+        this.removeConnection(peerId)
+      }
+    }, HEARTBEAT_INTERVAL_MS)
+    this.heartbeatTimers.set(peerId, timer)
+  }
+
+  private removeConnection(peerId: string): void {
+    const timer = this.heartbeatTimers.get(peerId)
+    if (timer) clearInterval(timer)
+    this.heartbeatTimers.delete(peerId)
+    this.lastPong.delete(peerId)
+
+    const conn = this.connections.get(peerId)
+    if (conn) {
+      this.connections.delete(peerId)
+      try {
+        conn.close()
+      } catch {
+        /* already closed */
+      }
+      this.callbacks.onPlayerDisconnected(peerId)
+    }
+  }
+
+  sendTo(peerId: string, message: HostMessage): void {
+    const conn = this.connections.get(peerId)
+    if (!conn || !conn.open) return
+    try {
+      conn.send(serializeHostMessage(message))
+    } catch (e) {
+      devLog('[Host] Failed to send to', peerId, e)
+    }
+  }
+
+  broadcast(message: HostMessage): void {
+    const data = serializeHostMessage(message)
+    for (const [, conn] of this.connections) {
+      if (conn.open) {
+        try {
+          conn.send(data)
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  }
+
+  isConnected(peerId: string): boolean {
+    const conn = this.connections.get(peerId)
+    return conn?.open === true
+  }
+
+  close(): void {
+    for (const peerId of [...this.connections.keys()]) {
+      this.removeConnection(peerId)
+    }
+    this.peer?.destroy()
+    this.peer = null
+    this.setStatus('disconnected')
+    devLog('[Host] Network manager closed')
+  }
+}
+
+// --- Controller-side network manager ---
+
+export interface ControllerConnectionCallbacks {
+  onConnected: () => void
+  onDisconnected: () => void
+  onMessage: (message: HostMessage) => void
+}
+
+export class ControllerNetworkManager {
+  private peer: Peer | null = null
+  private connection: DataConnection | null = null
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private lastPing = 0
+  private callbacks: ControllerConnectionCallbacks
+  private _status: ConnectionStatus = 'disconnected'
+  private statusListeners = new Set<(status: ConnectionStatus) => void>()
+  private _roomId = ''
+
+  constructor(callbacks: ControllerConnectionCallbacks) {
+    this.callbacks = callbacks
+  }
+
+  get status(): ConnectionStatus {
+    return this._status
+  }
+
+  get roomId(): string {
+    return this._roomId
+  }
+
+  onStatusChange(listener: (status: ConnectionStatus) => void): () => void {
+    this.statusListeners.add(listener)
+    return () => this.statusListeners.delete(listener)
+  }
+
+  private setStatus(status: ConnectionStatus): void {
+    this._status = status
+    for (const listener of this.statusListeners) listener(status)
+  }
+
+  async connect(roomId: string): Promise<void> {
+    this._roomId = roomId
+    const hostPeerId = PEER_ID_PREFIX + roomId
+
+    return new Promise<void>((resolve, reject) => {
+      this.setStatus('connecting')
+      this.peer = new Peer()
+
+      this.peer.on('open', () => {
+        devLog('[Controller] Peer opened, connecting to host:', hostPeerId)
+        const conn = this.peer!.connect(hostPeerId, { reliable: true })
+        this.connection = conn
+
+        conn.on('open', () => {
+          devLog('[Controller] Connected to host')
+          this.setStatus('connected')
+          this.startHeartbeatListener()
+          this.callbacks.onConnected()
+          resolve()
+        })
+
+        conn.on('data', (rawData) => {
+          const data = typeof rawData === 'string' ? rawData : JSON.stringify(rawData)
+          if (data === '"ping"' || data === 'ping') {
+            this.lastPing = Date.now()
+            try {
+              conn.send('"pong"')
+            } catch {
+              /* ignore */
+            }
+            return
+          }
+          try {
+            const msg = deserializeHostMessage(data)
+            this.callbacks.onMessage(msg)
+          } catch (e) {
+            devLog('[Controller] Failed to parse message:', data, e)
+          }
+        })
+
+        conn.on('close', () => {
+          devLog('[Controller] Connection closed')
+          this.setStatus('disconnected')
+          this.stopHeartbeatListener()
+          this.callbacks.onDisconnected()
+        })
+
+        conn.on('error', (err) => {
+          devLog('[Controller] Connection error:', err)
+          if (this._status === 'connecting') {
+            reject(err)
+          }
+          this.setStatus('disconnected')
+          this.callbacks.onDisconnected()
+        })
+      })
+
+      this.peer.on('error', (err) => {
+        devLog('[Controller] Peer error:', err)
+        if (this._status === 'connecting') {
+          reject(err)
+        }
+      })
+
+      this.peer.on('disconnected', () => {
+        devLog('[Controller] Peer disconnected from signaling')
+        this.setStatus('reconnecting')
+        this.peer?.reconnect()
+      })
+    })
+  }
+
+  private startHeartbeatListener(): void {
+    this.lastPing = Date.now()
+    this.heartbeatTimer = setInterval(() => {
+      if (Date.now() - this.lastPing > HEARTBEAT_TIMEOUT_MS) {
+        devLog('[Controller] Heartbeat timeout, host may be unreachable')
+        this.setStatus('reconnecting')
+      }
+    }, HEARTBEAT_INTERVAL_MS)
+  }
+
+  private stopHeartbeatListener(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
+
+  send(message: ControllerMessage): void {
+    if (!this.connection?.open) return
+    try {
+      this.connection.send(serializeControllerMessage(message))
+    } catch (e) {
+      devLog('[Controller] Failed to send:', e)
+    }
+  }
+
+  close(): void {
+    this.stopHeartbeatListener()
+    this.connection?.close()
+    this.connection = null
+    this.peer?.destroy()
+    this.peer = null
+    this.setStatus('disconnected')
+  }
+}

--- a/src/services/syncProtocol.ts
+++ b/src/services/syncProtocol.ts
@@ -1,0 +1,63 @@
+import type { Player, GameState } from '../types/game'
+import type {
+  PublicPlayerInfo,
+  PlayerView,
+  HostMessage,
+  ControllerMessage,
+  RequiredAction,
+} from '../types/network'
+import type { PartySession, PartyAct } from './partyMode'
+
+export function toPublicPlayerInfo(player: Player): PublicPlayerInfo {
+  return {
+    id: player.id,
+    name: player.name,
+    color: player.color,
+    position: player.position,
+    hasTakenOff: player.hasTakenOff ?? false,
+    isWinner: player.isWinner,
+  }
+}
+
+export function projectPlayerView(
+  playerIndex: number,
+  gameState: GameState,
+  session: PartySession | null,
+  pendingAction: RequiredAction | null,
+  lastEffect: string | null
+): PlayerView {
+  const act: PartyAct = session?.act ?? 'warmup'
+  const tokensRemaining = session?.tokensRemaining[playerIndex] ?? 0
+  const diceChangedThisTurn = session?.diceChangedThisTurn ?? false
+
+  return {
+    myIndex: playerIndex,
+    isMyTurn: gameState.currentPlayerIndex === playerIndex,
+    tokensRemaining,
+    diceValue: gameState.diceValue,
+    gameStatus: gameState.gameStatus,
+    currentAct: act,
+    allPlayers: gameState.players.map(toPublicPlayerInfo),
+    boardSize: gameState.board.length,
+    roundNumber: session?.roundNumber ?? 1,
+    pendingAction,
+    lastEffect,
+    diceChangedThisTurn,
+  }
+}
+
+export function serializeHostMessage(msg: HostMessage): string {
+  return JSON.stringify(msg)
+}
+
+export function deserializeHostMessage(data: string): HostMessage {
+  return JSON.parse(data) as HostMessage
+}
+
+export function serializeControllerMessage(msg: ControllerMessage): string {
+  return JSON.stringify(msg)
+}
+
+export function deserializeControllerMessage(data: string): ControllerMessage {
+  return JSON.parse(data) as ControllerMessage
+}

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -1,0 +1,88 @@
+import type { PartyAct, PartyPrediction, PartyReactionDecision } from '../services/partyMode'
+
+/** Public player info safe to broadcast to all controllers */
+export interface PublicPlayerInfo {
+  readonly id: number
+  readonly name: string
+  readonly color: string
+  readonly position: number
+  readonly hasTakenOff: boolean
+  readonly isWinner: boolean
+}
+
+/** Per-player private view projected by host */
+export interface PlayerView {
+  readonly myIndex: number
+  readonly isMyTurn: boolean
+  readonly tokensRemaining: number
+  readonly diceValue: number | null
+  readonly gameStatus: string
+  readonly currentAct: PartyAct
+  readonly allPlayers: readonly PublicPlayerInfo[]
+  readonly boardSize: number
+  readonly roundNumber: number
+  readonly pendingAction: RequiredAction | null
+  readonly lastEffect: string | null
+  readonly diceChangedThisTurn: boolean
+}
+
+// --- Host -> Controller messages ---
+
+export type RequiredAction =
+  | { readonly type: 'roll_dice' }
+  | { readonly type: 'predict'; readonly timeoutSeconds: number }
+  | {
+      readonly type: 'reaction_decision'
+      readonly rolledValue: number
+      readonly timeoutSeconds: number
+    }
+  | {
+      readonly type: 'dice_decision'
+      readonly diceValue: number
+      readonly canReroll: boolean
+      readonly timeoutSeconds: number
+    }
+  | {
+      readonly type: 'punishment_choice'
+      readonly choiceA: string
+      readonly choiceB: string
+    }
+  | { readonly type: 'acknowledge'; readonly message: string }
+  | { readonly type: 'tiebreak_roll' }
+
+export type HostMessage =
+  | { readonly type: 'player_assigned'; readonly playerIndex: number; readonly player: PublicPlayerInfo }
+  | { readonly type: 'state_update'; readonly view: PlayerView }
+  | { readonly type: 'game_ended'; readonly winnerName: string }
+  | { readonly type: 'room_closed' }
+  | { readonly type: 'error'; readonly message: string }
+
+// --- Controller -> Host messages ---
+
+export type ControllerMessage =
+  | { readonly type: 'join'; readonly preferredName?: string }
+  | { readonly type: 'roll_dice' }
+  | { readonly type: 'predict'; readonly prediction: PartyPrediction }
+  | { readonly type: 'reaction_decision'; readonly decision: PartyReactionDecision }
+  | { readonly type: 'reroll' }
+  | { readonly type: 'continue_move' }
+  | { readonly type: 'select_punishment'; readonly index: number }
+  | { readonly type: 'skip_punishment_choice' }
+  | { readonly type: 'acknowledge' }
+  | { readonly type: 'tiebreak_roll' }
+
+// --- Connection management ---
+
+export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'reconnecting'
+
+export interface ConnectedPlayer {
+  readonly playerIndex: number
+  readonly peerId: string
+  readonly status: ConnectionStatus
+}
+
+export interface RoomInfo {
+  readonly roomId: string
+  readonly hostPeerId: string
+  readonly gameUrl: string
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'path'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { VitePWA } from 'vite-plugin-pwa'
@@ -80,6 +81,10 @@ export default defineConfig(async ({ command, mode }) => {
       assetsDir: 'assets',
       sourcemap: false,
       rollupOptions: {
+        input: {
+          main: resolve(__dirname, 'index.html'),
+          controller: resolve(__dirname, 'controller.html'),
+        },
         output: {
           manualChunks: {
             vendor: ['vue'],
@@ -89,7 +94,7 @@ export default defineConfig(async ({ command, mode }) => {
     },
     // 优化依赖处理
     optimizeDeps: {
-      include: ['qrcode'],
+      include: ['qrcode', 'peerjs'],
     },
   }
 })


### PR DESCRIPTION
## Summary

为升温局实现同一 WiFi 下的多设备同步：每位玩家在自己手机上操作，Host 大屏展示共享棋盘。

- **零服务器成本**：PeerJS 免费信令握手 + WebRTC DataChannel P2P 传输
- **私密信息隔离**：干预筹码、预测、骰子决定仅在玩家手机上可见
- **渐进增强**：不选多设备时行为完全不变（本地传设备模式）
- **不重构 App.vue**：通过 composable 适配层桥接，无需拆分 4000 行 monolith

### 新增文件（15 个）

| 层级 | 文件 | 职责 |
|---|---|---|
| 类型 | `src/types/network.ts` | 消息协议、PlayerView、RequiredAction |
| 服务 | `src/services/networkService.ts` | PeerJS 封装、心跳、断线重连 |
| 服务 | `src/services/syncProtocol.ts` | 状态投影、序列化 |
| Composable | `src/composables/useMultiDeviceHost.ts` | Host 端连接管理、状态广播、远程操作路由 |
| Composable | `src/composables/useMultiDeviceController.ts` | Controller 端连接、状态接收 |
| 入口 | `controller.html` + `src/controller/main.ts` | Vite 多页面构建 |
| Controller UI | `src/controller/App.vue` | 根组件 |
| Controller UI | 6 个组件 | ConnectionScreen、ControllerMain、MiniBoard、ControllerDice、ActionPanel、GameEndScreen、ConnectionStatus |

### 修改文件（4 个）

- `vite.config.ts` — 多页面 input + peerjs 预打包
- `package.json` — 添加 `peerjs` 依赖
- `src/App.vue` — 集成 useMultiDeviceHost、远程操作分支、overlay 条件渲染、连接面板
- `src/components/IntroPage.vue` — 升温局开局增加"多设备模式"开关

### 关键设计

Host (大屏) ←WebRTC DataChannel→ Controller (手机)
- Host 是唯一状态权威，Controller 只发送动作指令
- 每个 Controller 只收到自己的 PlayerView 投影
- 断线后重连自动恢复玩家槽位

## Test plan

- [x] `vue-tsc --noEmit` 通过
- [x] `npm run build` 成功（controller.html 正确输出）
- [x] 116 个现有单元测试全部通过
- [ ] 手动测试：启动 dev server → 开启升温局多设备模式 → 手机扫码连接 → 完整回合流程
- [ ] 手动测试：断线重连 → 重新扫码后恢复玩家分配
- [ ] 手动测试：不开启多设备模式时行为无变化


Made with [Cursor](https://cursor.com)