### PR TITLE
chore: add fail-closed online acceptance evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coverage
 /playwright-report/
 /test-results/
 /.playwright-cli/
+/.acceptance-evidence/
 
 # Editor directories and files
 .vscode/*

--- a/apps/room-server/package.json
+++ b/apps/room-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/room-server",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "private": true,
   "type": "module",
   "scripts": {
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@flying-chess/game-core": "1.12.2",
+    "@flying-chess/game-core": "1.12.3",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/deploy/room-server/ACCEPTANCE.md
+++ b/deploy/room-server/ACCEPTANCE.md
@@ -1,0 +1,84 @@
+# 联机升温局发布验收
+
+这份流程是 v1.12 联机升温局的发布终点，不是自动化演示。自动浏览器、WebSocket 脚本、模拟客户端或代理人不能替代真实 iOS、Android 与 4/6/8 名真人参加者。任一门槛缺证据时，校验器必须失败，发布状态保持未完成。
+
+## 前置条件
+
+开始现场验收前必须同时满足：
+
+- `rooms.atang-sp.run.place` 的权威 DNS 已生效；
+- 公网证书 SAN 同时包含主域和房间子域；
+- 公网 `https://rooms.atang-sp.run.place/health` 与真实 `wss://rooms.atang-sp.run.place` 建房、加入、断线重连冒烟通过；
+- Discourse 主站健康，部署期间内核 OOM 为 0；
+- 20 房间、160 连接压测测量全部房间客户端收到状态的延迟，P95 小于 500ms，房间服务 RSS 小于 128MiB；
+- 日志与验收材料均不包含房间码、昵称、玩法设置、消息正文或惩罚内容。
+
+## 匿名证据目录
+
+证据不得提交到仓库。先复制模板到已被 `.gitignore` 排除的目录：
+
+```bash
+mkdir -p .acceptance-evidence/v1.12.3/{evidence,artifacts}
+cp deploy/room-server/acceptance-evidence.template.json \
+  .acceptance-evidence/v1.12.3/evidence.json
+```
+
+每个 `evidenceRefs` 都必须指向结构化 JSON 证明，可从 `acceptance-proof.template.json` 复制。证明必须包含同一个发布标签、UTC 时间、证明类别、与主清单完全一致的 `claims`，以及至少一个原始材料文件和它的 SHA-256。校验器会读取原始文件并重新计算摘要；空文件、目录、错误摘要、错误版本、错误类别、声明不一致或私人字段都会失败。
+
+九份证明使用下列六种 `kind`；各自的 `claims` 必填字段如下：
+
+| `kind`                   | `claims` 字段                                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `public_gateway`         | `dnsResolved`、`certificateSans`、`httpsHealth`、`wssCreateJoinReconnect`                                |
+| `load_test`              | `rooms`、`connections`、`measurementScope`、`p95Ms`、`rssMiB`                                            |
+| `privacy_audit`          | `passed`                                                                                                 |
+| `production_observation` | `discourseHealthy`、`kernelOomEvents`、`swapSamplesMiB`                                                  |
+| `physical_device`        | `platform`、`realDevice`、`createRoom`、`reconnect`、`fullGameCompleted`                                 |
+| `field_session`          | `playerCount`、`realParticipants`、`unattended`、`completed`、`joinConfirmSeconds`、`staffInterventions` |
+
+`public_gateway`、`load_test`、`privacy_audit`、`production_observation` 各一份，`physical_device` 两份，`field_session` 三份。`claims` 中的值必须与 `evidence.json` 对应项一致。
+
+原始材料只记录：发布标签、UTC 时间范围、设备/浏览器类别、参加人数、是否完成、重连结果、加入确认耗时和人工介入次数。不要记录参与者身份、昵称、房间码、SP 设置、聊天/消息正文或惩罚内容。截图和录像必须先裁剪或遮盖这些信息；证明 JSON 及原始材料均不得提交仓库。
+
+计算摘要示例：
+
+```bash
+sha256sum .acceptance-evidence/v1.12.3/artifacts/<已脱敏材料>
+```
+
+生产资源证据至少在现场验收前、中、后各采样一次。`swapSamplesMiB` 至少填 3 个数；校验器将峰峰值不超过 128MiB 作为“无 swap 振荡”的保守可重复判据。
+
+## 真机门槛
+
+分别在真实 iPhone/iPad Safari 与真实 Android Chrome 上执行：
+
+1. 从公开 Pages 入口显式选择联机升温局并建房；
+2. 参加一局直到胜负结算；
+3. 对局中关闭页面或断网，再在 90 秒内恢复；
+4. 确认恢复到本人私有视图，且未看到其他玩家的私有选择；
+5. 将对应设备项的四个布尔值置为 `true`，附上匿名证据引用。
+
+两种平台都完成前不得复用桌面浏览器或设备模拟器代替。
+
+## 4/6/8 人现场门槛
+
+分别组织 4、6、8 名真人完成三场独立对局。每场必须满足：
+
+- 所有人从公开入口加入并在 60 秒内完成加入确认；
+- 主持人或运维人员不触碰任何参与者设备，不手工修复状态；
+- 房主离开/超时、私密选择、投票/猜拳/小游戏、惩罚延后与胜负结算按实际触发情况由服务端继续推进；
+- 全局计时器与断线重连不要求工作人员干预；
+- 对局正常结算，`staffInterventions` 为 `0`。
+
+只有真实参加者完成的场次才可设置 `realParticipants`、`unattended` 和 `completed` 为 `true`。脚本并发、机器人或自动浏览器记录只能作为补充材料。
+
+## 校验与结论
+
+填写 JSON 并创建全部引用文件后运行：
+
+```bash
+npm run verify:online-acceptance -- \
+  .acceptance-evidence/v1.12.3/evidence.json
+```
+
+退出码 `0` 且输出 `PASS` 才表示证据合同满足；退出码 `1` 表示一个或多个硬门槛失败，退出码 `2` 表示文件/JSON 用法错误。该命令只校验证据完整性，不会替代人工核对材料真实性。

--- a/deploy/room-server/README.md
+++ b/deploy/room-server/README.md
@@ -4,10 +4,10 @@
 
 ## 构建与安装
 
-在已检出不可变 `v1.12.2` 标签的仓库根目录执行：
+在已检出不可变 `v1.12.3` 标签的仓库根目录执行：
 
 ```bash
-docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.12.2 .
+docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.12.3 .
 ufw allow in on docker0 from 172.17.0.0/16 to 172.17.0.1 port 8787 proto tcp comment "flying chess room from discourse"
 install -m 0644 deploy/room-server/flying-chess-room.service /etc/systemd/system/
 install -m 0644 deploy/room-server/flying-chess-room-health.service /etc/systemd/system/
@@ -45,3 +45,5 @@ ufw delete allow in on docker0 from 172.17.0.0/16 to 172.17.0.1 port 8787 proto 
 ```
 
 停止服务会结束全部内存房间，这是协议的既定行为。不要尝试从磁盘恢复房间。
+
+发布后的真机与真人现场验收见 [ACCEPTANCE.md](./ACCEPTANCE.md)。缺少其中任一匿名证据时，发布不得判定完成。

--- a/deploy/room-server/acceptance-evidence.template.json
+++ b/deploy/room-server/acceptance-evidence.template.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": 1,
+  "release": "v1.12.3",
+  "publicGateway": {
+    "dnsResolved": false,
+    "certificateSans": [],
+    "httpsHealth": false,
+    "wssCreateJoinReconnect": false,
+    "evidenceRefs": ["evidence/public-gateway.json"]
+  },
+  "loadTest": {
+    "rooms": 20,
+    "connections": 160,
+    "measurementScope": "all_room_clients",
+    "p95Ms": null,
+    "rssMiB": null,
+    "evidenceRefs": ["evidence/load-test.json"]
+  },
+  "privacy": {
+    "passed": false,
+    "evidenceRefs": ["evidence/privacy-audit.json"]
+  },
+  "production": {
+    "discourseHealthy": false,
+    "kernelOomEvents": null,
+    "swapSamplesMiB": [],
+    "evidenceRefs": ["evidence/production-observation.json"]
+  },
+  "physicalDevices": [
+    {
+      "platform": "ios_safari",
+      "realDevice": false,
+      "createRoom": false,
+      "reconnect": false,
+      "fullGameCompleted": false,
+      "evidenceRefs": ["evidence/ios-session.json"]
+    },
+    {
+      "platform": "android_chrome",
+      "realDevice": false,
+      "createRoom": false,
+      "reconnect": false,
+      "fullGameCompleted": false,
+      "evidenceRefs": ["evidence/android-session.json"]
+    }
+  ],
+  "fieldSessions": [
+    {
+      "playerCount": 4,
+      "realParticipants": false,
+      "unattended": false,
+      "completed": false,
+      "joinConfirmSeconds": null,
+      "staffInterventions": null,
+      "evidenceRefs": ["evidence/4-player-session.json"]
+    },
+    {
+      "playerCount": 6,
+      "realParticipants": false,
+      "unattended": false,
+      "completed": false,
+      "joinConfirmSeconds": null,
+      "staffInterventions": null,
+      "evidenceRefs": ["evidence/6-player-session.json"]
+    },
+    {
+      "playerCount": 8,
+      "realParticipants": false,
+      "unattended": false,
+      "completed": false,
+      "joinConfirmSeconds": null,
+      "staffInterventions": null,
+      "evidenceRefs": ["evidence/8-player-session.json"]
+    }
+  ]
+}

--- a/deploy/room-server/acceptance-proof.template.json
+++ b/deploy/room-server/acceptance-proof.template.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "release": "v1.12.3",
+  "recordedAtUtc": "2026-08-02T00:00:00.000Z",
+  "kind": "replace_with_required_kind",
+  "artifacts": [
+    {
+      "path": "artifacts/replace-with-anonymous-artifact.bin",
+      "sha256": "replace_with_64_lowercase_hex_characters"
+    }
+  ],
+  "claims": {}
+}

--- a/deploy/room-server/flying-chess-room.service
+++ b/deploy/room-server/flying-chess-room.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=ROOM_IMAGE=flying-chess-room:1.12.2
+Environment=ROOM_IMAGE=flying-chess-room:1.12.3
 EnvironmentFile=-/etc/flying-chess-room.env
 ExecStartPre=-/usr/bin/docker rm -f flying-chess-room
 ExecStart=/usr/bin/docker run --rm --name flying-chess-room --network host --read-only --tmpfs /tmp:rw,noexec,nosuid,size=8m --cap-drop ALL --security-opt no-new-privileges --pids-limit 128 --cpus 1 --memory 128m --memory-swap 192m --health-cmd "wget -qO- http://172.17.0.1:8787/ready >/dev/null || exit 1" --health-interval 30s --health-timeout 3s --health-start-period 5s --health-retries 3 --log-driver journald -e NODE_ENV=production -e HOST=172.17.0.1 -e PORT=8787 -e ALLOWED_ORIGINS=https://atang-sp.github.io ${ROOM_IMAGE}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -54,9 +54,9 @@
     },
     "apps/room-server": {
       "name": "@flying-chess/room-server",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "dependencies": {
-        "@flying-chess/game-core": "1.12.2",
+        "@flying-chess/game-core": "1.12.3",
         "ws": "^8.18.3"
       },
       "devDependencies": {
@@ -11199,7 +11199,7 @@
     },
     "packages/game-core": {
       "name": "@flying-chess/game-core",
-      "version": "1.12.2"
+      "version": "1.12.3"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "private": true,
   "workspaces": [
     "packages/*",
@@ -35,6 +35,7 @@
     "dev:room-server": "npm run dev --workspace @flying-chess/room-server",
     "build:room-server": "npm run build --workspace @flying-chess/room-server",
     "test:room-server-load": "npm run build:room-server && node scripts/room-server-load-test.mjs",
+    "verify:online-acceptance": "node scripts/online-acceptance-evidence.mjs",
     "test:e2e": "playwright test tests/e2e"
   },
   "lint-staged": {

--- a/packages/game-core/package.json
+++ b/packages/game-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/game-core",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,8 @@
 import { defineConfig, devices } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+
+const packageVersion = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'))
+  .version as string
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -10,8 +14,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      command:
-        'VITE_ROOM_SERVER_URL=ws://127.0.0.1:8787 npm run dev -- --host 127.0.0.1 --port 4175',
+      command: `VITE_APP_VERSION=${packageVersion} VITE_ROOM_SERVER_URL=ws://127.0.0.1:8787 npm run dev -- --host 127.0.0.1 --port 4175`,
       url: 'http://127.0.0.1:4175/flying-chess/',
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,

--- a/scripts/online-acceptance-evidence.mjs
+++ b/scripts/online-acceptance-evidence.mjs
@@ -1,0 +1,349 @@
+import { createHash } from 'node:crypto'
+import { readFileSync, statSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const forbiddenPrivateKeys = new Set([
+  'identity',
+  'identities',
+  'participant',
+  'participants',
+  'nickname',
+  'playername',
+  'playernames',
+  'roomcode',
+  'settings',
+  'spsettings',
+  'message',
+  'messagebody',
+  'messages',
+  'roomcontent',
+  'punishment',
+  'punishments',
+  'punishmentdata',
+  'punishmentsettings',
+])
+
+function findForbiddenPrivatePaths(value, path = '') {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry, index) => findForbiddenPrivatePaths(entry, `${path}[${index}]`))
+  }
+  if (typeof value !== 'object' || value === null) return []
+
+  return Object.entries(value).flatMap(([key, entry]) => {
+    const entryPath = path ? `${path}.${key}` : key
+    const normalizedKey = key.toLowerCase().replaceAll(/[_-]/g, '')
+    if (forbiddenPrivateKeys.has(normalizedKey)) return [entryPath]
+    return findForbiddenPrivatePaths(entry, entryPath)
+  })
+}
+
+function parseProof(rawProof) {
+  if (typeof rawProof !== 'string' || rawProof.trim().length === 0) return null
+  try {
+    const proof = JSON.parse(rawProof)
+    return typeof proof === 'object' && proof !== null && !Array.isArray(proof) ? proof : null
+  } catch {
+    return null
+  }
+}
+
+function hasValidProofMetadata(proof, release, kind) {
+  const recordedAtUtc = proof?.recordedAtUtc
+  const recordedAt = typeof recordedAtUtc === 'string' ? Date.parse(recordedAtUtc) : NaN
+  const artifacts = proof?.artifacts
+  return (
+    proof?.schemaVersion === 1 &&
+    proof?.release === release &&
+    proof?.kind === kind &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(recordedAtUtc) &&
+    Number.isFinite(recordedAt) &&
+    Array.isArray(artifacts) &&
+    artifacts.length > 0 &&
+    artifacts.every(
+      artifact =>
+        typeof artifact?.path === 'string' &&
+        artifact.path.length > 0 &&
+        !artifact.path.startsWith('/') &&
+        !artifact.path.split('/').includes('..') &&
+        typeof artifact.sha256 === 'string' &&
+        /^[a-f0-9]{64}$/i.test(artifact.sha256)
+    )
+  )
+}
+
+const claimFieldsByKind = {
+  public_gateway: ['dnsResolved', 'certificateSans', 'httpsHealth', 'wssCreateJoinReconnect'],
+  load_test: ['rooms', 'connections', 'measurementScope', 'p95Ms', 'rssMiB'],
+  privacy_audit: ['passed'],
+  production_observation: ['discourseHealthy', 'kernelOomEvents', 'swapSamplesMiB'],
+  physical_device: ['platform', 'realDevice', 'createRoom', 'reconnect', 'fullGameCompleted'],
+  field_session: [
+    'playerCount',
+    'realParticipants',
+    'unattended',
+    'completed',
+    'joinConfirmSeconds',
+    'staffInterventions',
+  ],
+}
+
+function proofClaimsMatch(proof, evidenceValue, kind) {
+  if (typeof proof?.claims !== 'object' || proof.claims === null || Array.isArray(proof.claims)) {
+    return false
+  }
+  return claimFieldsByKind[kind].every(
+    field => JSON.stringify(proof.claims[field]) === JSON.stringify(evidenceValue?.[field])
+  )
+}
+
+export function verifyOnlineAcceptanceEvidence(evidence, context = {}) {
+  if (typeof evidence !== 'object' || evidence === null || Array.isArray(evidence)) {
+    return {
+      ok: false,
+      failures: [{ gate: 'schema', message: '验收证据必须是 JSON 对象' }],
+    }
+  }
+
+  const failures = []
+  const fail = (gate, message) => failures.push({ gate, message })
+  const hasStrictContext =
+    typeof context === 'object' &&
+    context !== null &&
+    typeof context.expectedRelease === 'string' &&
+    typeof context.referenceExists === 'function' &&
+    typeof context.readReference === 'function' &&
+    typeof context.readArtifact === 'function'
+  if (!hasStrictContext) {
+    fail('verification.context', '校验必须绑定当前发布版本并读取证据文件内容')
+  }
+  const referenceExists =
+    typeof context === 'function' ? context : (context?.referenceExists ?? (() => false))
+  const expectedRelease = typeof context === 'object' ? context?.expectedRelease : undefined
+  const readReference = typeof context === 'object' ? context?.readReference : undefined
+  const readArtifact = typeof context === 'object' ? context?.readArtifact : undefined
+  if (evidence.schemaVersion !== 1) fail('schema.version', 'schemaVersion 必须为 1')
+  if (typeof evidence.release !== 'string' || !/^v\d+\.\d+\.\d+$/.test(evidence.release)) {
+    fail('release', 'release 必须是 vX.Y.Z 发布标签')
+  }
+  if (expectedRelease && evidence.release !== expectedRelease) {
+    fail(
+      'release.current',
+      `证据发布 ${evidence.release ?? 'unknown'} 与当前待发布版本 ${expectedRelease} 不一致`
+    )
+  }
+  const forbiddenPaths = findForbiddenPrivatePaths(evidence)
+  if (forbiddenPaths.length > 0) {
+    fail('privacy.forbidden_fields', `证据不得包含私人字段：${forbiddenPaths.join('、')}`)
+  }
+  const publicGateway = evidence.publicGateway
+  if (publicGateway?.dnsResolved !== true) fail('gateway.dns', '房间子域权威 DNS 必须已生效')
+  const certificateSans = Array.isArray(publicGateway?.certificateSans)
+    ? publicGateway.certificateSans
+    : []
+  if (
+    !certificateSans.includes('atang-sp.run.place') ||
+    !certificateSans.includes('rooms.atang-sp.run.place')
+  ) {
+    fail('gateway.certificate', '公网证书 SAN 必须包含主域和房间子域')
+  }
+  if (publicGateway?.httpsHealth !== true) fail('gateway.https', '公网 HTTPS 健康检查必须通过')
+  if (publicGateway?.wssCreateJoinReconnect !== true) {
+    fail('gateway.wss', '公网 WSS 建房、加入和重连冒烟必须通过')
+  }
+  const loadTest = evidence.loadTest
+  if (loadTest?.rooms !== 20) fail('load.rooms', '压测必须覆盖 20 个房间')
+  if (loadTest?.connections !== 160) fail('load.connections', '压测必须覆盖 160 个连接')
+  if (loadTest?.measurementScope !== 'all_room_clients') {
+    fail('load.scope', '延迟必须测量所有房间客户端收到状态的时间')
+  }
+  if (!(Number.isFinite(loadTest?.p95Ms) && loadTest.p95Ms >= 0 && loadTest.p95Ms < 500)) {
+    fail('load.p95', '全房间状态同步 P95 必须是小于 500ms 的非负数')
+  }
+  if (!(Number.isFinite(loadTest?.rssMiB) && loadTest.rssMiB > 0 && loadTest.rssMiB < 128)) {
+    fail('load.rss', '房间服务 RSS 必须是小于 128MiB 的正数')
+  }
+
+  if (evidence.privacy?.passed !== true) fail('privacy', '隐私边界检查必须通过')
+  const production = evidence.production
+  if (production?.discourseHealthy !== true) {
+    fail('production.discourse', 'Discourse 健康检查必须通过')
+  }
+  if (production?.kernelOomEvents !== 0) fail('production.oom', '生产部署期间不得发生 OOM')
+  const swapSamples = Array.isArray(production?.swapSamplesMiB)
+    ? production.swapSamplesMiB.filter(Number.isFinite)
+    : []
+  const swapRange =
+    swapSamples.length >= 3 ? Math.max(...swapSamples) - Math.min(...swapSamples) : Infinity
+  if (swapSamples.length < 3 || swapRange > 128) {
+    fail('production.swap', '至少 3 个 swap 样本的峰峰值必须不超过 128MiB')
+  }
+
+  const physicalDevices = Array.isArray(evidence.physicalDevices) ? evidence.physicalDevices : []
+  for (const platform of ['ios_safari', 'android_chrome']) {
+    const device = physicalDevices.find(candidate => candidate?.platform === platform)
+    const passed =
+      device?.realDevice === true &&
+      device?.createRoom === true &&
+      device?.reconnect === true &&
+      device?.fullGameCompleted === true
+    if (!passed) {
+      fail(`device.${platform}`, `${platform} 必须在真实设备完成建房、重连和完整对局`)
+    }
+  }
+
+  const fieldSessions = Array.isArray(evidence.fieldSessions) ? evidence.fieldSessions : []
+  for (const playerCount of [4, 6, 8]) {
+    const session = fieldSessions.find(candidate => candidate?.playerCount === playerCount)
+    const joinConfirmSeconds = session?.joinConfirmSeconds
+    const passed =
+      session?.realParticipants === true &&
+      session?.unattended === true &&
+      session?.completed === true &&
+      typeof joinConfirmSeconds === 'number' &&
+      joinConfirmSeconds >= 0 &&
+      joinConfirmSeconds <= 60 &&
+      session?.staffInterventions === 0
+    if (!passed) {
+      fail(
+        `session.${playerCount}_players`,
+        `${playerCount} 人场必须由真人在 60 秒内确认并零人工介入完成`
+      )
+    }
+  }
+
+  const requiredEvidenceHolders = [
+    { label: 'public_gateway', kind: 'public_gateway', value: publicGateway },
+    { label: 'load_test', kind: 'load_test', value: loadTest },
+    { label: 'privacy_audit', kind: 'privacy_audit', value: evidence.privacy },
+    { label: 'production_observation', kind: 'production_observation', value: production },
+    ...['ios_safari', 'android_chrome'].map(platform => ({
+      label: platform,
+      kind: 'physical_device',
+      value: physicalDevices.find(candidate => candidate?.platform === platform),
+    })),
+    ...[4, 6, 8].map(playerCount => ({
+      label: `${playerCount}_players`,
+      kind: 'field_session',
+      value: fieldSessions.find(candidate => candidate?.playerCount === playerCount),
+    })),
+  ]
+  const missingReferences = []
+  const invalidProofs = []
+  const mismatchedClaims = []
+  const invalidArtifacts = []
+  for (const holder of requiredEvidenceHolders) {
+    if (!holder.value) continue
+    const references = holder.value?.evidenceRefs
+    if (!Array.isArray(references) || references.length === 0) {
+      missingReferences.push(`${holder.label}（缺少引用）`)
+      continue
+    }
+    for (const reference of references) {
+      const isSafeRelativePath =
+        typeof reference === 'string' &&
+        reference.length > 0 &&
+        !reference.startsWith('/') &&
+        !reference.split('/').includes('..')
+      if (!isSafeRelativePath || !referenceExists(reference)) {
+        missingReferences.push(String(reference))
+        continue
+      }
+      if (readReference) {
+        const proof = parseProof(readReference(reference))
+        const hasPrivateFields = proof ? findForbiddenPrivatePaths(proof).length > 0 : true
+        const validMetadata = hasValidProofMetadata(proof, evidence.release, holder.kind)
+        if (!validMetadata || hasPrivateFields) {
+          invalidProofs.push(String(reference))
+        } else {
+          if (!proofClaimsMatch(proof, holder.value, holder.kind)) {
+            mismatchedClaims.push(String(reference))
+          }
+          for (const artifact of proof.artifacts) {
+            const artifactBytes = readArtifact?.(artifact.path)
+            const actualSha256 = artifactBytes
+              ? createHash('sha256').update(artifactBytes).digest('hex')
+              : ''
+            if (!referenceExists(artifact.path) || actualSha256 !== artifact.sha256.toLowerCase()) {
+              invalidArtifacts.push(artifact.path)
+            }
+          }
+        }
+      }
+    }
+  }
+  if (missingReferences.length > 0) {
+    fail('evidence.refs', `证据引用不存在：${missingReferences.join('、')}`)
+  }
+  if (invalidProofs.length > 0) {
+    fail(
+      'evidence.proof',
+      `证据文件为空、格式错误、含私人字段或元数据不匹配：${invalidProofs.join('、')}`
+    )
+  }
+  if (mismatchedClaims.length > 0) {
+    fail('evidence.claims', `证据声明与验收清单不一致：${mismatchedClaims.join('、')}`)
+  }
+  if (invalidArtifacts.length > 0) {
+    fail('evidence.artifact', `原始材料不存在或 SHA-256 不匹配：${invalidArtifacts.join('、')}`)
+  }
+
+  return { ok: failures.length === 0, failures }
+}
+
+function runCli() {
+  const evidenceArgument = process.argv[2]
+  if (!evidenceArgument) {
+    console.error('用法：npm run verify:online-acceptance -- <证据.json>')
+    process.exitCode = 2
+    return
+  }
+
+  const evidencePath = resolve(evidenceArgument)
+  let evidence
+  try {
+    evidence = JSON.parse(readFileSync(evidencePath, 'utf8'))
+  } catch (error) {
+    console.error(`无法读取证据 JSON：${error instanceof Error ? error.message : String(error)}`)
+    process.exitCode = 2
+    return
+  }
+
+  const evidenceDirectory = dirname(evidencePath)
+  const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
+  const result = verifyOnlineAcceptanceEvidence(evidence, {
+    expectedRelease: `v${packageJson.version}`,
+    referenceExists(reference) {
+      try {
+        return statSync(resolve(evidenceDirectory, reference)).isFile()
+      } catch {
+        return false
+      }
+    },
+    readReference(reference) {
+      try {
+        return readFileSync(resolve(evidenceDirectory, reference), 'utf8')
+      } catch {
+        return undefined
+      }
+    },
+    readArtifact(reference) {
+      try {
+        return readFileSync(resolve(evidenceDirectory, reference))
+      } catch {
+        return undefined
+      }
+    },
+  })
+  if (result.ok) {
+    console.log(`PASS ${evidence.release}：全部联机升温局硬门槛均有匿名证据`)
+    return
+  }
+
+  console.error(`FAIL ${evidence.release ?? 'unknown'}：${result.failures.length} 个门槛未满足`)
+  for (const failure of result.failures) console.error(`- [${failure.gate}] ${failure.message}`)
+  process.exitCode = 1
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : ''
+if (invokedPath === import.meta.url) runCli()

--- a/scripts/online-acceptance-evidence.test.mjs
+++ b/scripts/online-acceptance-evidence.test.mjs
@@ -1,0 +1,404 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { verifyOnlineAcceptanceEvidence } from './online-acceptance-evidence.mjs'
+
+const verifierPath = fileURLToPath(new URL('./online-acceptance-evidence.mjs', import.meta.url))
+const artifactContents = 'anonymous acceptance artifact'
+const artifactSha256 = '6a8a31835b9db9c616312f93f89e556ca380cc986fca993da786ee72697b957d'
+
+function proofKind(reference) {
+  if (reference.includes('public-gateway')) return 'public_gateway'
+  if (reference.includes('load-test')) return 'load_test'
+  if (reference.includes('privacy-audit')) return 'privacy_audit'
+  if (reference.includes('production-observation')) return 'production_observation'
+  if (reference.includes('session') && !reference.match(/[468]-player/)) return 'physical_device'
+  return 'field_session'
+}
+
+function validEvidence() {
+  return {
+    schemaVersion: 1,
+    release: 'v1.12.3',
+    publicGateway: {
+      dnsResolved: true,
+      certificateSans: ['atang-sp.run.place', 'rooms.atang-sp.run.place'],
+      httpsHealth: true,
+      wssCreateJoinReconnect: true,
+      evidenceRefs: ['evidence/public-gateway.json'],
+    },
+    loadTest: {
+      rooms: 20,
+      connections: 160,
+      measurementScope: 'all_room_clients',
+      p95Ms: 0.3,
+      rssMiB: 101,
+      evidenceRefs: ['evidence/load-test.json'],
+    },
+    privacy: { passed: true, evidenceRefs: ['evidence/privacy-audit.json'] },
+    production: {
+      discourseHealthy: true,
+      kernelOomEvents: 0,
+      swapSamplesMiB: [771, 804, 790],
+      evidenceRefs: ['evidence/production-observation.json'],
+    },
+    physicalDevices: [
+      {
+        platform: 'ios_safari',
+        realDevice: true,
+        createRoom: true,
+        reconnect: true,
+        fullGameCompleted: true,
+        evidenceRefs: ['evidence/ios-session.json'],
+      },
+      {
+        platform: 'android_chrome',
+        realDevice: true,
+        createRoom: true,
+        reconnect: true,
+        fullGameCompleted: true,
+        evidenceRefs: ['evidence/android-session.json'],
+      },
+    ],
+    fieldSessions: [4, 6, 8].map(playerCount => ({
+      playerCount,
+      realParticipants: true,
+      unattended: true,
+      completed: true,
+      joinConfirmSeconds: 45,
+      staffInterventions: 0,
+      evidenceRefs: [`evidence/${playerCount}-player-session.json`],
+    })),
+  }
+}
+
+const proofClaimFields = {
+  public_gateway: ['dnsResolved', 'certificateSans', 'httpsHealth', 'wssCreateJoinReconnect'],
+  load_test: ['rooms', 'connections', 'measurementScope', 'p95Ms', 'rssMiB'],
+  privacy_audit: ['passed'],
+  production_observation: ['discourseHealthy', 'kernelOomEvents', 'swapSamplesMiB'],
+  physical_device: ['platform', 'realDevice', 'createRoom', 'reconnect', 'fullGameCompleted'],
+  field_session: [
+    'playerCount',
+    'realParticipants',
+    'unattended',
+    'completed',
+    'joinConfirmSeconds',
+    'staffInterventions',
+  ],
+}
+
+function evidenceValueForReference(evidence, reference) {
+  const kind = proofKind(reference)
+  if (kind === 'public_gateway') return evidence.publicGateway
+  if (kind === 'load_test') return evidence.loadTest
+  if (kind === 'privacy_audit') return evidence.privacy
+  if (kind === 'production_observation') return evidence.production
+  if (kind === 'physical_device') {
+    const platform = reference.includes('ios-') ? 'ios_safari' : 'android_chrome'
+    return evidence.physicalDevices.find(device => device.platform === platform)
+  }
+  const playerCount = Number(reference.match(/([468])-player/)?.[1])
+  return evidence.fieldSessions.find(session => session.playerCount === playerCount)
+}
+
+function validProof(evidence, reference) {
+  const kind = proofKind(reference)
+  const value = evidenceValueForReference(evidence, reference)
+  const claims = Object.fromEntries(proofClaimFields[kind].map(field => [field, value[field]]))
+  return JSON.stringify({
+    schemaVersion: 1,
+    release: evidence.release,
+    recordedAtUtc: '2026-08-02T10:00:00.000Z',
+    kind,
+    artifacts: [
+      {
+        path: reference.replace('evidence/', 'artifacts/').replace('.json', '.txt'),
+        sha256: artifactSha256,
+      },
+    ],
+    claims,
+  })
+}
+
+function verifyEvidence(evidence, overrides = {}) {
+  return verifyOnlineAcceptanceEvidence(evidence, {
+    expectedRelease: 'v1.12.3',
+    referenceExists: () => true,
+    readReference: reference => validProof(evidence, reference),
+    readArtifact: () => Buffer.from(artifactContents),
+    ...overrides,
+  })
+}
+
+describe('联机升温局验收证据', () => {
+  it('接受满足全部硬门槛且引用文件存在的匿名证据', () => {
+    const result = verifyEvidence(validEvidence())
+
+    expect(result).toEqual({ ok: true, failures: [] })
+  })
+
+  it('拒绝不是对象的证据输入', () => {
+    const result = verifyEvidence(null)
+
+    expect(result.ok).toBe(false)
+    expect(result.failures).toContainEqual({
+      gate: 'schema',
+      message: '验收证据必须是 JSON 对象',
+    })
+  })
+
+  it('拒绝没有覆盖 20 房间 160 连接及资源门槛的压测证据', () => {
+    const evidence = validEvidence()
+    evidence.loadTest = {
+      ...evidence.loadTest,
+      rooms: 19,
+      connections: 159,
+      measurementScope: 'host_only',
+      p95Ms: 500,
+      rssMiB: 128,
+    }
+
+    const result = verifyEvidence(evidence)
+
+    expect(result.failures.map(failure => failure.gate)).toEqual([
+      'load.rooms',
+      'load.connections',
+      'load.scope',
+      'load.p95',
+      'load.rss',
+    ])
+  })
+
+  it('拒绝用 null 冒充压测数值', () => {
+    const evidence = validEvidence()
+    evidence.loadTest.p95Ms = null
+    evidence.loadTest.rssMiB = null
+
+    const result = verifyEvidence(evidence)
+
+    expect(result.failures.map(failure => failure.gate)).toEqual(['load.p95', 'load.rss'])
+  })
+
+  it('拒绝 DNS、双域证书或公网 HTTPS/WSS 未通过的上线证据', () => {
+    const evidence = validEvidence()
+    evidence.publicGateway = {
+      dnsResolved: false,
+      certificateSans: ['atang-sp.run.place'],
+      httpsHealth: false,
+      wssCreateJoinReconnect: false,
+      evidenceRefs: ['evidence/public-gateway.json'],
+    }
+
+    const result = verifyEvidence(evidence)
+
+    expect(result.failures.map(failure => failure.gate)).toEqual([
+      'gateway.dns',
+      'gateway.certificate',
+      'gateway.https',
+      'gateway.wss',
+    ])
+  })
+
+  it('拒绝缺失真实 iOS 或 Android 完整对局与重连的证据', () => {
+    const evidence = validEvidence()
+    evidence.physicalDevices = [
+      {
+        ...evidence.physicalDevices[0],
+        reconnect: false,
+      },
+    ]
+
+    const result = verifyEvidence(evidence)
+
+    expect(result.failures.map(failure => failure.gate)).toEqual([
+      'device.ios_safari',
+      'device.android_chrome',
+    ])
+  })
+
+  it('拒绝不是 4/6/8 人真人、60 秒内确认、零人工介入的完整场次', () => {
+    const evidence = validEvidence()
+    evidence.fieldSessions = [
+      { ...evidence.fieldSessions[0], unattended: false },
+      { ...evidence.fieldSessions[1], joinConfirmSeconds: 61 },
+    ]
+
+    const result = verifyEvidence(evidence)
+
+    expect(result.failures.map(failure => failure.gate)).toEqual([
+      'session.4_players',
+      'session.6_players',
+      'session.8_players',
+    ])
+  })
+
+  it('拒绝隐私、Discourse、OOM 或 swap 稳定性未过门槛的证据', () => {
+    const evidence = validEvidence()
+    evidence.privacy.passed = false
+    evidence.production = {
+      ...evidence.production,
+      discourseHealthy: false,
+      kernelOomEvents: 1,
+      swapSamplesMiB: [700, 900, 700],
+    }
+
+    const result = verifyEvidence(evidence)
+
+    expect(result.failures.map(failure => failure.gate)).toEqual([
+      'privacy',
+      'production.discourse',
+      'production.oom',
+      'production.swap',
+    ])
+  })
+
+  it('拒绝证据 JSON 中出现昵称、房间码、消息或惩罚内容字段', () => {
+    const evidence = validEvidence()
+    evidence.fieldSessions[0].participants = ['不应保存的身份']
+
+    const result = verifyEvidence(evidence)
+
+    expect(result.failures).toContainEqual({
+      gate: 'privacy.forbidden_fields',
+      message: '证据不得包含私人字段：fieldSessions[0].participants',
+    })
+  })
+
+  it('拒绝不存在的证据文件引用', () => {
+    const evidence = validEvidence()
+    const result = verifyEvidence(evidence, {
+      referenceExists: reference => reference !== 'evidence/6-player-session.json',
+    })
+
+    expect(result.failures).toContainEqual({
+      gate: 'evidence.refs',
+      message: '证据引用不存在：evidence/6-player-session.json',
+    })
+  })
+
+  it('拒绝未知证据版本或非发布标签', () => {
+    const evidence = validEvidence()
+    evidence.schemaVersion = 2
+    evidence.release = 'main'
+
+    const result = verifyEvidence(evidence, { expectedRelease: 'main' })
+
+    expect(result.failures.map(failure => failure.gate)).toEqual(['schema.version', 'release'])
+  })
+
+  it('拒绝与当前待发布版本不一致的证据', () => {
+    const evidence = validEvidence()
+    const result = verifyEvidence(evidence, { expectedRelease: 'v1.12.4' })
+
+    expect(result.failures).toContainEqual({
+      gate: 'release.current',
+      message: '证据发布 v1.12.3 与当前待发布版本 v1.12.4 不一致',
+    })
+  })
+
+  it('拒绝空白或无法解析的证据引用文件', () => {
+    const evidence = validEvidence()
+    const result = verifyEvidence(evidence, { readReference: () => '' })
+
+    expect(result.failures.map(failure => failure.gate)).toContain('evidence.proof')
+  })
+
+  it('拒绝没有明确 UTC 时区的证明时间', () => {
+    const evidence = validEvidence()
+    const result = verifyEvidence(evidence, {
+      readReference: reference => {
+        const proof = JSON.parse(validProof(evidence, reference))
+        proof.recordedAtUtc = '2026-08-02'
+        return JSON.stringify(proof)
+      },
+    })
+
+    expect(result.failures.map(failure => failure.gate)).toContain('evidence.proof')
+  })
+
+  it('拒绝元数据有效但声明与验收清单不一致的证据文件', () => {
+    const evidence = validEvidence()
+    const result = verifyEvidence(evidence, {
+      readReference: reference =>
+        JSON.stringify({
+          schemaVersion: 1,
+          release: 'v1.12.3',
+          recordedAtUtc: '2026-08-02T10:00:00.000Z',
+          kind: proofKind(reference),
+          artifacts: [
+            {
+              path: reference.replace('evidence/', 'artifacts/').replace('.json', '.txt'),
+              sha256: artifactSha256,
+            },
+          ],
+          claims: {},
+        }),
+    })
+
+    expect(result.failures.map(failure => failure.gate)).toContain('evidence.claims')
+  })
+
+  it('拒绝无法用 SHA-256 对应到原始材料的结构化证明', () => {
+    const evidence = validEvidence()
+    const result = verifyEvidence(evidence, {
+      readArtifact: () => Buffer.from('digest mismatch'),
+    })
+
+    expect(result.failures.map(failure => failure.gate)).toContain('evidence.artifact')
+  })
+
+  it('拒绝未提供当前版本与证据读取器的宽松调用', () => {
+    const result = verifyOnlineAcceptanceEvidence(validEvidence(), () => true)
+
+    expect(result.failures).toContainEqual({
+      gate: 'verification.context',
+      message: '校验必须绑定当前发布版本并读取证据文件内容',
+    })
+  })
+
+  it('命令行缺少证据文件时以用法错误退出', () => {
+    const result = spawnSync(process.execPath, [verifierPath], { encoding: 'utf8' })
+
+    expect(result.status).toBe(2)
+    expect(result.stderr).toContain('用法：npm run verify:online-acceptance -- <证据.json>')
+  })
+
+  it('命令行读取结构化证明并绑定 package.json 当前版本', () => {
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), 'flying-chess-acceptance-'))
+    try {
+      const evidence = validEvidence()
+      const references = [
+        ...evidence.publicGateway.evidenceRefs,
+        ...evidence.loadTest.evidenceRefs,
+        ...evidence.privacy.evidenceRefs,
+        ...evidence.production.evidenceRefs,
+        ...evidence.physicalDevices.flatMap(device => device.evidenceRefs),
+        ...evidence.fieldSessions.flatMap(session => session.evidenceRefs),
+      ]
+      for (const reference of references) {
+        const proofPath = join(temporaryDirectory, reference)
+        mkdirSync(dirname(proofPath), { recursive: true })
+        const proof = JSON.parse(validProof(evidence, reference))
+        writeFileSync(proofPath, JSON.stringify(proof))
+        for (const artifact of proof.artifacts) {
+          const artifactPath = join(temporaryDirectory, artifact.path)
+          mkdirSync(dirname(artifactPath), { recursive: true })
+          writeFileSync(artifactPath, artifactContents)
+        }
+      }
+      const evidencePath = join(temporaryDirectory, 'evidence.json')
+      writeFileSync(evidencePath, JSON.stringify(evidence))
+
+      const result = spawnSync(process.execPath, [verifierPath, evidencePath], { encoding: 'utf8' })
+
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain('PASS v1.12.3')
+    } finally {
+      rmSync(temporaryDirectory, { recursive: true, force: true })
+    }
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,8 +58,13 @@ export default defineConfig(async ({ command, mode }) => {
     base: '/flying-chess/',
     test: {
       setupFiles: ['src/tests/setup.ts'],
-      include: ['src/tests/**/*.test.ts', 'packages/**/*.test.ts', 'apps/**/*.test.ts'],
-      exclude: ['scripts/**', '**/e2e/**', 'node_modules/**'],
+      include: [
+        'src/tests/**/*.test.ts',
+        'packages/**/*.test.ts',
+        'apps/**/*.test.ts',
+        'scripts/**/*.test.mjs',
+      ],
+      exclude: ['**/e2e/**', 'node_modules/**'],
     },
     server: {
       // 允许内网访问


### PR DESCRIPTION
## 变更

- 新增 fail-closed 的联机升温局验收证据校验器与匿名模板
- 将 DNS、双域证书、公网 HTTPS/WSS、压测、隐私、生产健康、真机和 4/6/8 人现场场次纳入统一合同
- 结构化证明绑定当前发布版本、UTC、声明内容与原始材料 SHA-256
- 将前端、共享核心、房间服务及部署镜像版本同步到 v1.12.3
- 固定 Playwright 版本注入，避免待发布分支误显示历史标签

## 原因与影响

v1.12.2 已完成代码与生产内网部署，但公网 DNS、真机和真人现场硬门槛仍缺证据。本补丁防止自动化结果、空占位文件、自报布尔值或旧版本材料被误判为完整上线。经典模式和联机玩法行为均未改变。

## 验证

- `npm test`：22 文件、200 项通过
- `npm run type-check`
- `npm run lint:check`
- `npm run format:check`
- `npm run build`
- `npm run validate-config`
- `npm run test:room-server-load`：20 房间、160 连接、RSS 100.9MiB、P95 2.4ms、320 样本
- `npm run test:e2e`：57 通过、55 个矩阵预期跳过
- 双轴复审：Standards 0 项、Spec 0 项
