### PR TITLE
fix: enforce online room host controls

### DIFF
--- a/apps/room-server/package.json
+++ b/apps/room-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/room-server",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "private": true,
   "type": "module",
   "scripts": {
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@flying-chess/game-core": "1.12.5",
+    "@flying-chess/game-core": "1.12.6",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/apps/room-server/src/cli.ts
+++ b/apps/room-server/src/cli.ts
@@ -7,6 +7,10 @@ const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',')
   .map(origin => origin.trim())
   .filter(Boolean)
 const testDice = Number.parseInt(process.env.ROOM_SERVER_TEST_DICE ?? '', 10)
+const testReconnectGraceMs = Number.parseInt(
+  process.env.ROOM_SERVER_TEST_RECONNECT_GRACE_MS ?? '',
+  10
+)
 const rollDice =
   process.env.NODE_ENV === 'test' && Number.isInteger(testDice) && testDice >= 1 && testDice <= 6
     ? () => testDice
@@ -32,6 +36,10 @@ async function main(): Promise<void> {
     rollDice,
     eventDeck: quietTestEventDeck,
     allowedOrigins,
+    reconnectGraceMs:
+      process.env.NODE_ENV === 'test' && testReconnectGraceMs > 0
+        ? testReconnectGraceMs
+        : undefined,
   })
   console.info(`room server listening on port ${server.port}`)
 

--- a/apps/room-server/src/server.ts
+++ b/apps/room-server/src/server.ts
@@ -50,6 +50,7 @@ interface Room {
   settings: OnlineRoomSettings
   readonly confirmedPlayerIds: Set<string>
   readonly skipRequestedPlayerIds: Set<string>
+  readonly pauseRequestedPlayerIds: Set<string>
   game: OnlineGameState | null
 }
 
@@ -222,6 +223,8 @@ export async function createRoomServer(
       if (!session || session.player.socket !== socket) return
       session.player.socket = null
       session.player.disconnectedAt = now()
+      session.room.skipRequestedPlayerIds.delete(session.player.id)
+      session.room.pauseRequestedPlayerIds.delete(session.player.id)
       if (rooms.get(session.room.code) === session.room) broadcastRoom(session.room)
     })
   })
@@ -242,6 +245,7 @@ export async function createRoomServer(
         settings: { ...DEFAULT_ONLINE_ROOM_SETTINGS },
         confirmedPlayerIds: new Set(),
         skipRequestedPlayerIds: new Set(),
+        pauseRequestedPlayerIds: new Set(),
         game: null,
       }
       rooms.set(code, room)
@@ -322,6 +326,8 @@ export async function createRoomServer(
         )
       }
       room.hostPlayerId = message.playerId
+      room.skipRequestedPlayerIds.clear()
+      room.pauseRequestedPlayerIds.clear()
       broadcastRoom(room)
       return
     }
@@ -360,6 +366,8 @@ export async function createRoomServer(
       }
       room.players.splice(targetIndex, 1)
       room.confirmedPlayerIds.delete(target.id)
+      room.skipRequestedPlayerIds.delete(target.id)
+      room.pauseRequestedPlayerIds.delete(target.id)
       broadcastRoom(room)
       return
     }
@@ -428,6 +436,16 @@ export async function createRoomServer(
     }
 
     if (!room.game) throw new ProtocolError('GAME_NOT_STARTED', '游戏尚未开始', message.requestId)
+    if (message.type === 'pause_game' && room.hostPlayerId !== player.id) {
+      if (room.game.partySession.pausedAt === undefined) {
+        room.pauseRequestedPlayerIds.add(player.id)
+        broadcastRoom(room)
+      }
+      return
+    }
+    if (message.type === 'resume_game' && room.hostPlayerId !== player.id) {
+      throw new ProtocolError('HOST_ONLY', '只有主持人可以恢复游戏', message.requestId)
+    }
     let command: OnlineGameCommand
     if (message.type === 'submit_prediction') {
       command = { type: message.type, prediction: message.prediction }
@@ -466,6 +484,9 @@ export async function createRoomServer(
     }
     room.game = applyOnlineGameCommand(room.game, player.id, command, gameDependencies)
     room.skipRequestedPlayerIds.clear()
+    if (message.type === 'pause_game' || message.type === 'resume_game') {
+      room.pauseRequestedPlayerIds.clear()
+    }
     broadcastRoom(room)
   }
 
@@ -526,25 +547,41 @@ function projectRoom(
   now: number,
   reconnectGraceMs: number
 ): RoomView {
+  const removalSafe = room.game ? isOnlinePlayerRemovalSafe(room.game) : true
   return {
     status: room.game?.status ?? 'lobby',
     hostPlayerId: room.hostPlayerId,
-    players: room.players.map<RoomPlayerView>(player => ({
-      id: player.id,
-      nickname: player.nickname,
-      color: player.color,
-      connected: player.socket?.readyState === WebSocket.OPEN,
-      disconnectedAt: player.disconnectedAt ?? undefined,
-      removable:
-        player.disconnectedAt !== null &&
-        now - player.disconnectedAt >= reconnectGraceMs &&
-        (!room.game || (room.players.length > 2 && isOnlinePlayerRemovalSafe(room.game))),
-    })),
+    players: room.players.map<RoomPlayerView>(player => {
+      const connected = player.socket?.readyState === WebSocket.OPEN
+      const graceExpired =
+        player.disconnectedAt !== null && now - player.disconnectedAt >= reconnectGraceMs
+      const removable =
+        !connected && graceExpired && (!room.game || (room.players.length > 2 && removalSafe))
+      const removalBlockReason = connected
+        ? undefined
+        : !graceExpired
+          ? ('reconnect_grace' as const)
+          : room.game && room.players.length <= 2
+            ? ('minimum_players' as const)
+            : room.game && !removalSafe
+              ? ('unsafe_game_state' as const)
+              : undefined
+      return {
+        id: player.id,
+        nickname: player.nickname,
+        color: player.color,
+        connected,
+        disconnectedAt: player.disconnectedAt ?? undefined,
+        removable,
+        removalBlockReason,
+      }
+    }),
     settings: room.settings,
     confirmedPlayerIds: room.players
       .filter(player => room.confirmedPlayerIds.has(player.id))
       .map(player => player.id),
     skipRequestedPlayerIds: [...room.skipRequestedPlayerIds],
+    pauseRequestedPlayerIds: [...room.pauseRequestedPlayerIds],
     game: room.game ? projectOnlineGameView(room.game, viewerId) : null,
   }
 }

--- a/apps/room-server/test/vertical-slice.test.ts
+++ b/apps/room-server/test/vertical-slice.test.ts
@@ -288,6 +288,75 @@ describe('联网升温局服务器权威纵向切片', () => {
     ).resolves.toMatchObject({ type: 'room_state' })
   })
 
+  it('普通玩家只能请求暂停，只有主持人可以暂停和恢复整局', async () => {
+    server = await createRoomServer({ port: 0 })
+    const host = await TestClient.connect(server.wsUrl)
+    const guest = await TestClient.connect(server.wsUrl)
+    clients.push(host, guest)
+
+    host.send({
+      type: 'create_room',
+      requestId: 'pause-create',
+      nickname: '主持人',
+      color: '#ff6b6b',
+    })
+    const created = await host.next(message => message.type === 'session')
+    if (created.type !== 'session') throw new Error('expected session')
+    guest.send({
+      type: 'join_room',
+      requestId: 'pause-join',
+      roomCode: created.roomCode,
+      nickname: '普通玩家',
+      color: '#4ecdc4',
+    })
+    const joined = await guest.next(message => message.type === 'session')
+    if (joined.type !== 'session') throw new Error('expected session')
+
+    host.send({ type: 'confirm_settings', requestId: 'pause-confirm-host' })
+    guest.send({ type: 'confirm_settings', requestId: 'pause-confirm-guest' })
+    await host.next(
+      message => message.type === 'room_state' && message.room.confirmedPlayerIds.length === 2
+    )
+    host.send({ type: 'start_game', requestId: 'pause-start' })
+    await host.next(message => message.type === 'room_state' && message.room.status === 'playing')
+
+    guest.send({ type: 'pause_game', requestId: 'pause-request' })
+    const requested = await host.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.pauseRequestedPlayerIds.includes(joined.playerId)
+    )
+    expect(requested).toMatchObject({
+      type: 'room_state',
+      room: { game: { paused: false }, pauseRequestedPlayerIds: [joined.playerId] },
+    })
+
+    host.send({ type: 'pause_game', requestId: 'pause-approve' })
+    await expect(
+      guest.next(
+        message =>
+          message.type === 'room_state' &&
+          message.room.game?.paused === true &&
+          message.room.pauseRequestedPlayerIds.length === 0
+      )
+    ).resolves.toMatchObject({ type: 'room_state' })
+
+    guest.send({ type: 'resume_game', requestId: 'pause-resume-guest' })
+    await expect(
+      guest.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'pause-resume-guest' &&
+          message.code === 'HOST_ONLY'
+      )
+    ).resolves.toMatchObject({ type: 'error' })
+
+    host.send({ type: 'resume_game', requestId: 'pause-resume-host' })
+    await expect(
+      guest.next(message => message.type === 'room_state' && message.room.game?.paused === false)
+    ).resolves.toMatchObject({ type: 'room_state' })
+  })
+
   it('主持人可以把管理角色转交给另一名玩家，权限立即随角色移动', async () => {
     server = await createRoomServer({ port: 0 })
     const host = await TestClient.connect(server.wsUrl)
@@ -607,14 +676,33 @@ describe('联网升温局服务器权威纵向切片', () => {
     const joined = await successor.next(message => message.type === 'session')
     if (joined.type !== 'session') throw new Error('expected session')
 
+    host.send({ type: 'confirm_settings', requestId: 'failover-confirm-host' })
+    successor.send({ type: 'confirm_settings', requestId: 'failover-confirm-successor' })
+    await host.next(
+      message => message.type === 'room_state' && message.room.confirmedPlayerIds.length === 2
+    )
+    host.send({ type: 'start_game', requestId: 'failover-start' })
+    await host.next(message => message.type === 'room_state' && message.room.status === 'playing')
+
     await host.disconnect()
     now += 90_000
 
-    await expect(
-      successor.next(
-        message => message.type === 'room_state' && message.room.hostPlayerId === joined.playerId
-      )
-    ).resolves.toMatchObject({ type: 'room_state' })
+    const transferred = await successor.next(
+      message => message.type === 'room_state' && message.room.hostPlayerId === joined.playerId
+    )
+    expect(transferred).toMatchObject({
+      type: 'room_state',
+      room: {
+        players: expect.arrayContaining([
+          expect.objectContaining({
+            id: created.playerId,
+            connected: false,
+            removable: false,
+            removalBlockReason: 'minimum_players',
+          }),
+        ]),
+      },
+    })
   })
 
   it('断线后凭一次性恢复凭证回到原席位，并在 90 秒保护期后允许主持人移除', async () => {

--- a/deploy/room-server/ACCEPTANCE.md
+++ b/deploy/room-server/ACCEPTANCE.md
@@ -18,9 +18,9 @@
 证据不得提交到仓库。先复制模板到已被 `.gitignore` 排除的目录：
 
 ```bash
-mkdir -p .acceptance-evidence/v1.12.5/{evidence,artifacts}
+mkdir -p .acceptance-evidence/v1.12.6/{evidence,artifacts}
 cp deploy/room-server/acceptance-evidence.template.json \
-  .acceptance-evidence/v1.12.5/evidence.json
+  .acceptance-evidence/v1.12.6/evidence.json
 ```
 
 每个 `evidenceRefs` 都必须指向结构化 JSON 证明，可从 `acceptance-proof.template.json` 复制。证明必须包含同一个发布标签、UTC 时间、证明类别、与主清单完全一致的 `claims`，以及至少一个原始材料文件和它的 SHA-256。校验器会读取原始文件并重新计算摘要；空文件、目录、错误摘要、错误版本、错误类别、声明不一致或私人字段都会失败。
@@ -43,7 +43,7 @@ cp deploy/room-server/acceptance-evidence.template.json \
 计算摘要示例：
 
 ```bash
-sha256sum .acceptance-evidence/v1.12.5/artifacts/<已脱敏材料>
+sha256sum .acceptance-evidence/v1.12.6/artifacts/<已脱敏材料>
 ```
 
 生产资源证据至少在现场验收前、中、后各采样一次。`swapSamplesMiB` 至少填 3 个数；校验器将峰峰值不超过 128MiB 作为“无 swap 振荡”的保守可重复判据。
@@ -78,7 +78,7 @@ sha256sum .acceptance-evidence/v1.12.5/artifacts/<已脱敏材料>
 
 ```bash
 npm run verify:online-acceptance -- \
-  .acceptance-evidence/v1.12.5/evidence.json
+  .acceptance-evidence/v1.12.6/evidence.json
 ```
 
 退出码 `0` 且输出 `PASS` 才表示证据合同满足；退出码 `1` 表示一个或多个硬门槛失败，退出码 `2` 表示文件/JSON 用法错误。该命令只校验证据完整性，不会替代人工核对材料真实性。

--- a/deploy/room-server/README.md
+++ b/deploy/room-server/README.md
@@ -4,10 +4,10 @@
 
 ## 构建与安装
 
-在已检出不可变 `v1.12.5` 标签的仓库根目录执行：
+在已检出不可变 `v1.12.6` 标签的仓库根目录执行：
 
 ```bash
-docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.12.5 .
+docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.12.6 .
 ufw allow in on docker0 from 172.17.0.0/16 to 172.17.0.1 port 8787 proto tcp comment "flying chess room from discourse"
 install -m 0644 deploy/room-server/flying-chess-room.service /etc/systemd/system/
 install -m 0644 deploy/room-server/flying-chess-room-health.service /etc/systemd/system/

--- a/deploy/room-server/acceptance-evidence.template.json
+++ b/deploy/room-server/acceptance-evidence.template.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "release": "v1.12.5",
+  "release": "v1.12.6",
   "publicGateway": {
     "dnsResolved": false,
     "certificateSans": [],

--- a/deploy/room-server/acceptance-proof.template.json
+++ b/deploy/room-server/acceptance-proof.template.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "release": "v1.12.5",
+  "release": "v1.12.6",
   "recordedAtUtc": "2026-08-02T00:00:00.000Z",
   "kind": "replace_with_required_kind",
   "artifacts": [

--- a/deploy/room-server/flying-chess-room.service
+++ b/deploy/room-server/flying-chess-room.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=ROOM_IMAGE=flying-chess-room:1.12.5
+Environment=ROOM_IMAGE=flying-chess-room:1.12.6
 EnvironmentFile=-/etc/flying-chess-room.env
 ExecStartPre=-/usr/bin/docker rm -f flying-chess-room
 ExecStart=/usr/bin/docker run --rm --name flying-chess-room --network host --read-only --tmpfs /tmp:rw,noexec,nosuid,size=8m --cap-drop ALL --security-opt no-new-privileges --pids-limit 128 --cpus 1 --memory 128m --memory-swap 192m --health-cmd "wget -qO- http://172.17.0.1:8787/ready >/dev/null || exit 1" --health-interval 30s --health-timeout 3s --health-start-period 5s --health-retries 3 --log-driver journald -e NODE_ENV=production -e HOST=172.17.0.1 -e PORT=8787 -e ALLOWED_ORIGINS=https://atang-sp.github.io ${ROOM_IMAGE}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "1.12.5",
+      "version": "1.12.6",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -54,9 +54,9 @@
     },
     "apps/room-server": {
       "name": "@flying-chess/room-server",
-      "version": "1.12.5",
+      "version": "1.12.6",
       "dependencies": {
-        "@flying-chess/game-core": "1.12.5",
+        "@flying-chess/game-core": "1.12.6",
         "ws": "^8.18.3"
       },
       "devDependencies": {
@@ -11199,7 +11199,7 @@
     },
     "packages/game-core": {
       "name": "@flying-chess/game-core",
-      "version": "1.12.5"
+      "version": "1.12.6"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/game-core/package.json
+++ b/packages/game-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/game-core",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/game-core/src/index.ts
+++ b/packages/game-core/src/index.ts
@@ -585,6 +585,7 @@ export interface OnlineRoomPlayerView {
   readonly connected: boolean
   readonly disconnectedAt?: number
   readonly removable: boolean
+  readonly removalBlockReason?: 'reconnect_grace' | 'minimum_players' | 'unsafe_game_state'
 }
 
 export interface OnlineRoomView {
@@ -594,6 +595,7 @@ export interface OnlineRoomView {
   readonly settings: OnlineRoomSettings
   readonly confirmedPlayerIds: readonly string[]
   readonly skipRequestedPlayerIds: readonly string[]
+  readonly pauseRequestedPlayerIds: readonly string[]
   readonly game: OnlineGameView | null
 }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
       timeout: 120_000,
     },
     {
-      command: 'NODE_ENV=test ROOM_SERVER_TEST_DICE=6 npm run dev:room-server',
+      command:
+        'NODE_ENV=test ROOM_SERVER_TEST_DICE=6 ROOM_SERVER_TEST_RECONNECT_GRACE_MS=500 npm run dev:room-server',
       url: 'http://127.0.0.1:8787/health',
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,

--- a/scripts/online-acceptance-evidence.test.mjs
+++ b/scripts/online-acceptance-evidence.test.mjs
@@ -295,11 +295,11 @@ describe('联机升温局验收证据', () => {
 
   it('拒绝与当前待发布版本不一致的证据', () => {
     const evidence = validEvidence()
-    const result = verifyEvidence(evidence, { expectedRelease: 'v1.12.5' })
+    const result = verifyEvidence(evidence, { expectedRelease: 'v1.12.6' })
 
     expect(result.failures).toContainEqual({
       gate: 'release.current',
-      message: '证据发布 v1.12.4 与当前待发布版本 v1.12.5 不一致',
+      message: '证据发布 v1.12.4 与当前待发布版本 v1.12.6 不一致',
     })
   })
 

--- a/src/multiplayer/App.vue
+++ b/src/multiplayer/App.vue
@@ -4,6 +4,7 @@
   import {
     ONLINE_PLAYER_COLORS,
     type OnlineClientMessage,
+    type OnlineRoomPlayerView,
     type OnlineRoomSettings,
     type OnlineRoomView,
     type OnlineServerMessage,
@@ -33,6 +34,7 @@
   const qrCodeUrl = ref('')
   const memoryAnswer = ref<string[]>([])
   const eventSelectedPlayerIds = ref<string[]>([])
+  const hostTransferNotice = ref('')
   const currentTime = ref(Date.now())
   let requestSequence = 0
   let clockTimer: number | undefined
@@ -117,11 +119,41 @@
       game.value?.phase ?? ''
     )
   )
+  const hasRequestedPause = computed(
+    () =>
+      !!session.value &&
+      (room.value?.pauseRequestedPlayerIds.includes(session.value.playerId) ?? false)
+  )
+
+  const scenePresetLabels: Record<OnlineRoomSettings['scenePreset'], string> = {
+    default: '默认升温局',
+    icebreaker: '初见破冰',
+    hardcore: '老友加码',
+    couple: '双人终局风格',
+  }
+  const boardPresetLabels: Record<OnlineRoomSettings['boardPreset'], string> = {
+    party_default: '升温局默认棋盘',
+    icebreaker: '破冰棋盘',
+    hardcore: '加码棋盘',
+    couple_finale: '终局棋盘',
+  }
+  const actLabels: Record<'warmup' | 'heating' | 'finale', string> = {
+    warmup: '热身阶段',
+    heating: '升温阶段',
+    finale: '终局阶段',
+  }
 
   function offlineSeconds(disconnectedAt: number | undefined): number {
     return disconnectedAt === undefined
       ? 0
       : Math.max(0, Math.floor((currentTime.value - disconnectedAt) / 1_000))
+  }
+
+  function offlineRetentionMessage(player: OnlineRoomPlayerView): string {
+    if (player.removalBlockReason === 'minimum_players') return '双人局需保留两位玩家'
+    if (player.removalBlockReason === 'unsafe_game_state') return '等待新回合安全节点后可移除'
+    if (player.removalBlockReason === 'reconnect_grace') return '保留原席位（90 秒保护）'
+    return '保留原席位'
   }
 
   function punishmentCountOptions(
@@ -253,6 +285,22 @@
       if (settings) settingsDraft.value = { ...settings }
     },
     { deep: true }
+  )
+
+  watch(
+    () => room.value?.hostPlayerId,
+    (nextHostPlayerId, previousHostPlayerId) => {
+      if (
+        previousHostPlayerId &&
+        nextHostPlayerId &&
+        nextHostPlayerId !== previousHostPlayerId &&
+        nextHostPlayerId === session.value?.playerId
+      ) {
+        hostTransferNotice.value = '原主持人离线或已转交，你已接任主持人。'
+      } else if (nextHostPlayerId !== session.value?.playerId) {
+        hostTransferNotice.value = ''
+      }
+    }
   )
 
   watch(
@@ -469,11 +517,15 @@
             <dl v-else class="settings-summary">
               <div>
                 <dt>场景</dt>
-                <dd>{{ room.settings.scenePreset }}</dd>
+                <dd data-testid="scene-setting-label">
+                  {{ scenePresetLabels[room.settings.scenePreset] }}
+                </dd>
               </div>
               <div>
                 <dt>棋盘</dt>
-                <dd>{{ room.settings.boardPreset }}</dd>
+                <dd data-testid="board-setting-label">
+                  {{ boardPresetLabels[room.settings.boardPreset] }}
+                </dd>
               </div>
             </dl>
           </div>
@@ -509,8 +561,14 @@
           <p class="eyebrow">第 {{ game.revision }} 次状态更新</p>
           <h2 v-if="game.status === 'finished'">对局结束</h2>
           <h2 v-else>{{ currentPlayer?.nickname }} 的回合</h2>
+          <span v-if="isHost" class="host-badge" data-testid="host-role">你是主持人</span>
+          <p v-if="hostTransferNotice" class="confirmed-note" role="status">
+            {{ hostTransferNotice }}
+          </p>
           <p>
-            第 {{ game.roundNumber }} 轮 · {{ game.currentAct }} · 你的筹码
+            第 {{ game.roundNumber }} 轮 ·
+            <span data-testid="act-label">{{ actLabels[game.currentAct] }}</span>
+            · 你的筹码
             {{ game.myTokensRemaining }}
           </p>
           <p v-if="deadlineSeconds !== null" class="deadline-note">
@@ -520,20 +578,26 @@
           <p v-if="room.skipRequestedPlayerIds.length" class="hint">
             {{ room.skipRequestedPlayerIds.length }} 人请求跳过当前核心操作，等待主持人决定。
           </p>
+          <p v-if="room.pauseRequestedPlayerIds.length" class="hint">
+            {{ room.pauseRequestedPlayerIds.length }} 人请求暂停，等待主持人决定。
+          </p>
           <div class="decision-grid session-controls">
             <button
-              v-if="game.paused"
+              v-if="game.paused && isHost"
               class="btn btn-secondary"
+              data-testid="resume-game"
               @click="send({ type: 'resume_game', requestId: requestId('resume-game') })"
             >
               恢复游戏
             </button>
             <button
-              v-else
+              v-else-if="!game.paused"
               class="btn btn-secondary"
+              :data-testid="isHost ? 'pause-game' : 'request-pause'"
+              :disabled="!isHost && hasRequestedPause"
               @click="send({ type: 'pause_game', requestId: requestId('pause') })"
             >
-              暂停游戏
+              {{ isHost ? '暂停游戏' : hasRequestedPause ? '已请求暂停' : '请求暂停' }}
             </button>
             <button
               v-if="!game.paused"
@@ -543,6 +607,7 @@
               {{ isCoreOperation && !isHost ? '请求主持人跳过' : '跳过当前操作' }}
             </button>
           </div>
+          <p v-if="game.paused && !isHost" class="hint">等待主持人恢复游戏。</p>
           <ul
             v-if="room.players.some(player => !player.connected)"
             class="player-list compact-list"
@@ -565,7 +630,12 @@
               >
                 移除离场玩家
               </button>
-              <small v-else>保留原席位（90 秒保护）</small>
+              <small v-else-if="player.removable" data-testid="offline-retention-status">
+                等待主持人处理离场玩家
+              </small>
+              <small v-else data-testid="offline-retention-status">
+                {{ offlineRetentionMessage(player) }}
+              </small>
             </li>
           </ul>
           <div class="dice-face" data-testid="dice-value">{{ game.diceValue ?? '—' }}</div>

--- a/tests/e2e/online-vertical-slice.spec.ts
+++ b/tests/e2e/online-vertical-slice.spec.ts
@@ -50,9 +50,21 @@ test('扫码受邀页突出加入动作，并允许两名玩家确认后开局',
     await guest.getByTestId('join-room').click()
 
     await expect(host.getByTestId('room-player')).toHaveCount(2)
+    await expect(guest.getByTestId('scene-setting-label')).toHaveText('默认升温局')
+    await expect(guest.getByTestId('board-setting-label')).toHaveText('升温局默认棋盘')
     await Promise.all([host, guest].map(page => page.getByTestId('confirm-settings').click()))
     await expect(host.getByTestId('start-online-game')).toBeEnabled()
     await host.getByTestId('start-online-game').click()
+    await expect(host.getByTestId('host-role')).toHaveText('你是主持人')
+    await expect(guest.getByTestId('host-role')).toHaveCount(0)
+    await expect(guest.getByTestId('act-label')).toHaveText('热身阶段')
+    await guest.getByTestId('request-pause').click()
+    await expect(host.getByText('1 人请求暂停，等待主持人决定。')).toBeVisible()
+    await expect(guest.getByTestId('request-pause')).toBeDisabled()
+    await host.getByTestId('pause-game').click()
+    await expect(guest.getByText('游戏已暂停，倒计时已冻结。')).toBeVisible()
+    await expect(guest.getByTestId('resume-game')).toHaveCount(0)
+    await host.getByTestId('resume-game').click()
     await guest.getByTestId('predict-high').click()
     await expect(host.getByTestId('roll-dice')).toBeVisible()
   } finally {
@@ -114,6 +126,39 @@ test('两套浏览器通过房间服务器完成建房、加入、刷新重连�
     await expect(playerTwo.getByText('房间服务已连接')).toBeVisible()
     await expect(playerTwo.getByTestId('roll-dice')).toBeVisible()
     await expect(playerTwo.getByTestId('player-position')).toHaveCount(3)
+  } finally {
+    await hostContext.close()
+    await guestContext.close()
+  }
+})
+
+test('主持人断线后明确通知接任玩家，并说明双人局保留离线席位的原因', async ({
+  browser,
+}, testInfo) => {
+  const options = projectContextOptions(testInfo.project.name, testInfo.project.use.viewport)
+  const hostContext = await browser.newContext(options)
+  const guestContext = await browser.newContext(options)
+  const host = await hostContext.newPage()
+  const guest = await guestContext.newPage()
+
+  try {
+    await host.goto('/flying-chess/online.html')
+    await host.getByTestId('nickname').fill('主持人')
+    await host.getByTestId('create-room').click()
+    const roomCode = (await host.getByTestId('room-code').textContent())?.trim()
+    expect(roomCode).toMatch(/^[A-Z2-9]{6}$/)
+
+    await guest.goto(`/flying-chess/online.html?room=${roomCode}`)
+    await guest.getByTestId('nickname').fill('接任玩家')
+    await guest.getByTestId('join-room').click()
+    await Promise.all([host, guest].map(page => page.getByTestId('confirm-settings').click()))
+    await host.getByTestId('start-online-game').click()
+    await expect(guest.getByTestId('host-role')).toHaveCount(0)
+
+    await host.close()
+    await expect(guest.getByTestId('host-role')).toHaveText('你是主持人')
+    await expect(guest.getByRole('status')).toHaveText('原主持人离线或已转交，你已接任主持人。')
+    await expect(guest.getByTestId('offline-retention-status')).toHaveText('双人局需保留两位玩家')
   } finally {
     await hostContext.close()
     await guestContext.close()


### PR DESCRIPTION
## Summary

- restrict whole-game pause and resume authority to the host while allowing ordinary players to request a pause
- localize room setting and act protocol values in the invited-player UI
- notify the successor after host failover and explain why an offline seat is retained
- publish the coordinated frontend, game-core, room-server, and deployment metadata as v1.12.6

## Root cause

The client exposed protocol enum values and authoritative room commands directly without modeling the viewer's role. The room projection also exposed only a boolean removal result, so the UI could not distinguish reconnect grace, the two-player minimum, and an unsafe removal point.

## User impact

Ordinary players can no longer pause or resume the whole match directly. They can send a visible pause request for the host to approve. Invited players see Chinese setting and stage labels, and a player promoted after host disconnect receives a clear role notification and an accurate offline-seat retention reason.

## Validation

- `npm test` — 23 files, 212 tests passed
- `npm run type-check`
- `npm run lint:check`
- `npm run format:check`
- `VITE_APP_VERSION=1.12.6 VITE_ROOM_SERVER_URL=wss://rooms.atang-sp.run.place npm run build`
- `npm run build:room-server`
- `npm run test:e2e` — 61 passed, 55 conditional skips
- room-server load test — 20 rooms / 160 connections, P95 1 ms, RSS 101 MiB
- `git diff --check`
