### PR TITLE
fix: make v1.12.1 room gateway reachable

### DIFF
--- a/apps/room-server/package.json
+++ b/apps/room-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/room-server",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@flying-chess/game-core": "1.12.0",
+    "@flying-chess/game-core": "1.12.1",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/deploy/room-server/README.md
+++ b/deploy/room-server/README.md
@@ -1,13 +1,13 @@
 # 联机升温局房间服务部署
 
-生产拓扑：GitHub Pages 前端连接 `wss://rooms.atang-sp.run.place`；Discourse 容器内的 Nginx 终止 TLS，并反代到 Docker 网桥 `172.17.0.1:8787`。房间服务不写磁盘，容器被限制为 128 MiB 内存、1 CPU、只读根文件系统。
+生产拓扑：GitHub Pages 前端连接 `wss://rooms.atang-sp.run.place`；Discourse 容器内的 Nginx 终止 TLS，并反代到 Docker 网桥 `172.17.0.1:8787`。房间容器使用 host 网络并只监听该网桥地址，避免 Docker 发布端口在同机容器间被防火墙阻断，也不会把 `8787` 暴露到公网。房间服务不写磁盘，容器被限制为 128 MiB 内存、1 CPU、只读根文件系统。
 
 ## 构建与安装
 
-在已检出不可变 `v1.12.0` 标签的仓库根目录执行：
+在已检出不可变 `v1.12.1` 标签的仓库根目录执行：
 
 ```bash
-docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.12.0 .
+docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.12.1 .
 install -m 0644 deploy/room-server/flying-chess-room.service /etc/systemd/system/
 install -m 0644 deploy/room-server/flying-chess-room-health.service /etc/systemd/system/
 install -m 0644 deploy/room-server/flying-chess-room-health.timer /etc/systemd/system/

--- a/deploy/room-server/flying-chess-room.service
+++ b/deploy/room-server/flying-chess-room.service
@@ -6,11 +6,11 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=ROOM_IMAGE=flying-chess-room:1.12.0
+Environment=ROOM_IMAGE=flying-chess-room:1.12.1
 EnvironmentFile=-/etc/flying-chess-room.env
 ExecStartPre=-/usr/bin/docker rm -f flying-chess-room
-ExecStart=/usr/bin/docker run --rm --name flying-chess-room --read-only --tmpfs /tmp:rw,noexec,nosuid,size=8m --cap-drop ALL --security-opt no-new-privileges --pids-limit 128 --cpus 1 --memory 128m --memory-swap 192m --log-driver journald -p 172.17.0.1:8787:8787 -e NODE_ENV=production -e HOST=0.0.0.0 -e PORT=8787 -e ALLOWED_ORIGINS=https://atang-sp.github.io ${ROOM_IMAGE}
-ExecStop=/usr/bin/docker stop --time 10 flying-chess-room
+ExecStart=/usr/bin/docker run --rm --name flying-chess-room --network host --read-only --tmpfs /tmp:rw,noexec,nosuid,size=8m --cap-drop ALL --security-opt no-new-privileges --pids-limit 128 --cpus 1 --memory 128m --memory-swap 192m --health-cmd "wget -qO- http://172.17.0.1:8787/ready >/dev/null || exit 1" --health-interval 30s --health-timeout 3s --health-start-period 5s --health-retries 3 --log-driver journald -e NODE_ENV=production -e HOST=172.17.0.1 -e PORT=8787 -e ALLOWED_ORIGINS=https://atang-sp.github.io ${ROOM_IMAGE}
+ExecStop=/usr/bin/docker stop --timeout 10 flying-chess-room
 Restart=always
 RestartSec=3
 TimeoutStartSec=30
@@ -18,4 +18,3 @@ TimeoutStopSec=20
 
 [Install]
 WantedBy=multi-user.target
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -54,9 +54,9 @@
     },
     "apps/room-server": {
       "name": "@flying-chess/room-server",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "dependencies": {
-        "@flying-chess/game-core": "1.12.0",
+        "@flying-chess/game-core": "1.12.1",
         "ws": "^8.18.3"
       },
       "devDependencies": {
@@ -11199,7 +11199,7 @@
     },
     "packages/game-core": {
       "name": "@flying-chess/game-core",
-      "version": "1.12.0"
+      "version": "1.12.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/game-core/package.json
+++ b/packages/game-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/game-core",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- run the room container in host-network mode while binding only to 172.17.0.1:8787
- override the container health check for the bridge-only listener
- bump the patch release to v1.12.1 and document the same-host container topology

## Why
Production verification showed that the Discourse container could not reach a Docker-published port on the host bridge. A host-network process bound only to the bridge address is reachable from Discourse without exposing port 8787 publicly.

## Validation
- 21 Vitest files / 181 tests passed
- type-check, ESLint, Prettier passed
- systemd-analyze verify passed
- a separate default-bridge container reached the host-network room service through 172.17.0.1
- service became Docker healthy under the 128 MiB limit