### PR TITLE
docs: publish v1.12.2 room firewall boundary

### DIFF
--- a/apps/room-server/package.json
+++ b/apps/room-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/room-server",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "private": true,
   "type": "module",
   "scripts": {
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@flying-chess/game-core": "1.12.1",
+    "@flying-chess/game-core": "1.12.2",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/deploy/room-server/README.md
+++ b/deploy/room-server/README.md
@@ -4,10 +4,11 @@
 
 ## 构建与安装
 
-在已检出不可变 `v1.12.1` 标签的仓库根目录执行：
+在已检出不可变 `v1.12.2` 标签的仓库根目录执行：
 
 ```bash
-docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.12.1 .
+docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.12.2 .
+ufw allow in on docker0 from 172.17.0.0/16 to 172.17.0.1 port 8787 proto tcp comment "flying chess room from discourse"
 install -m 0644 deploy/room-server/flying-chess-room.service /etc/systemd/system/
 install -m 0644 deploy/room-server/flying-chess-room-health.service /etc/systemd/system/
 install -m 0644 deploy/room-server/flying-chess-room-health.timer /etc/systemd/system/
@@ -29,6 +30,7 @@ curl --fail https://rooms.atang-sp.run.place/health
 systemctl is-active flying-chess-room.service
 systemctl is-active flying-chess-room-health.timer
 docker inspect --format '{{.State.Health.Status}} {{.HostConfig.Memory}}' flying-chess-room
+docker exec app curl --fail http://172.17.0.1:8787/ready
 ```
 
 健康响应只有聚合的房间数、连接数、运行时长与 RSS，不包含房间码、昵称、玩法设置或消息正文。
@@ -39,6 +41,7 @@ docker inspect --format '{{.State.Health.Status}} {{.HostConfig.Memory}}' flying
 
 ```bash
 systemctl disable --now flying-chess-room-health.timer flying-chess-room.service
+ufw delete allow in on docker0 from 172.17.0.0/16 to 172.17.0.1 port 8787 proto tcp
 ```
 
 停止服务会结束全部内存房间，这是协议的既定行为。不要尝试从磁盘恢复房间。

--- a/deploy/room-server/flying-chess-room.service
+++ b/deploy/room-server/flying-chess-room.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=ROOM_IMAGE=flying-chess-room:1.12.1
+Environment=ROOM_IMAGE=flying-chess-room:1.12.2
 EnvironmentFile=-/etc/flying-chess-room.env
 ExecStartPre=-/usr/bin/docker rm -f flying-chess-room
 ExecStart=/usr/bin/docker run --rm --name flying-chess-room --network host --read-only --tmpfs /tmp:rw,noexec,nosuid,size=8m --cap-drop ALL --security-opt no-new-privileges --pids-limit 128 --cpus 1 --memory 128m --memory-swap 192m --health-cmd "wget -qO- http://172.17.0.1:8787/ready >/dev/null || exit 1" --health-interval 30s --health-timeout 3s --health-start-period 5s --health-retries 3 --log-driver journald -e NODE_ENV=production -e HOST=172.17.0.1 -e PORT=8787 -e ALLOWED_ORIGINS=https://atang-sp.github.io ${ROOM_IMAGE}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -54,9 +54,9 @@
     },
     "apps/room-server": {
       "name": "@flying-chess/room-server",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "dependencies": {
-        "@flying-chess/game-core": "1.12.1",
+        "@flying-chess/game-core": "1.12.2",
         "ws": "^8.18.3"
       },
       "devDependencies": {
@@ -11199,7 +11199,7 @@
     },
     "packages/game-core": {
       "name": "@flying-chess/game-core",
-      "version": "1.12.1"
+      "version": "1.12.2"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/game-core/package.json
+++ b/packages/game-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/game-core",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- document the exact UFW rule that permits only Discourse-to-room traffic on docker0
- add the container-to-room readiness check and matching firewall rollback
- bump the reproducible deployment patch to v1.12.2

## Production evidence
- Discourse container reaches 172.17.0.1:8787 after the private docker0 rule
- public port 8787 remains unreachable
- a complete WSS upgrade, create-room session, and projected room-state exchange passed through Nginx
- the smoke room was removed by restarting the in-memory room service
- service logs contained no smoke nickname, request ID, or room code