### PR TITLE
feat: add server-confirmed forum achievement claims

### DIFF
--- a/apps/room-server/package.json
+++ b/apps/room-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/room-server",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@flying-chess/game-core": "1.13.0",
+    "@flying-chess/game-core": "1.14.0",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/apps/room-server/src/cli.ts
+++ b/apps/room-server/src/cli.ts
@@ -6,6 +6,11 @@ const host = process.env.HOST ?? '0.0.0.0'
 const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',')
   .map(origin => origin.trim())
   .filter(Boolean)
+const achievementClaimSecret = process.env.ACHIEVEMENT_CLAIM_SECRET
+const achievementClaimUrl = process.env.ACHIEVEMENT_CLAIM_URL?.trim()
+if (Boolean(achievementClaimSecret) !== Boolean(achievementClaimUrl)) {
+  throw new Error('ACHIEVEMENT_CLAIM_SECRET and ACHIEVEMENT_CLAIM_URL must be configured together')
+}
 const testDice = Number.parseInt(process.env.ROOM_SERVER_TEST_DICE ?? '', 10)
 const testReconnectGraceMs = Number.parseInt(
   process.env.ROOM_SERVER_TEST_RECONNECT_GRACE_MS ?? '',
@@ -36,6 +41,10 @@ async function main(): Promise<void> {
     rollDice,
     eventDeck: quietTestEventDeck,
     allowedOrigins,
+    achievementClaims:
+      achievementClaimSecret && achievementClaimUrl
+        ? { secret: achievementClaimSecret, claimUrl: achievementClaimUrl }
+        : undefined,
     reconnectGraceMs:
       process.env.NODE_ENV === 'test' && testReconnectGraceMs > 0
         ? testReconnectGraceMs

--- a/apps/room-server/src/gameCompletionClaims.ts
+++ b/apps/room-server/src/gameCompletionClaims.ts
@@ -1,0 +1,241 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+export const GAME_COMPLETION_CLAIM_ISSUER = 'flying-chess-room-server' as const
+export const GAME_COMPLETION_CLAIM_AUDIENCE = 'where-is-my-friends' as const
+export const GAME_COMPLETION_CLAIM_EVENT = 'game_completed' as const
+export const GAME_COMPLETION_CLAIM_VERSION = 1 as const
+export const DEFAULT_GAME_COMPLETION_CLAIM_TTL_MS = 7 * 24 * 60 * 60 * 1_000
+export const MAXIMUM_GAME_COMPLETION_CLAIM_TTL_MS = 8 * 24 * 60 * 60 * 1_000
+
+const TOKEN_ALGORITHM = 'HS256' as const
+const TOKEN_TYPE = 'JWT' as const
+const TOKEN_KEY_ID = 'flying-chess-v1' as const
+const TOKEN_HEADER = Object.freeze({ alg: TOKEN_ALGORITHM, typ: TOKEN_TYPE, kid: TOKEN_KEY_ID })
+const MINIMUM_SECRET_BYTES = 32
+const MAXIMUM_TOKEN_LENGTH = 4_096
+const MAXIMUM_IDENTIFIER_BYTES = 128
+const MINIMUM_CLAIM_TTL_MS = 1_000
+const CLOCK_SKEW_MS = 5 * 60 * 1_000
+
+export interface GameCompletionClaimInput {
+  readonly claimId: string
+  readonly gameId: string
+  readonly playerId: string
+  readonly rulesetVersion: string
+  readonly completedAt: number
+  readonly place: number
+  readonly winner: boolean
+}
+
+export interface GameCompletionClaimPayload {
+  readonly v: typeof GAME_COMPLETION_CLAIM_VERSION
+  readonly iss: typeof GAME_COMPLETION_CLAIM_ISSUER
+  readonly aud: typeof GAME_COMPLETION_CLAIM_AUDIENCE
+  readonly event: typeof GAME_COMPLETION_CLAIM_EVENT
+  readonly jti: string
+  readonly game_id: string
+  readonly player_id: string
+  readonly mode: 'online_party'
+  readonly ruleset_version: string
+  readonly completed_at: number
+  readonly place: number
+  readonly winner: boolean
+  readonly iat: number
+  readonly exp: number
+}
+
+export interface GameCompletionClaimOptions {
+  readonly secret: string
+  readonly ttlMs?: number
+}
+
+export function validateGameCompletionClaimConfiguration(
+  options: GameCompletionClaimOptions & Readonly<{ claimUrl: string }>
+): void {
+  normalizeSecret(options.secret)
+  normalizeClaimUrl(options.claimUrl)
+  if (options.ttlMs !== undefined) validateClaimTtl(options.ttlMs)
+}
+
+export function createGameCompletionClaim(
+  input: GameCompletionClaimInput,
+  options: GameCompletionClaimOptions
+): string {
+  const secret = normalizeSecret(options.secret)
+  const ttlMs = options.ttlMs ?? DEFAULT_GAME_COMPLETION_CLAIM_TTL_MS
+  validateClaimTtl(ttlMs)
+  if (!Number.isSafeInteger(input.completedAt) || input.completedAt < 0) {
+    throw new Error('game completion timestamp must be a non-negative integer')
+  }
+  if (!Number.isSafeInteger(input.place) || input.place < 1) {
+    throw new Error('game completion place must be a positive integer')
+  }
+  for (const [name, value] of [
+    ['claimId', input.claimId],
+    ['gameId', input.gameId],
+    ['playerId', input.playerId],
+    ['rulesetVersion', input.rulesetVersion],
+  ] as const) {
+    if (!value || Buffer.byteLength(value, 'utf8') > MAXIMUM_IDENTIFIER_BYTES) {
+      throw new Error(
+        `game completion ${name} must contain 1-${MAXIMUM_IDENTIFIER_BYTES} UTF-8 bytes`
+      )
+    }
+  }
+
+  const issuedAt = Math.floor(input.completedAt / 1_000)
+  const payload: GameCompletionClaimPayload = {
+    v: GAME_COMPLETION_CLAIM_VERSION,
+    iss: GAME_COMPLETION_CLAIM_ISSUER,
+    aud: GAME_COMPLETION_CLAIM_AUDIENCE,
+    event: GAME_COMPLETION_CLAIM_EVENT,
+    jti: input.claimId,
+    game_id: input.gameId,
+    player_id: input.playerId,
+    mode: 'online_party',
+    ruleset_version: input.rulesetVersion,
+    completed_at: issuedAt,
+    place: input.place,
+    winner: input.winner,
+    iat: issuedAt,
+    exp: Math.floor((input.completedAt + ttlMs) / 1_000),
+  }
+  const header = encodeJson(TOKEN_HEADER)
+  const body = encodeJson(payload)
+  const signature = sign(`${header}.${body}`, secret)
+  return `${header}.${body}.${signature}`
+}
+
+export function verifyGameCompletionClaim(
+  token: string,
+  secretValue: string,
+  now = Date.now()
+): GameCompletionClaimPayload {
+  const secret = normalizeSecret(secretValue)
+  if (!token || token.length > MAXIMUM_TOKEN_LENGTH) {
+    throw new Error('game completion claim is malformed')
+  }
+  const parts = token.split('.')
+  if (parts.length !== 3) throw new Error('game completion claim is malformed')
+  const [headerPart, bodyPart, signaturePart] = parts
+  if (!headerPart || !bodyPart || !signaturePart) {
+    throw new Error('game completion claim is malformed')
+  }
+  const expectedSignature = Buffer.from(sign(`${headerPart}.${bodyPart}`, secret), 'base64url')
+  const actualSignature = decodeBase64Url(signaturePart)
+  if (
+    actualSignature.length !== expectedSignature.length ||
+    !timingSafeEqual(actualSignature, expectedSignature)
+  ) {
+    throw new Error('game completion claim signature is invalid')
+  }
+
+  const header = decodeJson(headerPart) as Record<string, unknown>
+  if (
+    header.alg !== TOKEN_HEADER.alg ||
+    header.typ !== TOKEN_HEADER.typ ||
+    header.kid !== TOKEN_HEADER.kid
+  ) {
+    throw new Error('game completion claim header is invalid')
+  }
+  const payload = decodeJson(bodyPart) as Partial<GameCompletionClaimPayload>
+  if (
+    payload.v !== GAME_COMPLETION_CLAIM_VERSION ||
+    payload.iss !== GAME_COMPLETION_CLAIM_ISSUER ||
+    payload.aud !== GAME_COMPLETION_CLAIM_AUDIENCE ||
+    payload.event !== GAME_COMPLETION_CLAIM_EVENT ||
+    payload.mode !== 'online_party' ||
+    !isNonEmptyString(payload.jti) ||
+    !isNonEmptyString(payload.game_id) ||
+    !isNonEmptyString(payload.player_id) ||
+    !isNonEmptyString(payload.ruleset_version) ||
+    identifierIsTooLong(payload.jti) ||
+    identifierIsTooLong(payload.game_id) ||
+    identifierIsTooLong(payload.player_id) ||
+    identifierIsTooLong(payload.ruleset_version) ||
+    !Number.isSafeInteger(payload.completed_at) ||
+    !Number.isSafeInteger(payload.iat) ||
+    !Number.isSafeInteger(payload.exp) ||
+    !Number.isSafeInteger(payload.place) ||
+    Number(payload.place) < 1 ||
+    typeof payload.winner !== 'boolean'
+  ) {
+    throw new Error('game completion claim payload is invalid')
+  }
+  const nowSeconds = Math.floor(now / 1_000)
+  if (
+    Number(payload.completed_at) !== Number(payload.iat) ||
+    Number(payload.exp) <= Number(payload.iat) ||
+    (Number(payload.exp) - Number(payload.iat)) * 1_000 > MAXIMUM_GAME_COMPLETION_CLAIM_TTL_MS ||
+    nowSeconds >= Number(payload.exp) ||
+    Number(payload.iat) * 1_000 > now + CLOCK_SKEW_MS
+  ) {
+    throw new Error('game completion claim has expired or has invalid timestamps')
+  }
+  return payload as GameCompletionClaimPayload
+}
+
+export function buildGameCompletionClaimUrl(claimUrl: string, token: string): string {
+  const url = normalizeClaimUrl(claimUrl)
+  const fragment = new URLSearchParams(url.hash.replace(/^#/, ''))
+  fragment.set('token', token)
+  url.hash = fragment.toString()
+  return url.toString()
+}
+
+function normalizeClaimUrl(value: string): URL {
+  const url = new URL(value)
+  if (url.protocol !== 'https:') throw new Error('game completion claim URL must use HTTPS')
+  return url
+}
+
+function normalizeSecret(value: string): Buffer {
+  const secret = Buffer.from(value, 'utf8')
+  if (secret.byteLength < MINIMUM_SECRET_BYTES) {
+    throw new Error(
+      `game completion claim secret must contain at least ${MINIMUM_SECRET_BYTES} bytes`
+    )
+  }
+  return secret
+}
+
+function validateClaimTtl(value: number): void {
+  if (
+    !Number.isSafeInteger(value) ||
+    value < MINIMUM_CLAIM_TTL_MS ||
+    value > MAXIMUM_GAME_COMPLETION_CLAIM_TTL_MS
+  ) {
+    throw new Error(
+      `game completion claim TTL must be an integer between ${MINIMUM_CLAIM_TTL_MS} and ${MAXIMUM_GAME_COMPLETION_CLAIM_TTL_MS} milliseconds`
+    )
+  }
+}
+
+function encodeJson(value: object): string {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url')
+}
+
+function decodeJson(value: string): unknown {
+  try {
+    return JSON.parse(decodeBase64Url(value).toString('utf8')) as unknown
+  } catch {
+    throw new Error('game completion claim JSON is invalid')
+  }
+}
+
+function decodeBase64Url(value: string): Buffer {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) throw new Error('game completion claim is malformed')
+  return Buffer.from(value, 'base64url')
+}
+
+function sign(value: string, secret: Buffer): string {
+  return createHmac('sha256', secret).update(value).digest('base64url')
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function identifierIsTooLong(value: unknown): boolean {
+  return typeof value === 'string' && Buffer.byteLength(value, 'utf8') > MAXIMUM_IDENTIFIER_BYTES
+}

--- a/apps/room-server/src/server.ts
+++ b/apps/room-server/src/server.ts
@@ -21,6 +21,12 @@ import {
 } from '@flying-chess/game-core'
 import { WebSocket, WebSocketServer } from 'ws'
 import type { ClientMessage, RoomPlayerView, RoomView, ServerMessage } from './protocol'
+import {
+  buildGameCompletionClaimUrl,
+  createGameCompletionClaim,
+  validateGameCompletionClaimConfiguration,
+  type GameCompletionClaimOptions,
+} from './gameCompletionClaims'
 
 const ROOM_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
 const DEFAULT_ROOM_TTL_MS = 2 * 60 * 60 * 1_000
@@ -53,6 +59,9 @@ interface Room {
   readonly skipRequestedPlayerIds: Set<string>
   readonly pauseRequestedPlayerIds: Set<string>
   game: OnlineGameState | null
+  gameId: string | null
+  gameCompletedAt: number | null
+  readonly achievementClaimUrls: Map<string, string>
 }
 
 interface ConnectionSession {
@@ -73,6 +82,7 @@ export interface RoomServerOptions {
   readonly allowedOrigins?: readonly string[]
   readonly messagesPerSecond?: number
   readonly messageBurst?: number
+  readonly achievementClaims?: GameCompletionClaimOptions & Readonly<{ claimUrl: string }>
 }
 
 export interface RunningRoomServer {
@@ -94,6 +104,9 @@ class ProtocolError extends Error {
 export async function createRoomServer(
   options: RoomServerOptions = {}
 ): Promise<RunningRoomServer> {
+  if (options.achievementClaims) {
+    validateGameCompletionClaimConfiguration(options.achievementClaims)
+  }
   const now = options.now ?? Date.now
   const maxRooms = options.maxRooms ?? DEFAULT_MAX_ROOMS
   const roomTtlMs = options.roomTtlMs ?? DEFAULT_ROOM_TTL_MS
@@ -157,7 +170,7 @@ export async function createRoomServer(
       if (room.game) {
         const next = applyOnlineGameTimeout(room.game, timestamp, gameDependencies)
         if (next !== room.game) {
-          room.game = next
+          updateRoomGame(room, next)
           changed = true
         }
       }
@@ -248,6 +261,9 @@ export async function createRoomServer(
         skipRequestedPlayerIds: new Set(),
         pauseRequestedPlayerIds: new Set(),
         game: null,
+        gameId: null,
+        gameCompletedAt: null,
+        achievementClaimUrls: new Map(),
       }
       rooms.set(code, room)
       sessions.set(socket, { room, player })
@@ -432,6 +448,9 @@ export async function createRoomServer(
         room.settings,
         { startedAt: now(), eventDeck: options.eventDeck }
       )
+      room.gameId = randomUUID()
+      room.gameCompletedAt = null
+      room.achievementClaimUrls.clear()
       broadcastRoom(room)
       return
     }
@@ -483,12 +502,44 @@ export async function createRoomServer(
     } else {
       command = { type: message.type } as OnlineGameCommand
     }
-    room.game = applyOnlineGameCommand(room.game, player.id, command, gameDependencies)
+    updateRoomGame(room, applyOnlineGameCommand(room.game, player.id, command, gameDependencies))
     room.skipRequestedPlayerIds.clear()
     if (message.type === 'pause_game' || message.type === 'resume_game') {
       room.pauseRequestedPlayerIds.clear()
     }
     broadcastRoom(room)
+  }
+
+  function updateRoomGame(room: Room, nextGame: OnlineGameState): void {
+    const wasFinished = room.game?.status === 'finished'
+    room.game = nextGame
+    if (!wasFinished && nextGame.status === 'finished') completeRoomGame(room)
+  }
+
+  function completeRoomGame(room: Room): void {
+    if (!room.game || room.game.status !== 'finished' || room.gameCompletedAt !== null) return
+    const completedAt = now()
+    room.gameCompletedAt = completedAt
+    const claims = options.achievementClaims
+    if (!claims || !room.gameId) return
+
+    for (const player of room.players) {
+      const settlement = room.game.victorySettlement.find(entry => entry.playerId === player.id)
+      const token = createGameCompletionClaim(
+        {
+          claimId: randomUUID(),
+          gameId: room.gameId,
+          playerId: player.id,
+          rulesetVersion: room.game.rulesetVersion,
+          completedAt,
+          place:
+            room.game.winnerPlayerId === player.id ? 1 : (settlement?.place ?? room.players.length),
+          winner: room.game.winnerPlayerId === player.id,
+        },
+        claims
+      )
+      room.achievementClaimUrls.set(player.id, buildGameCompletionClaimUrl(claims.claimUrl, token))
+    }
   }
 
   function transferExpiredHost(room: Room, timestamp: number): boolean {
@@ -584,6 +635,7 @@ function projectRoom(
     skipRequestedPlayerIds: [...room.skipRequestedPlayerIds],
     pauseRequestedPlayerIds: [...room.pauseRequestedPlayerIds],
     game: room.game ? projectOnlineGameView(room.game, viewerId) : null,
+    achievementClaimUrl: room.achievementClaimUrls.get(viewerId),
   }
 }
 

--- a/apps/room-server/test/gameCompletionClaims.test.ts
+++ b/apps/room-server/test/gameCompletionClaims.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildGameCompletionClaimUrl,
+  createGameCompletionClaim,
+  verifyGameCompletionClaim,
+} from '../src/gameCompletionClaims'
+
+const secret = 'test-only-achievement-secret-with-at-least-32-bytes'
+const completedAt = Date.UTC(2026, 7, 4, 12, 0, 0)
+
+describe('server-confirmed game completion claims', () => {
+  it('signs the minimal event contract and verifies it before expiry', () => {
+    const token = createGameCompletionClaim(
+      {
+        claimId: 'claim-1',
+        gameId: 'game-1',
+        playerId: 'player-1',
+        rulesetVersion: 'party_v2',
+        completedAt,
+        place: 2,
+        winner: false,
+      },
+      { secret }
+    )
+
+    expect(verifyGameCompletionClaim(token, secret, completedAt + 1_000)).toEqual({
+      v: 1,
+      iss: 'flying-chess-room-server',
+      aud: 'where-is-my-friends',
+      event: 'game_completed',
+      jti: 'claim-1',
+      game_id: 'game-1',
+      player_id: 'player-1',
+      mode: 'online_party',
+      ruleset_version: 'party_v2',
+      completed_at: completedAt / 1_000,
+      place: 2,
+      winner: false,
+      iat: completedAt / 1_000,
+      exp: completedAt / 1_000 + 7 * 24 * 60 * 60,
+    })
+  })
+
+  it('rejects tampering, expiry, weak secrets, and non-HTTPS handoffs', () => {
+    const token = createGameCompletionClaim(
+      {
+        claimId: 'claim-2',
+        gameId: 'game-2',
+        playerId: 'player-2',
+        rulesetVersion: 'party_v2',
+        completedAt,
+        place: 1,
+        winner: true,
+      },
+      { secret, ttlMs: 1_000 }
+    )
+    const [header, body, signature] = token.split('.')
+    const tamperedBody = Buffer.from(
+      JSON.stringify({
+        ...JSON.parse(Buffer.from(body ?? '', 'base64url').toString('utf8')),
+        winner: false,
+      })
+    ).toString('base64url')
+
+    expect(() =>
+      verifyGameCompletionClaim(`${header}.${tamperedBody}.${signature}`, secret)
+    ).toThrow('signature is invalid')
+    expect(() => verifyGameCompletionClaim(token, secret, completedAt + 2_000)).toThrow(
+      'expired or has invalid timestamps'
+    )
+    expect(() =>
+      createGameCompletionClaim(
+        {
+          claimId: 'claim-3',
+          gameId: 'game-3',
+          playerId: 'player-3',
+          rulesetVersion: 'party_v2',
+          completedAt,
+          place: 1,
+          winner: true,
+        },
+        { secret: 'weak' }
+      )
+    ).toThrow('at least 32 bytes')
+    expect(() => buildGameCompletionClaimUrl('http://forum.example/claim', token)).toThrow(
+      'must use HTTPS'
+    )
+  })
+
+  it('builds a fragment-only handoff so the claim never enters HTTP access logs', () => {
+    const token = createGameCompletionClaim(
+      {
+        claimId: 'claim-4',
+        gameId: 'game-4',
+        playerId: 'player-4',
+        rulesetVersion: 'party_v2',
+        completedAt,
+        place: 1,
+        winner: true,
+      },
+      { secret }
+    )
+    const url = new URL(buildGameCompletionClaimUrl('https://forum.example/flying-chess', token))
+    const fragment = new URLSearchParams(url.hash.replace(/^#/, ''))
+
+    expect(url.search).toBe('')
+    expect(fragment.get('token')).toBe(token)
+  })
+})

--- a/apps/room-server/test/vertical-slice.test.ts
+++ b/apps/room-server/test/vertical-slice.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import WebSocket from 'ws'
 import { DEFAULT_ONLINE_ROOM_SETTINGS, type OnlineRoomSettings } from '@flying-chess/game-core'
 import { createRoomServer, type RunningRoomServer } from '../src/server'
+import { verifyGameCompletionClaim } from '../src/gameCompletionClaims'
 import type { ServerMessage } from '../src/protocol'
 
 const quietEventDeck = [
@@ -204,6 +205,188 @@ describe('联网升温局服务器权威纵向切片', () => {
     })
     if (playerTwoView.type !== 'room_state') throw new Error('expected room state')
     expect(playerTwoView.room.game?.allowedCommands).toContain('roll_dice')
+  })
+
+  it('终局后只向各自席位签发私有、可验证的论坛认领凭证', async () => {
+    const claimSecret = 'room-server-integration-secret-with-at-least-32-bytes'
+    const diceValues = [6, 6, 6, 6, 6, 6, 6, 6, 1]
+    server = await createRoomServer({
+      port: 0,
+      rollDice: () => diceValues.shift() ?? 1,
+      eventDeck: quietEventDeck,
+      achievementClaims: {
+        secret: claimSecret,
+        claimUrl: 'https://forum.example/where-is-my-friends/flying-chess/claim',
+      },
+    })
+    const host = await TestClient.connect(server.wsUrl)
+    const guest = await TestClient.connect(server.wsUrl)
+    clients.push(host, guest)
+
+    host.send({
+      type: 'create_room',
+      requestId: 'claim-create',
+      nickname: '主持人',
+      color: '#ff6b6b',
+    })
+    const hostSession = await host.next(message => message.type === 'session')
+    if (hostSession.type !== 'session') throw new Error('expected host session')
+    host.send({
+      type: 'update_settings',
+      requestId: 'claim-settings',
+      settings: {
+        ...DEFAULT_ONLINE_ROOM_SETTINGS,
+        boardConfig: {
+          punishmentCells: 0,
+          chainPunishmentCells: 0,
+          bonusCells: 0,
+          reverseCells: 0,
+          restCells: 0,
+          restartCells: 0,
+          trapCells: 0,
+          qaCells: 0,
+          dareCells: 0,
+          totalCells: 20,
+        },
+      },
+    })
+    await host.next(
+      message =>
+        message.type === 'room_state' && message.room.settings.boardConfig.totalCells === 20
+    )
+
+    guest.send({
+      type: 'join_room',
+      requestId: 'claim-join',
+      roomCode: hostSession.roomCode,
+      nickname: '玩家二',
+      color: '#4ecdc4',
+    })
+    const guestSession = await guest.next(message => message.type === 'session')
+    if (guestSession.type !== 'session') throw new Error('expected guest session')
+    host.send({ type: 'confirm_settings', requestId: 'claim-confirm-host' })
+    guest.send({ type: 'confirm_settings', requestId: 'claim-confirm-guest' })
+    await host.next(
+      message => message.type === 'room_state' && message.room.confirmedPlayerIds.length === 2
+    )
+    host.send({ type: 'start_game', requestId: 'claim-start' })
+    const started = await host.next(
+      message => message.type === 'room_state' && message.room.game?.status === 'playing'
+    )
+    if (started.type !== 'room_state') throw new Error('expected room state')
+    expect(started.room.achievementClaimUrl).toBeUndefined()
+
+    const takeTurn = async (
+      actor: TestClient,
+      reactor: TestClient,
+      actorId: string,
+      suffix: string,
+      readyPhase: 'awaiting_prediction' | 'awaiting_roll'
+    ): Promise<void> => {
+      if (readyPhase === 'awaiting_prediction') {
+        reactor.send({
+          type: 'submit_prediction',
+          requestId: `claim-predict-${suffix}`,
+          prediction: 'high',
+        })
+        await actor.next(
+          message =>
+            message.type === 'room_state' &&
+            message.room.game?.phase === 'awaiting_roll' &&
+            message.room.game.currentPlayerId === actorId
+        )
+      }
+      actor.send({ type: 'roll_dice', requestId: `claim-roll-${suffix}` })
+      const rolled = await actor.next(
+        message =>
+          message.type === 'room_state' &&
+          (message.room.game?.phase === 'awaiting_reaction' ||
+            message.room.game?.phase === 'awaiting_move') &&
+          message.room.game.currentPlayerId === actorId
+      )
+      if (rolled.type !== 'room_state') throw new Error('expected rolled room state')
+      if (rolled.room.game?.phase === 'awaiting_reaction') {
+        reactor.send({
+          type: 'decide_reaction',
+          requestId: `claim-reaction-${suffix}`,
+          decision: 'keep',
+        })
+        await actor.next(
+          message =>
+            message.type === 'room_state' &&
+            message.room.game?.phase === 'awaiting_move' &&
+            message.room.game.currentPlayerId === actorId
+        )
+      }
+      actor.send({ type: 'move', requestId: `claim-move-${suffix}` })
+    }
+
+    const waitUntilTurn = async (
+      client: TestClient,
+      playerId: string
+    ): Promise<'awaiting_prediction' | 'awaiting_roll'> => {
+      const ready = await client.next(
+        message =>
+          message.type === 'room_state' &&
+          (message.room.game?.phase === 'awaiting_prediction' ||
+            message.room.game?.phase === 'awaiting_roll') &&
+          message.room.game.currentPlayerId === playerId
+      )
+      if (ready.type !== 'room_state' || !ready.room.game) {
+        throw new Error('expected turn-ready room state')
+      }
+      return ready.room.game.phase as 'awaiting_prediction' | 'awaiting_roll'
+    }
+
+    let hostReadyPhase = started.room.game?.phase as 'awaiting_prediction' | 'awaiting_roll'
+    for (let round = 0; round < 4; round += 1) {
+      await takeTurn(host, guest, hostSession.playerId, `host-${round}`, hostReadyPhase)
+      const guestReadyPhase = await waitUntilTurn(guest, guestSession.playerId)
+      await takeTurn(guest, host, guestSession.playerId, `guest-${round}`, guestReadyPhase)
+      hostReadyPhase = await waitUntilTurn(host, hostSession.playerId)
+    }
+    await takeTurn(host, guest, hostSession.playerId, 'host-final', hostReadyPhase)
+
+    const [hostFinished, guestFinished] = await Promise.all([
+      host.next(
+        message =>
+          message.type === 'room_state' &&
+          message.room.status === 'finished' &&
+          Boolean(message.room.achievementClaimUrl)
+      ),
+      guest.next(
+        message =>
+          message.type === 'room_state' &&
+          message.room.status === 'finished' &&
+          Boolean(message.room.achievementClaimUrl)
+      ),
+    ])
+    if (hostFinished.type !== 'room_state' || guestFinished.type !== 'room_state') {
+      throw new Error('expected finished room states')
+    }
+    const hostUrl = new URL(hostFinished.room.achievementClaimUrl ?? '')
+    const guestUrl = new URL(guestFinished.room.achievementClaimUrl ?? '')
+    const hostFragment = new URLSearchParams(hostUrl.hash.replace(/^#/, ''))
+    const guestFragment = new URLSearchParams(guestUrl.hash.replace(/^#/, ''))
+    const hostClaim = verifyGameCompletionClaim(hostFragment.get('token') ?? '', claimSecret)
+    const guestClaim = verifyGameCompletionClaim(guestFragment.get('token') ?? '', claimSecret)
+
+    expect(hostUrl.origin).toBe('https://forum.example')
+    expect(hostUrl.search).toBe('')
+    expect(hostClaim).toMatchObject({
+      event: 'game_completed',
+      player_id: hostSession.playerId,
+      winner: true,
+      place: 1,
+    })
+    expect(guestClaim).toMatchObject({
+      event: 'game_completed',
+      player_id: guestSession.playerId,
+      winner: false,
+    })
+    expect(guestClaim.game_id).toBe(hostClaim.game_id)
+    expect(guestClaim.jti).not.toBe(hostClaim.jti)
+    expect(guestUrl.toString()).not.toBe(hostUrl.toString())
   })
 
   it('设置变更会清空全员确认，未重新全员确认时服务器拒绝开局', async () => {

--- a/deploy/room-server/ACCEPTANCE.md
+++ b/deploy/room-server/ACCEPTANCE.md
@@ -18,9 +18,9 @@
 证据不得提交到仓库。先复制模板到已被 `.gitignore` 排除的目录：
 
 ```bash
-mkdir -p .acceptance-evidence/v1.13.0/{evidence,artifacts}
+mkdir -p .acceptance-evidence/v1.14.0/{evidence,artifacts}
 cp deploy/room-server/acceptance-evidence.template.json \
-  .acceptance-evidence/v1.13.0/evidence.json
+  .acceptance-evidence/v1.14.0/evidence.json
 ```
 
 每个 `evidenceRefs` 都必须指向结构化 JSON 证明，可从 `acceptance-proof.template.json` 复制。证明必须包含同一个发布标签、UTC 时间、证明类别、与主清单完全一致的 `claims`，以及至少一个原始材料文件和它的 SHA-256。校验器会读取原始文件并重新计算摘要；空文件、目录、错误摘要、错误版本、错误类别、声明不一致或私人字段都会失败。
@@ -43,7 +43,7 @@ cp deploy/room-server/acceptance-evidence.template.json \
 计算摘要示例：
 
 ```bash
-sha256sum .acceptance-evidence/v1.13.0/artifacts/<已脱敏材料>
+sha256sum .acceptance-evidence/v1.14.0/artifacts/<已脱敏材料>
 ```
 
 生产资源证据至少在现场验收前、中、后各采样一次。`swapSamplesMiB` 至少填 3 个数；校验器将峰峰值不超过 128MiB 作为“无 swap 振荡”的保守可重复判据。
@@ -78,7 +78,7 @@ sha256sum .acceptance-evidence/v1.13.0/artifacts/<已脱敏材料>
 
 ```bash
 npm run verify:online-acceptance -- \
-  .acceptance-evidence/v1.13.0/evidence.json
+  .acceptance-evidence/v1.14.0/evidence.json
 ```
 
 退出码 `0` 且输出 `PASS` 才表示证据合同满足；退出码 `1` 表示一个或多个硬门槛失败，退出码 `2` 表示文件/JSON 用法错误。该命令只校验证据完整性，不会替代人工核对材料真实性。

--- a/deploy/room-server/README.md
+++ b/deploy/room-server/README.md
@@ -4,10 +4,10 @@
 
 ## 构建与安装
 
-在已检出不可变 `v1.13.0` 标签的仓库根目录执行：
+在已检出不可变 `v1.14.0` 标签的仓库根目录执行：
 
 ```bash
-docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.13.0 .
+docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.14.0 .
 ufw allow in on docker0 from 172.17.0.0/16 to 172.17.0.1 port 8787 proto tcp comment "flying chess room from discourse"
 install -m 0644 deploy/room-server/flying-chess-room.service /etc/systemd/system/
 install -m 0644 deploy/room-server/flying-chess-room-health.service /etc/systemd/system/
@@ -16,7 +16,14 @@ systemctl daemon-reload
 systemctl enable --now flying-chess-room.service flying-chess-room-health.timer
 ```
 
-`/etc/flying-chess-room.env` 可覆盖 `ROOM_IMAGE`，不得放置房间码、昵称、玩法设置或消息内容。服务只输出启动状态；Nginx 对该子域关闭 access log。
+`/etc/flying-chess-room.env` 可覆盖 `ROOM_IMAGE`。启用论坛成就认领时，还必须同时配置：
+
+```dotenv
+ACHIEVEMENT_CLAIM_SECRET=<与 Discourse 插件相同的至少 32 字节随机密钥>
+ACHIEVEMENT_CLAIM_URL=https://atang-sp.run.place/where-is-my-friends/flying-chess
+```
+
+该文件必须为 root 所有且权限为 `0600`。两项缺一时服务拒绝启动；轮换密钥会令尚未认领的旧凭证失效。不得在这里放置房间码、昵称、玩法设置或消息内容。服务只输出启动状态；Nginx 对房间子域关闭 access log。认领凭证只放在 URL fragment 中，不会随论坛页面请求进入 HTTP access log。
 
 ## Discourse 反代与证书
 

--- a/deploy/room-server/acceptance-evidence.template.json
+++ b/deploy/room-server/acceptance-evidence.template.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "release": "v1.13.0",
+  "release": "v1.14.0",
   "publicGateway": {
     "dnsResolved": false,
     "certificateSans": [],

--- a/deploy/room-server/acceptance-proof.template.json
+++ b/deploy/room-server/acceptance-proof.template.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "release": "v1.13.0",
+  "release": "v1.14.0",
   "recordedAtUtc": "2026-08-02T00:00:00.000Z",
   "kind": "replace_with_required_kind",
   "artifacts": [

--- a/deploy/room-server/flying-chess-room.service
+++ b/deploy/room-server/flying-chess-room.service
@@ -6,10 +6,10 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=ROOM_IMAGE=flying-chess-room:1.13.0
+Environment=ROOM_IMAGE=flying-chess-room:1.14.0
 EnvironmentFile=-/etc/flying-chess-room.env
 ExecStartPre=-/usr/bin/docker rm -f flying-chess-room
-ExecStart=/usr/bin/docker run --rm --name flying-chess-room --network host --read-only --tmpfs /tmp:rw,noexec,nosuid,size=8m --cap-drop ALL --security-opt no-new-privileges --pids-limit 128 --cpus 1 --memory 128m --memory-swap 192m --health-cmd "wget -qO- http://172.17.0.1:8787/ready >/dev/null || exit 1" --health-interval 30s --health-timeout 3s --health-start-period 5s --health-retries 3 --log-driver journald -e NODE_ENV=production -e HOST=172.17.0.1 -e PORT=8787 -e ALLOWED_ORIGINS=https://atang-sp.github.io ${ROOM_IMAGE}
+ExecStart=/usr/bin/docker run --rm --name flying-chess-room --network host --read-only --tmpfs /tmp:rw,noexec,nosuid,size=8m --cap-drop ALL --security-opt no-new-privileges --pids-limit 128 --cpus 1 --memory 128m --memory-swap 192m --health-cmd "wget -qO- http://172.17.0.1:8787/ready >/dev/null || exit 1" --health-interval 30s --health-timeout 3s --health-start-period 5s --health-retries 3 --log-driver journald -e NODE_ENV=production -e HOST=172.17.0.1 -e PORT=8787 -e ALLOWED_ORIGINS=https://atang-sp.github.io -e ACHIEVEMENT_CLAIM_SECRET -e ACHIEVEMENT_CLAIM_URL ${ROOM_IMAGE}
 ExecStop=/usr/bin/docker stop --timeout 10 flying-chess-room
 Restart=always
 RestartSec=3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -54,9 +54,9 @@
     },
     "apps/room-server": {
       "name": "@flying-chess/room-server",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "dependencies": {
-        "@flying-chess/game-core": "1.13.0",
+        "@flying-chess/game-core": "1.14.0",
         "ws": "^8.18.3"
       },
       "devDependencies": {
@@ -11199,7 +11199,7 @@
     },
     "packages/game-core": {
       "name": "@flying-chess/game-core",
-      "version": "1.13.0"
+      "version": "1.14.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/game-core/package.json
+++ b/packages/game-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/game-core",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/game-core/src/index.ts
+++ b/packages/game-core/src/index.ts
@@ -751,6 +751,8 @@ export interface OnlineRoomView {
   readonly skipRequestedPlayerIds: readonly string[]
   readonly pauseRequestedPlayerIds: readonly string[]
   readonly game: OnlineGameView | null
+  /** Private, per-seat forum handoff issued only after a server-confirmed finish. */
+  readonly achievementClaimUrl?: string
 }
 
 export type OnlineServerMessage =

--- a/src/multiplayer/App.vue
+++ b/src/multiplayer/App.vue
@@ -1235,6 +1235,17 @@
             <p v-for="entry in game.victorySettlement" :key="entry.playerId">
               {{ playerNickname(entry.playerId) }}：第 {{ entry.place }} 名，{{ entry.count }} 次
             </p>
+            <a
+              v-if="room.achievementClaimUrl"
+              class="btn btn-primary"
+              data-testid="claim-forum-achievement"
+              :href="room.achievementClaimUrl"
+            >
+              绑定论坛账号，保存本局成就
+            </a>
+            <p v-if="room.achievementClaimUrl" class="hint">
+              可选操作；论坛只会保存服务器确认的完成记录，不公开你的游戏昵称。
+            </p>
           </div>
         </div>
 


### PR DESCRIPTION
## What changed

- issue one short-lived HS256 completion claim per seat only after the authoritative room state reaches `finished`
- hand the private claim to that seat through an HTTPS URL fragment
- add an optional post-game action without changing anonymous room entry or the classic/local flows
- document the paired room-server secret and immutable v1.14.0 deployment

## Why

Browser-submitted wins are not trustworthy. The room server already owns the authoritative game transition, so it is the correct seam for a verifiable but optional Discourse achievement.

## Safety and privacy

- no forum account is required to play
- no nickname, room code, settings, messages, or claim token is logged
- claims are per-seat, expire, use unique IDs, and are only emitted once per finished game
- the service refuses partial secret/URL configuration

## Validation

- Vitest: 25 files / 230 tests
- Playwright: 61 passed / 55 intentionally skipped
- type-check, format, config validation, lint and both production builds passed
- room load test: 20 rooms / 160 connections, RSS 103.1 MiB, P95 0.5 ms
- production dependency audit: 0 vulnerabilities

Paired with the where-is-my-friends Flying Chess achievement PR.
