### PR TITLE
fix: restore Pages deployment on Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '18'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "dependencies": {
         "@lucide/vue": "^1.24.0",
         "@primevue/themes": "^4.3.6",
@@ -43,6 +43,9 @@
         "vite-plugin-vue-devtools": "^7.7.2",
         "vitest": "^4.0.18",
         "vue-tsc": "^3.2.5"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@antfu/utils": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -242,7 +242,7 @@ test('development startup does not register a missing production service worker'
   await page.waitForLoadState('networkidle')
 
   expect(serviceWorkerErrors).toEqual([])
-  await expect(page.locator('.version-text')).toHaveText('v1.11.0')
+  await expect(page.locator('.version-text')).toHaveText('v1.11.1')
 })
 
 test('selects and starts party mode with anonymous mode telemetry', async ({ page }, testInfo) => {


### PR DESCRIPTION
## 根因

`v1.11.0` 的 Pages 工作流仍固定使用 Node 18，但当前锁文件中的 `@rollup/plugin-terser@1.0.0` 和 `serialize-javascript@7.0.7` 要求 Node >=20。构建在 PWA 压缩阶段因此报错：

```text
ReferenceError: crypto is not defined
```

失败工作流：https://github.com/atang-sp/flying-chess/actions/runs/30648710191

## 修复

- 将 `actions/checkout` 和 `actions/setup-node` 升级到官方当前的 v7（Node 24 action runtime）。
- 将 Pages 构建环境从 Node 18 升级到 Node 24。
- 在 `package.json` 声明 Node >=20，明确依赖要求。
- 将补丁版本提升到 `1.11.1`，不移动或覆盖已公开的 `v1.11.0` 标签。
- 更新版本 E2E 断言。

## 验证

在 Node 24.18.1 + npm 11.19.0 下执行：

- `npm ci`
- `npm run lint:check -- --max-warnings=0`
- `npm run type-check`
- `npm run test`：19 个文件、161 项通过
- `npm run validate-config`
- 带 `VITE_APP_VERSION=1.11.1` 和真实 Umami 变量执行 `npm run build`
- 版本与开发 Service Worker 回归 E2E：1 项通过

原失败点已不再出现。
