### PR TITLE
ci: update Pages actions for Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,15 +69,15 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
         with:
           enablement: true
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './dist'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "dependencies": {
         "@lucide/vue": "^1.24.0",
         "@primevue/themes": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "private": true,
   "engines": {
     "node": ">=20.0.0"

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -242,7 +242,7 @@ test('development startup does not register a missing production service worker'
   await page.waitForLoadState('networkidle')
 
   expect(serviceWorkerErrors).toEqual([])
-  await expect(page.locator('.version-text')).toHaveText('v1.11.1')
+  await expect(page.locator('.version-text')).toHaveText('v1.11.2')
 })
 
 test('selects and starts party mode with anonymous mode telemetry', async ({ page }, testInfo) => {


### PR DESCRIPTION
## Summary

- upgrade the remaining GitHub Pages actions to their current Node 24-compatible major versions
- bump the patch version to `1.11.2`
- keep the version assertion aligned with the release

## Why

The `v1.11.1` deployment succeeded after upgrading the build runtime, but GitHub still emitted a migration warning because the Pages setup, artifact upload, and deployment actions targeted Node 20. Their current releases target Node 24 and remove that follow-up deployment risk.

## Validation

- Node.js 24.18.1 / npm 11.19.0: `npm ci`
- zero-warning lint
- type check
- 161 unit tests
- configuration validation
- production PWA build with release and Umami environment variables
- targeted desktop Chrome Playwright version/service-worker test
