### PR TITLE
Harden online room reliability and privacy

### DIFF
--- a/apps/room-server/package.json
+++ b/apps/room-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/room-server",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "private": true,
   "type": "module",
   "scripts": {
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@flying-chess/game-core": "1.12.4",
+    "@flying-chess/game-core": "1.12.5",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/apps/room-server/src/server.ts
+++ b/apps/room-server/src/server.ts
@@ -30,6 +30,8 @@ const DEFAULT_RECONNECT_GRACE_MS = 90_000
 const MAX_MESSAGE_BYTES = 16 * 1_024
 const NICKNAME_MAX_LENGTH = 20
 const COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/
+const DEFAULT_MESSAGES_PER_SECOND = 30
+const DEFAULT_MESSAGE_BURST = 60
 
 interface RoomPlayer {
   readonly id: string
@@ -67,6 +69,8 @@ export interface RoomServerOptions {
   readonly reconnectGraceMs?: number
   readonly maxConnections?: number
   readonly allowedOrigins?: readonly string[]
+  readonly messagesPerSecond?: number
+  readonly messageBurst?: number
 }
 
 export interface RunningRoomServer {
@@ -93,6 +97,8 @@ export async function createRoomServer(
   const roomTtlMs = options.roomTtlMs ?? DEFAULT_ROOM_TTL_MS
   const reconnectGraceMs = options.reconnectGraceMs ?? DEFAULT_RECONNECT_GRACE_MS
   const maxConnections = options.maxConnections ?? DEFAULT_MAX_CONNECTIONS
+  const messagesPerSecond = Math.max(1, options.messagesPerSecond ?? DEFAULT_MESSAGES_PER_SECOND)
+  const messageBurst = Math.max(1, options.messageBurst ?? DEFAULT_MESSAGE_BURST)
   const startedAt = Date.now()
   const gameDependencies: GameCommandDependencies = {
     rollDice: options.rollDice ?? (() => randomInt(1, 7)),
@@ -101,6 +107,7 @@ export async function createRoomServer(
   }
   const rooms = new Map<string, Room>()
   const sessions = new Map<WebSocket, ConnectionSession>()
+  let connectionCount = 0
   const httpServer = createServer((request, response) => {
     if (request.method === 'GET' && (request.url === '/health' || request.url === '/ready')) {
       response.writeHead(200, { 'content-type': 'application/json; charset=utf-8' })
@@ -108,12 +115,7 @@ export async function createRoomServer(
         JSON.stringify({
           status: 'ok',
           rooms: rooms.size,
-          connections: [...rooms.values()].reduce(
-            (count, room) =>
-              count +
-              room.players.filter(player => player.socket?.readyState === WebSocket.OPEN).length,
-            0
-          ),
+          connections: connectionCount,
           uptimeSeconds: Math.floor((Date.now() - startedAt) / 1_000),
           rssBytes: process.memoryUsage().rss,
         })
@@ -176,14 +178,35 @@ export async function createRoomServer(
   heartbeatTimer.unref()
 
   webSocketServer.on('connection', socket => {
+    connectionCount += 1
+    let availableMessageTokens = messageBurst
+    let lastMessageRefillAt = Date.now()
     lastPongAt.set(socket, Date.now())
     socket.on('pong', () => lastPongAt.set(socket, Date.now()))
     socket.on('message', raw => {
+      const receivedAt = Date.now()
+      availableMessageTokens = Math.min(
+        messageBurst,
+        availableMessageTokens + ((receivedAt - lastMessageRefillAt) / 1_000) * messagesPerSecond
+      )
+      lastMessageRefillAt = receivedAt
+      if (availableMessageTokens < 1) {
+        send(socket, {
+          type: 'error',
+          code: 'RATE_LIMITED',
+          message: '消息过于频繁，请重新连接',
+        })
+        socket.close(1008, 'message rate exceeded')
+        return
+      }
+      availableMessageTokens -= 1
+      let requestId: string | undefined
       try {
         const message = parseClientMessage(raw.toString())
+        requestId = message.requestId
         handleMessage(socket, message)
       } catch (error) {
-        const protocolError = normalizeError(error)
+        const protocolError = normalizeError(error, requestId)
         send(socket, {
           type: 'error',
           requestId: protocolError.requestId,
@@ -193,12 +216,13 @@ export async function createRoomServer(
       }
     })
     socket.on('close', () => {
+      connectionCount = Math.max(0, connectionCount - 1)
       const session = sessions.get(socket)
       sessions.delete(socket)
       if (!session || session.player.socket !== socket) return
       session.player.socket = null
       session.player.disconnectedAt = now()
-      broadcastRoom(session.room)
+      if (rooms.get(session.room.code) === session.room) broadcastRoom(session.room)
     })
   })
 
@@ -289,6 +313,14 @@ export async function createRoomServer(
       if (!room.players.some(candidate => candidate.id === message.playerId)) {
         throw new ProtocolError('PLAYER_NOT_FOUND', '接任玩家不在房间中', message.requestId)
       }
+      const successor = room.players.find(candidate => candidate.id === message.playerId)
+      if (successor?.socket?.readyState !== WebSocket.OPEN) {
+        throw new ProtocolError(
+          'PLAYER_DISCONNECTED',
+          '只能把主持权转交给在线玩家',
+          message.requestId
+        )
+      }
       room.hostPlayerId = message.playerId
       broadcastRoom(room)
       return
@@ -378,6 +410,9 @@ export async function createRoomServer(
           '所有玩家确认设置后才能开始',
           message.requestId
         )
+      }
+      if (!room.players.every(roomPlayer => roomPlayer.socket?.readyState === WebSocket.OPEN)) {
+        throw new ProtocolError('PLAYERS_DISCONNECTED', '所有玩家在线时才能开始', message.requestId)
       }
       room.game = createOnlineGame(
         room.players.map(roomPlayer => ({
@@ -503,7 +538,7 @@ function projectRoom(
       removable:
         player.disconnectedAt !== null &&
         now - player.disconnectedAt >= reconnectGraceMs &&
-        (!room.game || isOnlinePlayerRemovalSafe(room.game)),
+        (!room.game || (room.players.length > 2 && isOnlinePlayerRemovalSafe(room.game))),
     })),
     settings: room.settings,
     confirmedPlayerIds: room.players
@@ -782,10 +817,11 @@ function createUniqueRoomCode(rooms: ReadonlyMap<string, Room>): string {
   throw new ProtocolError('ROOM_CODE_EXHAUSTED', '暂时无法分配房间码')
 }
 
-function normalizeError(error: unknown): ProtocolError {
+function normalizeError(error: unknown, requestId?: string): ProtocolError {
   if (error instanceof ProtocolError) return error
-  if (error instanceof GameCommandError) return new ProtocolError(error.code, error.message)
-  return new ProtocolError('INTERNAL_ERROR', '房间服务处理失败')
+  if (error instanceof GameCommandError)
+    return new ProtocolError(error.code, error.message, requestId)
+  return new ProtocolError('INTERNAL_ERROR', '房间服务处理失败', requestId)
 }
 
 function closeWebSocketServer(server: WebSocketServer): Promise<void> {

--- a/apps/room-server/test/vertical-slice.test.ts
+++ b/apps/room-server/test/vertical-slice.test.ts
@@ -76,6 +76,19 @@ describe('联网升温局服务器权威纵向切片', () => {
     await server?.close()
   })
 
+  it('健康指标统计所有已建立连接，包括尚未加入房间的连接', async () => {
+    server = await createRoomServer({ port: 0 })
+    const idleClient = await TestClient.connect(server.wsUrl)
+    clients.push(idleClient)
+
+    const response = await fetch(`${server.wsUrl.replace('ws://', 'http://')}/health`)
+    await expect(response.json()).resolves.toMatchObject({
+      status: 'ok',
+      rooms: 0,
+      connections: 1,
+    })
+  })
+
   it('三个玩家通过 WebSocket 建房加入后，由服务器判定掷骰与移动并同步给所有客户端', async () => {
     server = await createRoomServer({ port: 0, rollDice: () => 6, eventDeck: quietEventDeck })
     const host = await TestClient.connect(server.wsUrl)
@@ -335,6 +348,141 @@ describe('联网升温局服务器权威纵向切片', () => {
           message.type === 'room_state' && message.room.settings.scenePreset === 'icebreaker'
       )
     ).resolves.toMatchObject({ type: 'room_state' })
+  })
+
+  it('不允许把主持权转交给离线玩家', async () => {
+    server = await createRoomServer({ port: 0 })
+    const host = await TestClient.connect(server.wsUrl)
+    const guest = await TestClient.connect(server.wsUrl)
+    clients.push(host, guest)
+    host.send({
+      type: 'create_room',
+      requestId: 'offline-transfer-create',
+      nickname: '主持人',
+      color: '#ff6b6b',
+    })
+    const created = await host.next(message => message.type === 'session')
+    if (created.type !== 'session') throw new Error('expected session')
+    guest.send({
+      type: 'join_room',
+      requestId: 'offline-transfer-join',
+      roomCode: created.roomCode,
+      nickname: '离线玩家',
+      color: '#4ecdc4',
+    })
+    const joined = await guest.next(message => message.type === 'session')
+    if (joined.type !== 'session') throw new Error('expected session')
+    await guest.disconnect()
+    await host.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.players.some(player => player.id === joined.playerId && !player.connected)
+    )
+
+    host.send({
+      type: 'transfer_host',
+      requestId: 'offline-transfer',
+      playerId: joined.playerId,
+    })
+    await expect(
+      host.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'offline-transfer' &&
+          message.code === 'PLAYER_DISCONNECTED'
+      )
+    ).resolves.toMatchObject({ type: 'error' })
+  })
+
+  it('已确认玩家断线后不能开局，规则错误保留原请求标识', async () => {
+    server = await createRoomServer({ port: 0 })
+    const host = await TestClient.connect(server.wsUrl)
+    const guest = await TestClient.connect(server.wsUrl)
+    clients.push(host, guest)
+    host.send({
+      type: 'create_room',
+      requestId: 'connected-start-create',
+      nickname: '主持人',
+      color: '#ff6b6b',
+    })
+    const created = await host.next(message => message.type === 'session')
+    if (created.type !== 'session') throw new Error('expected session')
+    guest.send({
+      type: 'join_room',
+      requestId: 'connected-start-join',
+      roomCode: created.roomCode,
+      nickname: '玩家二',
+      color: '#4ecdc4',
+    })
+    const joined = await guest.next(message => message.type === 'session')
+    if (joined.type !== 'session') throw new Error('expected session')
+    host.send({ type: 'confirm_settings', requestId: 'connected-start-host-confirm' })
+    guest.send({ type: 'confirm_settings', requestId: 'connected-start-guest-confirm' })
+    await host.next(
+      message => message.type === 'room_state' && message.room.confirmedPlayerIds.length === 2
+    )
+    await guest.disconnect()
+    await host.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.players.some(player => player.id === joined.playerId && !player.connected)
+    )
+
+    host.send({ type: 'start_game', requestId: 'connected-start-blocked' })
+    await expect(
+      host.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'connected-start-blocked' &&
+          message.code === 'PLAYERS_DISCONNECTED'
+      )
+    ).resolves.toMatchObject({ type: 'error' })
+
+    const resumed = await TestClient.connect(server.wsUrl)
+    clients.push(resumed)
+    resumed.send({
+      type: 'resume_room',
+      requestId: 'connected-start-resume',
+      roomCode: joined.roomCode,
+      playerId: joined.playerId,
+      resumeToken: joined.resumeToken,
+    })
+    await resumed.next(message => message.type === 'session')
+    host.send({ type: 'start_game', requestId: 'connected-start-ok' })
+    await host.next(message => message.type === 'room_state' && message.room.status === 'playing')
+
+    host.send({ type: 'roll_dice', requestId: 'rule-error-request-id' })
+    await expect(
+      host.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'rule-error-request-id' &&
+          message.code === 'INVALID_PHASE'
+      )
+    ).resolves.toMatchObject({ type: 'error' })
+  })
+
+  it('单连接消息洪泛会被限速并断开', async () => {
+    server = await createRoomServer({
+      port: 0,
+      messagesPerSecond: 1,
+      messageBurst: 2,
+    })
+    const client = await TestClient.connect(server.wsUrl)
+    clients.push(client)
+    client.send({
+      type: 'create_room',
+      requestId: 'rate-create',
+      nickname: '限速玩家',
+      color: '#ff6b6b',
+    })
+    await client.next(message => message.type === 'session')
+    client.send({ type: 'confirm_settings', requestId: 'rate-confirm-1' })
+    client.send({ type: 'confirm_settings', requestId: 'rate-confirm-2' })
+
+    await expect(
+      client.next(message => message.type === 'error' && message.code === 'RATE_LIMITED')
+    ).resolves.toMatchObject({ type: 'error' })
   })
 
   it('八名玩家可在 60 秒门槛内加入并全员确认，第九名被容量门禁拒绝', async () => {

--- a/deploy/room-server/ACCEPTANCE.md
+++ b/deploy/room-server/ACCEPTANCE.md
@@ -18,9 +18,9 @@
 证据不得提交到仓库。先复制模板到已被 `.gitignore` 排除的目录：
 
 ```bash
-mkdir -p .acceptance-evidence/v1.12.4/{evidence,artifacts}
+mkdir -p .acceptance-evidence/v1.12.5/{evidence,artifacts}
 cp deploy/room-server/acceptance-evidence.template.json \
-  .acceptance-evidence/v1.12.4/evidence.json
+  .acceptance-evidence/v1.12.5/evidence.json
 ```
 
 每个 `evidenceRefs` 都必须指向结构化 JSON 证明，可从 `acceptance-proof.template.json` 复制。证明必须包含同一个发布标签、UTC 时间、证明类别、与主清单完全一致的 `claims`，以及至少一个原始材料文件和它的 SHA-256。校验器会读取原始文件并重新计算摘要；空文件、目录、错误摘要、错误版本、错误类别、声明不一致或私人字段都会失败。
@@ -43,7 +43,7 @@ cp deploy/room-server/acceptance-evidence.template.json \
 计算摘要示例：
 
 ```bash
-sha256sum .acceptance-evidence/v1.12.4/artifacts/<已脱敏材料>
+sha256sum .acceptance-evidence/v1.12.5/artifacts/<已脱敏材料>
 ```
 
 生产资源证据至少在现场验收前、中、后各采样一次。`swapSamplesMiB` 至少填 3 个数；校验器将峰峰值不超过 128MiB 作为“无 swap 振荡”的保守可重复判据。
@@ -78,7 +78,7 @@ sha256sum .acceptance-evidence/v1.12.4/artifacts/<已脱敏材料>
 
 ```bash
 npm run verify:online-acceptance -- \
-  .acceptance-evidence/v1.12.4/evidence.json
+  .acceptance-evidence/v1.12.5/evidence.json
 ```
 
 退出码 `0` 且输出 `PASS` 才表示证据合同满足；退出码 `1` 表示一个或多个硬门槛失败，退出码 `2` 表示文件/JSON 用法错误。该命令只校验证据完整性，不会替代人工核对材料真实性。

--- a/deploy/room-server/README.md
+++ b/deploy/room-server/README.md
@@ -1,13 +1,13 @@
 # 联机升温局房间服务部署
 
-生产拓扑：GitHub Pages 前端连接 `wss://rooms.atang-sp.run.place`；Discourse 容器内的 Nginx 终止 TLS，并反代到 Docker 网桥 `172.17.0.1:8787`。房间容器使用 host 网络并只监听该网桥地址，避免 Docker 发布端口在同机容器间被防火墙阻断，也不会把 `8787` 暴露到公网。房间服务不写磁盘，容器被限制为 128 MiB 内存、1 CPU、只读根文件系统。
+生产拓扑：GitHub Pages 前端连接 `wss://rooms.atang-sp.run.place`；Discourse 容器内的 Nginx 终止 TLS，并反代到 Docker 网桥 `172.17.0.1:8787`。房间容器使用 host 网络并只监听该网桥地址，避免 Docker 发布端口在同机容器间被防火墙阻断，也不会把 `8787` 暴露到公网。房间服务不写磁盘，容器被限制为 128 MiB 内存、1 CPU、只读根文件系统。Nginx 对单 IP 限制 16 个并发连接和每秒 5 次握手（允许 20 次突发），应用层对单连接限制每秒 30 条消息（允许 60 条突发）。
 
 ## 构建与安装
 
-在已检出不可变 `v1.12.4` 标签的仓库根目录执行：
+在已检出不可变 `v1.12.5` 标签的仓库根目录执行：
 
 ```bash
-docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.12.4 .
+docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.12.5 .
 ufw allow in on docker0 from 172.17.0.0/16 to 172.17.0.1 port 8787 proto tcp comment "flying chess room from discourse"
 install -m 0644 deploy/room-server/flying-chess-room.service /etc/systemd/system/
 install -m 0644 deploy/room-server/flying-chess-room-health.service /etc/systemd/system/

--- a/deploy/room-server/acceptance-evidence.template.json
+++ b/deploy/room-server/acceptance-evidence.template.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "release": "v1.12.4",
+  "release": "v1.12.5",
   "publicGateway": {
     "dnsResolved": false,
     "certificateSans": [],

--- a/deploy/room-server/acceptance-proof.template.json
+++ b/deploy/room-server/acceptance-proof.template.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "release": "v1.12.4",
+  "release": "v1.12.5",
   "recordedAtUtc": "2026-08-02T00:00:00.000Z",
   "kind": "replace_with_required_kind",
   "artifacts": [

--- a/deploy/room-server/flying-chess-room.service
+++ b/deploy/room-server/flying-chess-room.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=ROOM_IMAGE=flying-chess-room:1.12.4
+Environment=ROOM_IMAGE=flying-chess-room:1.12.5
 EnvironmentFile=-/etc/flying-chess-room.env
 ExecStartPre=-/usr/bin/docker rm -f flying-chess-room
 ExecStart=/usr/bin/docker run --rm --name flying-chess-room --network host --read-only --tmpfs /tmp:rw,noexec,nosuid,size=8m --cap-drop ALL --security-opt no-new-privileges --pids-limit 128 --cpus 1 --memory 128m --memory-swap 192m --health-cmd "wget -qO- http://172.17.0.1:8787/ready >/dev/null || exit 1" --health-interval 30s --health-timeout 3s --health-start-period 5s --health-retries 3 --log-driver journald -e NODE_ENV=production -e HOST=172.17.0.1 -e PORT=8787 -e ALLOWED_ORIGINS=https://atang-sp.github.io ${ROOM_IMAGE}

--- a/deploy/room-server/rooms.nginx.conf
+++ b/deploy/room-server/rooms.nginx.conf
@@ -1,3 +1,6 @@
+limit_conn_zone $binary_remote_addr zone=flying_chess_room_connections:10m;
+limit_req_zone $binary_remote_addr zone=flying_chess_room_handshakes:10m rate=5r/s;
+
 server {
   listen 80;
   listen [::]:80;
@@ -28,6 +31,10 @@ server {
   client_max_body_size 16k;
 
   location / {
+    limit_conn flying_chess_room_connections 16;
+    limit_conn_status 429;
+    limit_req zone=flying_chess_room_handshakes burst=20 nodelay;
+    limit_req_status 429;
     proxy_pass http://172.17.0.1:8787;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -38,4 +45,3 @@ server {
     proxy_send_timeout 120s;
   }
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "1.12.4",
+      "version": "1.12.5",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -54,9 +54,9 @@
     },
     "apps/room-server": {
       "name": "@flying-chess/room-server",
-      "version": "1.12.4",
+      "version": "1.12.5",
       "dependencies": {
-        "@flying-chess/game-core": "1.12.4",
+        "@flying-chess/game-core": "1.12.5",
         "ws": "^8.18.3"
       },
       "devDependencies": {
@@ -11199,7 +11199,7 @@
     },
     "packages/game-core": {
       "name": "@flying-chess/game-core",
-      "version": "1.12.4"
+      "version": "1.12.5"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/game-core/package.json
+++ b/packages/game-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/game-core",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/game-core/src/index.ts
+++ b/packages/game-core/src/index.ts
@@ -69,6 +69,8 @@ import type {
   Player,
   PunishmentAction,
   PunishmentConfig,
+  PunishmentConstraints,
+  PunishmentVariant,
   ResolvedPunishmentResult,
   VictoryConfig,
 } from '../../../src/types/game'
@@ -294,6 +296,17 @@ export interface OnlineVictorySettlementEntry {
   readonly count: number
 }
 
+export interface OnlineGamePlayerView {
+  readonly id: string
+  readonly nickname: string
+  readonly color: string
+  readonly position: number
+  readonly hasTakenOff: boolean
+  readonly failedTakeoffAttempts: number
+  readonly isWinner: boolean
+  readonly pendingSkippedTurns?: number
+}
+
 export interface OnlineGameState {
   readonly schemaVersion: 1
   readonly rulesetVersion: typeof ONLINE_RULESET_VERSION
@@ -428,6 +441,7 @@ export interface OnlineGameView {
         kind: 'event_activation'
         title: string
         description: string
+        selectionPlayerCount: 0 | 2
       }>
     | Readonly<{
         kind: 'event_rps'
@@ -468,7 +482,7 @@ export interface OnlineGameView {
   readonly diceValue: number | null
   readonly paused: boolean
   readonly deadlineAt: number | null
-  readonly players: readonly OnlinePlayer[]
+  readonly players: readonly OnlineGamePlayerView[]
   readonly allowedCommands: readonly OnlineGameCommandName[]
   readonly lastEvent: OnlineGameState['lastEvent']
 }
@@ -631,6 +645,13 @@ export interface OnlineGameCreationOptions {
   readonly victoryConfig?: VictoryConfig
 }
 
+const ONLINE_BASELINE_PUNISHMENT_VARIANTS: readonly PunishmentVariant[] = [
+  'blindbox',
+  'conditional',
+  'deferred',
+  'mutual',
+]
+
 const DEFAULT_DEPENDENCIES: GameCommandDependencies = {
   rollDice: () => (crypto.getRandomValues(new Uint8Array(1))[0] % 6) + 1,
 }
@@ -650,11 +671,12 @@ export function createOnlineGame(
   const firstPlayer = roster[0]
   if (!firstPlayer) throw new GameCommandError('INVALID_ROSTER', '玩家名单不能为空')
   const punishmentConfig = options.punishmentConfig ?? GameService.createPunishmentConfig()
+  const baselineTraps = GAME_CONFIG.PARTY_TRAPS.filter(
+    trap => !trap.trapVariant?.startsWith('mini_game_') || trap.trapVariant === 'mini_game_reaction'
+  ).filter(trap => settings.scenePreset !== 'couple' || trap.trapVariant !== 'all_players')
   const board = options.board
     ? [...options.board]
-    : GameService.createBoard(punishmentConfig, boardConfigFor(settings.boardPreset), [
-        ...GAME_CONFIG.PARTY_TRAPS,
-      ])
+    : GameService.createBoard(punishmentConfig, boardConfigFor(settings.boardPreset), baselineTraps)
   const partySession = beginPartyTurn(
     createPartySession({ playerCount: roster.length, startedAt: options.startedAt ?? 0 }),
     0
@@ -1088,7 +1110,7 @@ function applyOnlineGameCommandInternal(
     const action = createCompatiblePunishmentAction(
       state.punishmentConfig,
       undefined,
-      getActConstraints(state.partySession.act)
+      onlineActConstraints(state)
     )
     return beginPunishmentResolution(
       { ...state, pendingAction: null },
@@ -1121,7 +1143,7 @@ function applyOnlineGameCommandInternal(
       const action = createCompatiblePunishmentAction(
         state.punishmentConfig,
         undefined,
-        getActConstraints(state.partySession.act)
+        onlineActConstraints(state)
       )
       return beginPunishmentResolution(
         { ...state, pendingAction: null },
@@ -1220,6 +1242,16 @@ function applyOnlineGameCommandInternal(
     )
     if (selectedPlayerIndices.some(index => index < 0)) {
       throw new GameCommandError('PLAYER_NOT_FOUND', '事件选择了不在房间中的玩家')
+    }
+    const requiredSelectionCount = pending.card.effect.kind === 'bind_players' ? 2 : 0
+    if (
+      selectedPlayerIndices.length !== requiredSelectionCount ||
+      new Set(selectedPlayerIndices).size !== selectedPlayerIndices.length
+    ) {
+      throw new GameCommandError(
+        'INVALID_PHASE',
+        requiredSelectionCount === 2 ? '绑定事件需要两名不同玩家' : '当前事件不需要选择玩家'
+      )
     }
     if (pending.card.effect.kind === 'mini_game') {
       return startEventMiniGame(
@@ -1410,7 +1442,7 @@ function applyOnlineGameCommandInternal(
     const source = actor.hasTakenOff ? 'board_punishment' : 'takeoff_failure'
     const cellType =
       movement.cellEffect?.type === 'chain_punishment' ? 'chain_punishment' : 'punishment'
-    const constraints = getActConstraints(state.partySession.act)
+    const constraints = onlineActConstraints(state)
     const fallback = actor.hasTakenOff
       ? createPartyPunishmentChoices(state.punishmentConfig, undefined, constraints)[0]
       : movement.punishment
@@ -1601,7 +1633,7 @@ export function projectOnlineGameView(state: OnlineGameState, viewerId: string):
               ? reaction.prediction
               : undefined,
           predictionCorrect:
-            reaction.status === 'awaiting_decision' || reaction.status === 'resolved'
+            viewerIndex === reaction.reactorPlayerIndex || reaction.status === 'resolved'
               ? reaction.predictionCorrect
               : undefined,
         }
@@ -1615,7 +1647,16 @@ export function projectOnlineGameView(state: OnlineGameState, viewerId: string):
     diceValue: state.diceValue,
     paused: state.partySession.pausedAt !== undefined,
     deadlineAt: state.deadlineAt,
-    players: state.players,
+    players: state.players.map(player => ({
+      id: player.id,
+      nickname: player.nickname,
+      color: player.color,
+      position: player.position,
+      hasTakenOff: player.hasTakenOff,
+      failedTakeoffAttempts: player.failedTakeoffAttempts,
+      isWinner: player.isWinner,
+      pendingSkippedTurns: player.pendingSkippedTurns,
+    })),
     allowedCommands,
     lastEvent: state.lastEvent,
   }
@@ -1787,6 +1828,7 @@ function timeoutDecisionPlayerId(state: OnlineGameState): string | undefined {
     return state.players[pending.decisionPlayerIndex]?.id
   }
   if (pending?.kind === 'event_result') return state.currentPlayerId
+  if (pending?.kind === 'event_activation') return state.currentPlayerId
   if (pending?.kind === 'event_mini_game') return state.players[pending.actorIndex]?.id
   return undefined
 }
@@ -1999,6 +2041,12 @@ function onlineDeadlineDuration(state: OnlineGameState): number {
   if (state.phase === 'awaiting_prediction' || state.phase === 'awaiting_reaction') return 10_000
   if (state.pendingAction?.kind === 'punishment_intervention') return 15_000
   if (state.pendingAction?.kind === 'event_vote') return 10_000
+  if (
+    state.pendingAction?.kind === 'event_mini_game' &&
+    state.pendingAction.card.effect.game === 'quick_quiz'
+  ) {
+    return 8_000
+  }
   return 20_000
 }
 
@@ -2015,6 +2063,21 @@ function boardConfigFor(boardPreset: OnlineBoardPreset): BoardConfig {
   if (boardPreset === 'couple_finale')
     return { ...GAME_CONFIG.PARTY_SCENE_PRESETS.intimate.boardConfig }
   return { ...GAME_CONFIG.PARTY_BOARD_CONFIG }
+}
+
+function onlineActConstraints(state: OnlineGameState): PunishmentConstraints {
+  const scene =
+    state.settings.scenePreset === 'icebreaker'
+      ? GAME_CONFIG.PARTY_SCENE_PRESETS.icebreaker
+      : state.settings.scenePreset === 'hardcore'
+        ? GAME_CONFIG.PARTY_SCENE_PRESETS.hardcore
+        : state.settings.scenePreset === 'couple'
+          ? GAME_CONFIG.PARTY_SCENE_PRESETS.intimate
+          : undefined
+  return {
+    ...getActConstraints(state.partySession.act),
+    ...(scene?.actConstraintsOverride?.[state.partySession.act] ?? {}),
+  }
 }
 
 function toRulePlayers(players: readonly OnlinePlayer[]): Player[] {
@@ -2049,7 +2112,7 @@ function beginLandingResolution(
       createCompatiblePunishmentAction(
         state.punishmentConfig,
         undefined,
-        getActConstraints(state.partySession.act)
+        onlineActConstraints(state)
       )
     return beginPunishmentResolution(
       state,
@@ -2135,7 +2198,11 @@ function beginPunishmentResolution(
   const rulePlayers = toRulePlayers(state.players)
   const punishmentVariant =
     pending.source === 'board_punishment'
-      ? pickPunishmentVariant(state.partySession.act)
+      ? pickPunishmentVariant(
+          state.partySession.act,
+          undefined,
+          ONLINE_BASELINE_PUNISHMENT_VARIANTS
+        )
       : undefined
   let resolution =
     pending.source === 'board_punishment'
@@ -2581,6 +2648,7 @@ function projectPendingAction(
       kind: pending.kind,
       title: pending.card.title,
       description: pending.card.description,
+      selectionPlayerCount: pending.card.effect.kind === 'bind_players' ? 2 : 0,
     }
   }
   if (pending.kind === 'event_rps') {

--- a/packages/game-core/src/onlineGame.test.ts
+++ b/packages/game-core/src/onlineGame.test.ts
@@ -34,6 +34,14 @@ describe('联网升温局权威规则内核', () => {
 
     expect(game.players).toHaveLength(2)
     expect(game.status).toBe('playing')
+    expect(
+      game.board.some(
+        cell =>
+          cell.effect?.type === 'trap' &&
+          (cell.effect.trapVariant === 'mini_game_memory' ||
+            cell.effect.trapVariant === 'mini_game_quiz')
+      )
+    ).toBe(false)
   })
 
   it('安全节点允许三人局移除至两人，但不允许只剩一人', () => {
@@ -66,6 +74,96 @@ describe('联网升温局权威规则内核', () => {
     })
     expect(game.diceValue).toBe(1)
     expect(projectOnlineGameView(game, 'p1').allowedCommands).toContain('move')
+  })
+
+  it('预测结果在反应者做出决定前不得向无关玩家泄露', () => {
+    let game = createOnlineGame(roster)
+    game = applyOnlineGameCommand(game, 'p2', {
+      type: 'submit_prediction',
+      prediction: 'high',
+    })
+    game = applyOnlineGameCommand(game, 'p1', { type: 'roll_dice' }, { rollDice: () => 6 })
+
+    expect(game.phase).toBe('awaiting_reaction')
+    expect(projectOnlineGameView(game, 'p2').reaction).toMatchObject({
+      prediction: 'high',
+      predictionCorrect: true,
+    })
+    expect(projectOnlineGameView(game, 'p1').reaction?.prediction).toBeUndefined()
+    expect(projectOnlineGameView(game, 'p1').reaction?.predictionCorrect).toBeUndefined()
+    expect(projectOnlineGameView(game, 'p3').reaction?.predictionCorrect).toBeUndefined()
+  })
+
+  it('公共玩家列表不投影尚未消费的私密惩罚修正状态', () => {
+    const game = createOnlineGame(roster)
+    const stateWithPrivateModifier = {
+      ...game,
+      players: game.players.map((player, index) =>
+        index === 0
+          ? {
+              ...player,
+              pendingMiniGameImmunity: true,
+              pendingMiniGameMultiplier: 2,
+              pendingMercyMultiplier: 1.5,
+            }
+          : player
+      ),
+    }
+
+    const serializedView = JSON.stringify(projectOnlineGameView(stateWithPrivateModifier, 'p2'))
+    expect(serializedView).not.toContain('pendingMiniGameImmunity')
+    expect(serializedView).not.toContain('pendingMiniGameMultiplier')
+    expect(serializedView).not.toContain('pendingMercyMultiplier')
+  })
+
+  it('老友加码场景会应用暖场幕的最低惩罚强度', () => {
+    const board: BoardCell[] = Array.from({ length: 40 }, (_, index) => ({
+      id: index + 1,
+      position: index + 1,
+      type: 'bonus',
+      effect: { type: 'move', value: 0, description: '普通格子' },
+    }))
+    board[6] = {
+      id: 7,
+      position: 7,
+      type: 'punishment',
+      effect: {
+        type: 'punishment',
+        value: 0,
+        description: '场景约束测试',
+        punishment: {
+          tool: { name: '手掌', intensity: 2, ratio: 100 },
+          bodyPart: { name: '手心', sensitivity: 2, ratio: 100 },
+          position: { name: '站立', ratio: 100, compatibleBodyParts: ['手心'] },
+          strikes: 5,
+          description: '原始惩罚',
+        },
+      },
+    }
+    let game = createOnlineGame(
+      roster,
+      { scenePreset: 'hardcore', boardPreset: 'party_default' },
+      { board, eventDeck: quietEventDeck }
+    )
+    game = {
+      ...game,
+      players: game.players.map((player, index) =>
+        index === 0 ? { ...player, position: 1, hasTakenOff: true } : player
+      ),
+    }
+    game = applyOnlineGameCommand(game, 'p2', {
+      type: 'submit_prediction',
+      prediction: 'high',
+    })
+    game = applyOnlineGameCommand(game, 'p1', { type: 'roll_dice' }, { rollDice: () => 6 })
+    game = applyOnlineGameCommand(game, 'p2', { type: 'decide_reaction', decision: 'keep' })
+    game = applyOnlineGameCommand(game, 'p1', { type: 'move' })
+
+    expect(game.pendingAction?.kind).toBe('punishment_choice')
+    if (game.pendingAction?.kind !== 'punishment_choice') {
+      throw new Error('expected punishment choice')
+    }
+    expect(game.pendingAction.choices.every(choice => (choice.strikes ?? 0) >= 10)).toBe(true)
   })
 
   it('惩罚选择和筹码干预只投影给相关玩家，并由服务器结算免疫', () => {
@@ -393,6 +491,8 @@ describe('联网升温局权威规则内核', () => {
       { type: 'resolve_event' },
       { rollDice: () => 1, now: () => 100 }
     )
+    expect(game.deadlineAt).toBe(8_100)
+    expect(projectOnlineGameView(game, 'p2').pendingAction).toMatchObject({ deadline: 8_100 })
     game = applyOnlineGameCommand(
       game,
       'p2',
@@ -476,6 +576,58 @@ describe('联网升温局权威规则内核', () => {
     expect(game.phase).toBe('awaiting_roll')
     expect(game.partySession.reaction?.prediction).toBe('low')
     expect(game.deadlineAt).toBeNull()
+  })
+
+  it('需要选人的事件明确投影选择人数，超时后采用安全默认继续', () => {
+    const board: BoardCell[] = Array.from({ length: 40 }, (_, index) => ({
+      id: index + 1,
+      position: index + 1,
+      type: 'bonus',
+      effect: { type: 'move', value: 0, description: '普通格子' },
+    }))
+    const bindingDeck: readonly PartyEventCard[] = [
+      {
+        id: 'binding-event',
+        title: '命运绑定',
+        description: '选择两名玩家',
+        tags: ['关系'],
+        trigger: { kind: 'every_n_turns', interval: 1 },
+        effect: { kind: 'bind_players', durationTurns: 3 },
+      },
+    ]
+    let game = createOnlineGame(roster, DEFAULT_ONLINE_ROOM_SETTINGS, {
+      board,
+      eventDeck: bindingDeck,
+      startedAt: 0,
+    })
+    game = applyOnlineGameCommand(game, 'p2', {
+      type: 'submit_prediction',
+      prediction: 'high',
+    })
+    game = applyOnlineGameCommand(game, 'p1', { type: 'roll_dice' }, { rollDice: () => 6 })
+    game = applyOnlineGameCommand(game, 'p2', { type: 'decide_reaction', decision: 'keep' })
+    game = applyOnlineGameCommand(
+      game,
+      'p1',
+      { type: 'move' },
+      { rollDice: () => 1, now: () => 100 }
+    )
+
+    expect(projectOnlineGameView(game, 'p2').pendingAction).toMatchObject({
+      kind: 'event_activation',
+      selectionPlayerCount: 2,
+    })
+    expect(game.deadlineAt).toBe(20_100)
+    expect(() =>
+      applyOnlineGameCommand(game, 'p2', {
+        type: 'resolve_event',
+        selectedPlayerIds: ['p1', 'p1'],
+      })
+    ).toThrow('绑定事件需要两名不同玩家')
+
+    game = applyOnlineGameTimeout(game, 20_100, { rollDice: () => 1, now: () => 20_100 })
+    expect(game.pendingAction).toBeNull()
+    expect(['awaiting_prediction', 'awaiting_roll']).toContain(game.phase)
   })
 
   it('移动类格子由服务器确认结算，休息效果会在下一轮跳过对应玩家', () => {

--- a/scripts/online-acceptance-evidence.test.mjs
+++ b/scripts/online-acceptance-evidence.test.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -7,6 +7,9 @@ import { describe, expect, it } from 'vitest'
 import { verifyOnlineAcceptanceEvidence } from './online-acceptance-evidence.mjs'
 
 const verifierPath = fileURLToPath(new URL('./online-acceptance-evidence.mjs', import.meta.url))
+const packageVersion = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf8')
+).version
 const artifactContents = 'anonymous acceptance artifact'
 const artifactSha256 = '6a8a31835b9db9c616312f93f89e556ca380cc986fca993da786ee72697b957d'
 
@@ -371,6 +374,7 @@ describe('联机升温局验收证据', () => {
     const temporaryDirectory = mkdtempSync(join(tmpdir(), 'flying-chess-acceptance-'))
     try {
       const evidence = validEvidence()
+      evidence.release = `v${packageVersion}`
       const references = [
         ...evidence.publicGateway.evidenceRefs,
         ...evidence.loadTest.evidenceRefs,
@@ -396,7 +400,7 @@ describe('联机升温局验收证据', () => {
       const result = spawnSync(process.execPath, [verifierPath, evidencePath], { encoding: 'utf8' })
 
       expect(result.status).toBe(0)
-      expect(result.stdout).toContain('PASS v1.12.4')
+      expect(result.stdout).toContain(`PASS v${packageVersion}`)
     } finally {
       rmSync(temporaryDirectory, { recursive: true, force: true })
     }

--- a/src/components/IntroPage.vue
+++ b/src/components/IntroPage.vue
@@ -40,6 +40,7 @@
   import ProgressAchievements from './ProgressAchievements.vue'
   import PartyStudioEditor from './PartyStudioEditor.vue'
   import type { GameMode } from '../config/modes'
+  import { VERSION } from '../config/version'
   import type { PartyScenePreset, VictoryConfig } from '../types/game'
   import { PARTY_MIN_PLAYERS } from '../services/partyMode'
   import type { PartyEventCard } from '../services/partyEvents'
@@ -71,6 +72,7 @@
   const playerNames = ref<string[]>(['玩家1', '玩家2'])
   const selectedMode = ref<GameMode>(props.initialMode)
   const onlinePartyUrl = `${import.meta.env.BASE_URL}online.html`
+  const applicationVersion = VERSION
   const selectedScenePreset = ref<PartyScenePreset | 'default'>('default')
   const multiDeviceMode = ref(false)
   const victoryConfig = ref<VictoryConfig>(loadVictoryConfig())
@@ -432,7 +434,9 @@
             <strong>联机升温局</strong>
             <span>2–8 人扫码加入，由房间服务器同步局面</span>
           </span>
-          <span class="mode-card__badge mode-card__badge--party">应用 v1.12 · party_v2</span>
+          <span class="mode-card__badge mode-card__badge--party">
+            应用 v{{ applicationVersion }} · party_v2
+          </span>
         </a>
       </section>
 

--- a/src/multiplayer/App.vue
+++ b/src/multiplayer/App.vue
@@ -8,6 +8,7 @@
     type OnlineRoomView,
     type OnlineServerMessage,
   } from '@flying-chess/game-core'
+  import { VERSION } from '../config/version'
   import { OnlineRoomClient, type OnlineConnectionStatus } from './roomClient'
 
   const serverUrl = import.meta.env.VITE_ROOM_SERVER_URL ?? 'wss://rooms.atang-sp.run.place'
@@ -20,6 +21,7 @@
   const nickname = ref('')
   const color = ref<(typeof ONLINE_PLAYER_COLORS)[number]>(ONLINE_PLAYER_COLORS[0])
   const roomCodeInput = ref(roomCodeFromQuery)
+  const applicationVersion = VERSION
   const status = ref<OnlineConnectionStatus>('connecting')
   const errorMessage = ref('')
   const session = ref<Extract<OnlineServerMessage, { type: 'session' }> | null>(null)
@@ -30,6 +32,7 @@
   })
   const qrCodeUrl = ref('')
   const memoryAnswer = ref<string[]>([])
+  const eventSelectedPlayerIds = ref<string[]>([])
   const currentTime = ref(Date.now())
   let requestSequence = 0
   let clockTimer: number | undefined
@@ -84,6 +87,7 @@
       isHost.value &&
       room.value?.status === 'lobby' &&
       (room.value?.players.length ?? 0) >= 2 &&
+      room.value?.players.every(player => player.connected) &&
       room.value?.confirmedPlayerIds.length === room.value?.players.length
   )
   const isConfirmed = computed(
@@ -149,7 +153,11 @@
       errorMessage.value = ''
       return
     }
-    if (message.code === 'INVALID_RESUME_TOKEN' || message.code === 'ROOM_NOT_FOUND') {
+    if (
+      message.code === 'INVALID_RESUME_TOKEN' ||
+      message.code === 'ROOM_NOT_FOUND' ||
+      message.code === 'ROOM_EXPIRED'
+    ) {
       storedSession = null
       session.value = null
       room.value = null
@@ -198,6 +206,7 @@
   function chooseMemorySymbol(symbol: string): void {
     if (pendingAction.value?.kind !== 'event_mini_game') return
     const sequenceLength = pendingAction.value.sequence?.length ?? 0
+    if (memoryAnswer.value.length >= sequenceLength) return
     memoryAnswer.value = [...memoryAnswer.value, symbol]
     if (memoryAnswer.value.length < sequenceLength) return
     send({
@@ -205,6 +214,15 @@
       requestId: requestId('memory'),
       sequence: memoryAnswer.value,
     })
+  }
+
+  function toggleEventPlayer(playerId: string, requiredCount: number): void {
+    if (eventSelectedPlayerIds.value.includes(playerId)) {
+      eventSelectedPlayerIds.value = eventSelectedPlayerIds.value.filter(id => id !== playerId)
+      return
+    }
+    if (eventSelectedPlayerIds.value.length >= requiredCount) return
+    eventSelectedPlayerIds.value = [...eventSelectedPlayerIds.value, playerId]
   }
 
   function playerNickname(playerId: string | null | undefined): string {
@@ -244,6 +262,13 @@
     }
   )
 
+  watch(
+    () => `${game.value?.revision ?? 0}:${pendingAction.value?.kind ?? 'none'}`,
+    () => {
+      eventSelectedPlayerIds.value = []
+    }
+  )
+
   onMounted(async () => {
     clockTimer = window.setInterval(() => {
       currentTime.value = Date.now()
@@ -266,7 +291,7 @@
   <main class="online-shell">
     <header class="online-header">
       <a :href="localGameUrl" class="back-link">← 返回本地玩法</a>
-      <p class="eyebrow">应用 v1.12 · 规则集 party_v2 · 联机升温局</p>
+      <p class="eyebrow">应用 v{{ applicationVersion }} · 规则集 party_v2 · 联机升温局</p>
       <h1>每人一部手机，同步完成一局</h1>
       <p>服务器只在内存中保留房间；服务重启后房间结束。</p>
       <span class="connection-pill" :data-status="status">
@@ -369,7 +394,7 @@
               <span class="player-dot" :style="{ background: player.color }"></span>
               <span>{{ player.nickname }}</span>
               <button
-                v-if="isHost && player.id !== session.playerId"
+                v-if="isHost && player.id !== session.playerId && player.connected"
                 class="text-button"
                 :data-testid="`transfer-host-${player.id}`"
                 @click="
@@ -471,6 +496,9 @@
             全员到齐，开始游戏
           </button>
           <p v-if="isHost && room.players.length < 2" class="hint">至少 2 人才能开始。</p>
+          <p v-else-if="isHost && room.players.some(player => !player.connected)" class="hint">
+            等待所有玩家恢复连接后再开始。
+          </p>
           <p v-else-if="isHost && !canStart" class="hint">等待所有玩家确认设置。</p>
           <p v-else-if="!isHost" class="hint">等待主持人开始。</p>
         </div>
@@ -479,7 +507,8 @@
       <section v-else-if="game" class="game-layout">
         <div class="online-card game-status-card">
           <p class="eyebrow">第 {{ game.revision }} 次状态更新</p>
-          <h2>{{ currentPlayer?.nickname }} 的回合</h2>
+          <h2 v-if="game.status === 'finished'">对局结束</h2>
+          <h2 v-else>{{ currentPlayer?.nickname }} 的回合</h2>
           <p>
             第 {{ game.roundNumber }} 轮 · {{ game.currentAct }} · 你的筹码
             {{ game.myTokensRemaining }}
@@ -620,7 +649,16 @@
           >
             按骰点移动
           </button>
-          <p v-if="!canPredict && !canRoll && !canReact && !canReroll && !canMove">
+          <p
+            v-if="
+              game.status !== 'finished' &&
+              !canPredict &&
+              !canRoll &&
+              !canReact &&
+              !canReroll &&
+              !canMove
+            "
+          >
             请在自己的手机上操作，当前状态会自动同步。
           </p>
 
@@ -899,14 +937,35 @@
           <div v-else-if="pendingAction?.kind === 'event_activation'" class="decision-panel">
             <h3>{{ pendingAction.title }}</h3>
             <p>{{ pendingAction.description }}</p>
+            <div
+              v-if="
+                allowedCommands.includes('resolve_event') && pendingAction.selectionPlayerCount > 0
+              "
+              class="decision-grid"
+            >
+              <button
+                v-for="player in game.players"
+                :key="player.id"
+                class="btn btn-secondary"
+                :aria-pressed="eventSelectedPlayerIds.includes(player.id)"
+                :disabled="
+                  !eventSelectedPlayerIds.includes(player.id) &&
+                  eventSelectedPlayerIds.length >= pendingAction.selectionPlayerCount
+                "
+                @click="toggleEventPlayer(player.id, pendingAction.selectionPlayerCount)"
+              >
+                {{ eventSelectedPlayerIds.includes(player.id) ? '✓ ' : '' }}{{ player.nickname }}
+              </button>
+            </div>
             <button
               v-if="allowedCommands.includes('resolve_event')"
               class="btn btn-primary"
+              :disabled="eventSelectedPlayerIds.length !== pendingAction.selectionPlayerCount"
               @click="
                 send({
                   type: 'resolve_event',
                   requestId: requestId('event'),
-                  selectedPlayerIds: game.players.slice(0, 2).map(player => player.id),
+                  selectedPlayerIds: eventSelectedPlayerIds,
                 })
               "
             >
@@ -933,6 +992,7 @@
                   v-for="symbol in pendingAction.options ?? []"
                   :key="symbol"
                   class="btn btn-secondary"
+                  :disabled="memoryAnswer.length >= pendingAction.sequence.length"
                   @click="chooseMemorySymbol(symbol)"
                 >
                   {{ symbol }}
@@ -942,30 +1002,33 @@
             </template>
             <template v-else-if="pendingAction.game === 'quick_quiz'">
               <p>在截止时间前说出三个棋盘格子类型。</p>
-              <button
-                class="btn btn-primary"
-                @click="
-                  send({
-                    type: 'mini_game_quiz_result',
-                    requestId: requestId('quiz'),
-                    completed: true,
-                  })
-                "
-              >
-                已完成
-              </button>
-              <button
-                class="text-button"
-                @click="
-                  send({
-                    type: 'mini_game_quiz_result',
-                    requestId: requestId('quiz'),
-                    completed: false,
-                  })
-                "
-              >
-                放弃
-              </button>
+              <template v-if="allowedCommands.includes('mini_game_quiz_result')">
+                <button
+                  class="btn btn-primary"
+                  @click="
+                    send({
+                      type: 'mini_game_quiz_result',
+                      requestId: requestId('quiz'),
+                      completed: true,
+                    })
+                  "
+                >
+                  已完成
+                </button>
+                <button
+                  class="text-button"
+                  @click="
+                    send({
+                      type: 'mini_game_quiz_result',
+                      requestId: requestId('quiz'),
+                      completed: false,
+                    })
+                  "
+                >
+                  放弃
+                </button>
+              </template>
+              <p v-else>等待参与者完成快速问答。</p>
             </template>
           </div>
 

--- a/src/multiplayer/roomClient.ts
+++ b/src/multiplayer/roomClient.ts
@@ -35,7 +35,8 @@ export class OnlineRoomClient {
       }
     })
     socket.addEventListener('close', () => {
-      if (this.socket === socket) this.socket = null
+      if (this.socket !== socket) return
+      this.socket = null
       this.callbacks.onStatus('disconnected')
       if (!this.manuallyClosed) this.scheduleReconnect()
     })
@@ -43,6 +44,10 @@ export class OnlineRoomClient {
       socket.addEventListener(
         'open',
         () => {
+          if (this.socket !== socket) {
+            socket.close()
+            return
+          }
           this.reconnectAttempt = 0
           this.callbacks.onStatus('connected')
           resolve()

--- a/src/tests/roomClient.test.ts
+++ b/src/tests/roomClient.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OnlineRoomClient } from '../multiplayer/roomClient'
+
+type Listener = (event: { readonly data?: unknown }) => void
+
+class FakeWebSocket {
+  static readonly OPEN = 1
+  static readonly instances: FakeWebSocket[] = []
+
+  readonly listeners = new Map<string, Listener[]>()
+  readyState = 0
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener])
+  }
+
+  send(): void {}
+
+  close(): void {
+    this.readyState = 3
+  }
+
+  emit(type: string, data?: unknown): void {
+    if (type === 'open') this.readyState = FakeWebSocket.OPEN
+    if (type === 'close') this.readyState = 3
+    for (const listener of this.listeners.get(type) ?? []) listener({ data })
+  }
+}
+
+afterEach(() => {
+  FakeWebSocket.instances.length = 0
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('OnlineRoomClient', () => {
+  it('新连接成功后忽略旧 socket 的迟到 close 事件', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    vi.stubGlobal('window', {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+    })
+    const statuses: string[] = []
+    const client = new OnlineRoomClient('ws://example.test', {
+      onStatus: status => statuses.push(status),
+      onMessage: () => undefined,
+    })
+
+    const firstConnection = client.connect()
+    const firstSocket = FakeWebSocket.instances[0]
+    if (!firstSocket) throw new Error('expected first socket')
+    firstSocket.emit('error')
+    await expect(firstConnection).rejects.toThrow('无法连接房间服务')
+
+    const secondConnection = client.connect()
+    const secondSocket = FakeWebSocket.instances[1]
+    if (!secondSocket) throw new Error('expected second socket')
+    secondSocket.emit('open')
+    await secondConnection
+    firstSocket.emit('close')
+
+    expect(statuses.at(-1)).toBe('connected')
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/tests/e2e/online-vertical-slice.spec.ts
+++ b/tests/e2e/online-vertical-slice.spec.ts
@@ -1,8 +1,30 @@
-import { expect, test } from '@playwright/test'
+import {
+  devices,
+  expect,
+  test,
+  type BrowserContextOptions,
+  type ViewportSize,
+} from '@playwright/test'
 
-test('扫码受邀页突出加入动作，并允许两名玩家确认后开局', async ({ browser }) => {
-  const hostContext = await browser.newContext()
-  const guestContext = await browser.newContext()
+function projectContextOptions(
+  projectName: string,
+  viewport: ViewportSize | null | undefined
+): BrowserContextOptions {
+  const device = projectName === 'mobile-chrome' ? devices['Pixel 5'] : devices['Desktop Chrome']
+  return {
+    userAgent: device.userAgent,
+    viewport: viewport ?? device.viewport,
+    screen: device.screen,
+    deviceScaleFactor: device.deviceScaleFactor,
+    isMobile: device.isMobile,
+    hasTouch: device.hasTouch,
+  }
+}
+
+test('扫码受邀页突出加入动作，并允许两名玩家确认后开局', async ({ browser }, testInfo) => {
+  const options = projectContextOptions(testInfo.project.name, testInfo.project.use.viewport)
+  const hostContext = await browser.newContext(options)
+  const guestContext = await browser.newContext(options)
   const host = await hostContext.newPage()
   const guest = await guestContext.newPage()
 
@@ -39,9 +61,12 @@ test('扫码受邀页突出加入动作，并允许两名玩家确认后开局',
   }
 })
 
-test('两套浏览器通过房间服务器完成建房、加入、刷新重连、掷骰和移动', async ({ browser }) => {
-  const hostContext = await browser.newContext()
-  const guestContext = await browser.newContext()
+test('两套浏览器通过房间服务器完成建房、加入、刷新重连、掷骰和移动', async ({
+  browser,
+}, testInfo) => {
+  const options = projectContextOptions(testInfo.project.name, testInfo.project.use.viewport)
+  const hostContext = await browser.newContext(options)
+  const guestContext = await browser.newContext(options)
   const host = await hostContext.newPage()
   const playerTwo = await guestContext.newPage()
   const playerThree = await guestContext.newPage()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,9 @@ export default defineConfig(async ({ command, mode }) => {
       registerType: 'autoUpdate',
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+        // This is a multi-page app. Let the server/precache resolve these entry points instead of
+        // serving the classic game's index.html for a refreshed invitation or controller URL.
+        navigateFallbackDenylist: [/\/(?:online|controller)\.html(?:\?.*)?$/],
       },
       includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
       manifest: {


### PR DESCRIPTION
## Summary

- harden authoritative online-room validation, disconnect handling, host transfer, and per-connection rate limiting
- prevent private modifier and prediction-result leakage in player projections
- enforce scene-specific rules, event target selection, and consistent mini-game deadlines
- preserve the online invitation route across installed-PWA refreshes and ignore stale WebSocket callbacks
- improve disconnected-player, room-expiry, and finished-game UX
- publish the code and production room image as v1.12.5

## Root causes

Several online flows trusted UI state more than the authoritative protocol, while public projections exposed enough intermediate state to infer private results. The PWA navigation fallback also treated `online.html` as the main SPA route, and replacement WebSocket connections could still receive callbacks from stale sockets.

## Impact

Two to eight players can start and continue online games with stricter privacy and rule enforcement. Offline players cannot receive host control or silently block unsafe state transitions, invitation URLs survive installed-PWA refreshes, and abusive connections are bounded at both Nginx and application layers. Classic and local Party play remain unchanged.

## Validation

- `npm test` — 211 passed
- `npm run test:e2e` — 59 passed, 55 expected project-specific skips
- `npm run type-check`
- `npm run lint:check`
- `npm run format:check`
- `npm run validate-config`
- `VITE_APP_VERSION=1.12.5 npm run build`
- `npm run build:room-server`
- `npm run test:room-server-load` — 20 rooms, 160 connections, RSS 100.6 MiB, P95 0.8 ms
- `npm audit` — 0 vulnerabilities

## Remaining field gates

Real iOS Safari and Android Chrome full-game checks plus unattended 4/6/8-person sessions remain human acceptance gates and are not represented as completed by automated evidence.
