### PR TITLE
ci: add required quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Lint
+        run: npm run lint:check
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Validate configuration fixtures
+        run: npm run validate-config
+
+      - name: Test
+        run: npm test
+
+      - name: Build web application
+        run: npm run build
+
+      - name: Build room server
+        run: npm run build:room-server
+
+  browser-e2e:
+    name: Browser E2E
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chrome
+        run: npx playwright install --with-deps chrome
+
+      - name: Run browser tests
+        run: npm run test:e2e


### PR DESCRIPTION
## Summary

- add a required quality job covering formatting, lint, types, configuration validation, unit tests, and both production builds
- add a Chrome Playwright job for browser and room-server flows
- run on pull requests and master pushes with read-only permissions and concurrency cancellation

## Validation

- `npm run format:check`
- `npm run lint:check` (0 errors; 9 existing warnings)
- `npm run type-check`
- `npm run validate-config`
- `npm test` (230 passed)
- `npm run build`
- `npm run build:room-server`
- `npm run test:e2e` (61 passed, 55 intentionally skipped by project matrix)