### PR TITLE
fix: harden game and controller reliability

### DIFF
--- a/apps/room-server/package.json
+++ b/apps/room-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/room-server",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@flying-chess/game-core": "1.14.0",
+    "@flying-chess/game-core": "1.14.1",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/apps/room-server/src/server.ts
+++ b/apps/room-server/src/server.ts
@@ -557,6 +557,7 @@ export async function createRoomServer(
     if (!successor) return false
     room.hostPlayerId = successor.id
     room.skipRequestedPlayerIds.clear()
+    room.pauseRequestedPlayerIds.clear()
     return true
   }
 

--- a/apps/room-server/test/vertical-slice.test.ts
+++ b/apps/room-server/test/vertical-slice.test.ts
@@ -913,6 +913,13 @@ describe('联网升温局服务器权威纵向切片', () => {
     host.send({ type: 'start_game', requestId: 'failover-start' })
     await host.next(message => message.type === 'room_state' && message.room.status === 'playing')
 
+    successor.send({ type: 'pause_game', requestId: 'failover-pause-request' })
+    await host.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.pauseRequestedPlayerIds.includes(joined.playerId)
+    )
+
     await host.disconnect()
     now += 90_000
 
@@ -922,6 +929,7 @@ describe('联网升温局服务器权威纵向切片', () => {
     expect(transferred).toMatchObject({
       type: 'room_state',
       room: {
+        pauseRequestedPlayerIds: [],
         players: expect.arrayContaining([
           expect.objectContaining({
             id: created.playerId,

--- a/deploy/room-server/ACCEPTANCE.md
+++ b/deploy/room-server/ACCEPTANCE.md
@@ -18,9 +18,9 @@
 证据不得提交到仓库。先复制模板到已被 `.gitignore` 排除的目录：
 
 ```bash
-mkdir -p .acceptance-evidence/v1.14.0/{evidence,artifacts}
+mkdir -p .acceptance-evidence/v1.14.1/{evidence,artifacts}
 cp deploy/room-server/acceptance-evidence.template.json \
-  .acceptance-evidence/v1.14.0/evidence.json
+  .acceptance-evidence/v1.14.1/evidence.json
 ```
 
 每个 `evidenceRefs` 都必须指向结构化 JSON 证明，可从 `acceptance-proof.template.json` 复制。证明必须包含同一个发布标签、UTC 时间、证明类别、与主清单完全一致的 `claims`，以及至少一个原始材料文件和它的 SHA-256。校验器会读取原始文件并重新计算摘要；空文件、目录、错误摘要、错误版本、错误类别、声明不一致或私人字段都会失败。
@@ -43,7 +43,7 @@ cp deploy/room-server/acceptance-evidence.template.json \
 计算摘要示例：
 
 ```bash
-sha256sum .acceptance-evidence/v1.14.0/artifacts/<已脱敏材料>
+sha256sum .acceptance-evidence/v1.14.1/artifacts/<已脱敏材料>
 ```
 
 生产资源证据至少在现场验收前、中、后各采样一次。`swapSamplesMiB` 至少填 3 个数；校验器将峰峰值不超过 128MiB 作为“无 swap 振荡”的保守可重复判据。
@@ -78,7 +78,7 @@ sha256sum .acceptance-evidence/v1.14.0/artifacts/<已脱敏材料>
 
 ```bash
 npm run verify:online-acceptance -- \
-  .acceptance-evidence/v1.14.0/evidence.json
+  .acceptance-evidence/v1.14.1/evidence.json
 ```
 
 退出码 `0` 且输出 `PASS` 才表示证据合同满足；退出码 `1` 表示一个或多个硬门槛失败，退出码 `2` 表示文件/JSON 用法错误。该命令只校验证据完整性，不会替代人工核对材料真实性。

--- a/deploy/room-server/README.md
+++ b/deploy/room-server/README.md
@@ -4,10 +4,10 @@
 
 ## 构建与安装
 
-在已检出不可变 `v1.14.0` 标签的仓库根目录执行：
+在已检出不可变 `v1.14.1` 标签的仓库根目录执行：
 
 ```bash
-docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.14.0 .
+docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.14.1 .
 ufw allow in on docker0 from 172.17.0.0/16 to 172.17.0.1 port 8787 proto tcp comment "flying chess room from discourse"
 install -m 0644 deploy/room-server/flying-chess-room.service /etc/systemd/system/
 install -m 0644 deploy/room-server/flying-chess-room-health.service /etc/systemd/system/

--- a/deploy/room-server/acceptance-evidence.template.json
+++ b/deploy/room-server/acceptance-evidence.template.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "release": "v1.14.0",
+  "release": "v1.14.1",
   "publicGateway": {
     "dnsResolved": false,
     "certificateSans": [],

--- a/deploy/room-server/acceptance-proof.template.json
+++ b/deploy/room-server/acceptance-proof.template.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "release": "v1.14.0",
+  "release": "v1.14.1",
   "recordedAtUtc": "2026-08-02T00:00:00.000Z",
   "kind": "replace_with_required_kind",
   "artifacts": [

--- a/deploy/room-server/flying-chess-room.service
+++ b/deploy/room-server/flying-chess-room.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=ROOM_IMAGE=flying-chess-room:1.14.0
+Environment=ROOM_IMAGE=flying-chess-room:1.14.1
 EnvironmentFile=-/etc/flying-chess-room.env
 ExecStartPre=-/usr/bin/docker rm -f flying-chess-room
 ExecStart=/usr/bin/docker run --rm --name flying-chess-room --network host --read-only --tmpfs /tmp:rw,noexec,nosuid,size=8m --cap-drop ALL --security-opt no-new-privileges --pids-limit 128 --cpus 1 --memory 128m --memory-swap 192m --health-cmd "wget -qO- http://172.17.0.1:8787/ready >/dev/null || exit 1" --health-interval 30s --health-timeout 3s --health-start-period 5s --health-retries 3 --log-driver journald -e NODE_ENV=production -e HOST=172.17.0.1 -e PORT=8787 -e ALLOWED_ORIGINS=https://atang-sp.github.io -e ACHIEVEMENT_CLAIM_SECRET -e ACHIEVEMENT_CLAIM_URL ${ROOM_IMAGE}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -54,9 +54,9 @@
     },
     "apps/room-server": {
       "name": "@flying-chess/room-server",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "dependencies": {
-        "@flying-chess/game-core": "1.14.0",
+        "@flying-chess/game-core": "1.14.1",
         "ws": "^8.18.3"
       },
       "devDependencies": {
@@ -4159,9 +4159,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6771,9 +6771,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -10749,19 +10749,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/workbox-build/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/workbox-build/node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -11199,7 +11186,7 @@
     },
     "packages/game-core": {
       "name": "@flying-chess/game-core",
-      "version": "1.14.0"
+      "version": "1.14.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "private": true,
   "workspaces": [
     "packages/*",
@@ -22,7 +22,7 @@
     "deploy:manual": "npm run build && echo '✅ 构建完成，请手动上传dist文件夹到GitHub Pages'",
     "build:tag": "node scripts/build-with-tag.js",
     "lint": "eslint . --ext .vue,.js,.ts,.jsx,.tsx --fix",
-    "lint:check": "eslint . --ext .vue,.js,.ts,.jsx,.tsx",
+    "lint:check": "eslint . --ext .vue,.js,.ts,.jsx,.tsx --max-warnings=0",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "vue-tsc --noEmit && npm run type-check --workspaces --if-present",
@@ -61,7 +61,7 @@
     "vue": "^3.5.13"
   },
   "overrides": {
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/packages/game-core/package.json
+++ b/packages/game-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/game-core",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/game-core/src/index.ts
+++ b/packages/game-core/src/index.ts
@@ -23,6 +23,7 @@ import { GameService } from '../../../src/services/gameService'
 import {
   createBoardConfig as createSharedBoardConfig,
   createModeConfig,
+  cryptoRandomInt,
   createPunishmentConfig as createSharedPunishmentConfig,
   createSharedBoard,
   createStandardConfigSnapshot,
@@ -812,7 +813,7 @@ const ONLINE_BASELINE_PUNISHMENT_VARIANTS: readonly PunishmentVariant[] = [
 ]
 
 const DEFAULT_DEPENDENCIES: GameCommandDependencies = {
-  rollDice: () => (crypto.getRandomValues(new Uint8Array(1))[0] % 6) + 1,
+  rollDice: () => cryptoRandomInt(1, 6),
 }
 
 export function createOnlineGame(

--- a/packages/game-core/src/sharedConfig.test.ts
+++ b/packages/game-core/src/sharedConfig.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   createModeConfig,
+  cryptoRandomInt,
   createSharedBoard,
   createStandardConfigSnapshot,
   MODE_POLICIES,
@@ -14,10 +15,29 @@ import {
 
 const deterministicRandom = (value = 0): BoardRandomSource => ({
   randomInt: (minimum, maximum) => Math.min(maximum, Math.max(minimum, value)),
-  choice: entries => entries[value % entries.length]!,
+  choice: entries => {
+    const selected = entries[value % entries.length]
+    if (selected === undefined) throw new Error('test random source received an empty collection')
+    return selected
+  },
 })
 
 describe('shared game configuration contract', () => {
+  it('rejects uint32 tail samples so bounded random integers stay uniform', () => {
+    const samples = [0xffff_ffff, 5]
+    let calls = 0
+    const source = {
+      getRandomValues(values: Uint32Array) {
+        values[0] = samples[calls] ?? 0
+        calls += 1
+        return values
+      },
+    }
+
+    expect(cryptoRandomInt(1, 6, source)).toBe(6)
+    expect(calls).toBe(2)
+  })
+
   it('derives local and online heating snapshots from the effective standard snapshot', () => {
     const standard = createStandardConfigSnapshot({
       boardConfig: { totalCells: 40 },
@@ -37,9 +57,12 @@ describe('shared game configuration contract', () => {
     expect(online.boardConfig).toEqual(local.boardConfig)
     expect(online.punishmentConfig).toEqual(local.punishmentConfig)
 
-    local.punishmentConfig.tools['手掌']!.ratio = 0
+    const localHand = local.punishmentConfig.tools['手掌']
+    const standardHand = standard.punishmentConfig.tools['手掌']
+    if (!localHand || !standardHand) throw new Error('expected standard hand punishment tool')
+    localHand.ratio = 0
     local.boardConfig.totalCells = 60
-    expect(standard.punishmentConfig.tools['手掌']!.ratio).toBeGreaterThan(0)
+    expect(standardHand.ratio).toBeGreaterThan(0)
     expect(standard.boardConfig.totalCells).toBe(40)
   })
 

--- a/packages/game-core/src/sharedConfig.ts
+++ b/packages/game-core/src/sharedConfig.ts
@@ -159,6 +159,10 @@ export interface BoardRandomSource {
   weightedChoice?<T>(entries: readonly T[], weights: readonly number[]): T
 }
 
+export interface CryptoRandomSource {
+  getRandomValues(values: Uint32Array): Uint32Array
+}
+
 export interface PublicConfigProjection {
   modeId: ModeId
   rulesetVersion: RulesetVersion
@@ -1282,16 +1286,36 @@ export function projectPublicConfig(config: ConfigSnapshot): PublicConfigProject
   }
 }
 
+export function cryptoRandomInt(
+  minimum: number,
+  maximum: number,
+  source: CryptoRandomSource = globalThis.crypto
+): number {
+  if (!Number.isSafeInteger(minimum) || !Number.isSafeInteger(maximum) || minimum > maximum) {
+    throw new RangeError('随机整数范围必须是按升序排列的安全整数')
+  }
+  const range = maximum - minimum + 1
+  const uint32Range = 0x1_0000_0000
+  if (range > uint32Range) {
+    throw new RangeError('随机整数范围不能超过 uint32 可表示的取值数量')
+  }
+  const acceptanceLimit = Math.floor(uint32Range / range) * range
+  const bytes = new Uint32Array(1)
+  let sample: number
+  do {
+    source.getRandomValues(bytes)
+    sample = bytes[0]
+  } while (sample >= acceptanceLimit)
+  return minimum + (sample % range)
+}
+
 const secureRandomSource: BoardRandomSource = {
-  randomInt: (minimum, maximum) => {
-    const range = maximum - minimum + 1
-    const bytes = new Uint32Array(1)
-    globalThis.crypto.getRandomValues(bytes)
-    return minimum + (bytes[0]! % range)
-  },
+  randomInt: cryptoRandomInt,
   choice: entries => {
     if (entries.length === 0) throw new Error('不能从空集合中选择')
-    return entries[secureRandomSource.randomInt(0, entries.length - 1)]!
+    const selected = entries[secureRandomSource.randomInt(0, entries.length - 1)]
+    if (selected === undefined) throw new Error('随机选择结果超出集合范围')
+    return selected
   },
 }
 
@@ -1314,7 +1338,9 @@ const chooseWeighted = <T extends { ratio: number }>(
     cumulative += entry.ratio
     if (threshold <= cumulative) return entry
   }
-  return enabled[enabled.length - 1]!
+  const fallback = enabled[enabled.length - 1]
+  if (fallback === undefined) throw new Error('没有启用的惩罚配置')
+  return fallback
 }
 
 export function createCompatiblePunishmentAction(
@@ -1390,10 +1416,13 @@ export function createSharedBoard(
   const availablePositions = Array.from({ length: totalCells - 2 }, (_, index) => index + 2)
   for (let index = availablePositions.length - 1; index > 0; index -= 1) {
     const swapIndex = random.randomInt(0, index)
-    ;[availablePositions[index], availablePositions[swapIndex]] = [
-      availablePositions[swapIndex]!,
-      availablePositions[index]!,
-    ]
+    const current = availablePositions[index]
+    const swap = availablePositions[swapIndex]
+    if (current === undefined || swap === undefined) {
+      throw new Error('棋盘随机源返回了越界位置')
+    }
+    availablePositions[index] = swap
+    availablePositions[swapIndex] = current
   }
 
   const board = new Map<number, BoardCell>([
@@ -1546,5 +1575,9 @@ export function createSharedBoard(
       })
     }
   }
-  return Array.from({ length: totalCells }, (_, index) => board.get(index + 1)!)
+  return Array.from({ length: totalCells }, (_, index) => {
+    const cell = board.get(index + 1)
+    if (!cell) throw new Error(`棋盘缺少第 ${index + 1} 格`)
+    return cell
+  })
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,9 @@ const packageVersion = JSON.parse(readFileSync(new URL('./package.json', import.
 export default defineConfig({
   testDir: './tests/e2e',
   timeout: 30_000,
+  // Some scenarios create extra host/guest/controller contexts. Capping file-level
+  // parallelism avoids multiplying those into enough Chrome processes to cause false timeouts.
+  workers: 2,
   use: {
     baseURL: 'http://127.0.0.1:4175',
     channel: 'chrome',

--- a/src/App.vue
+++ b/src/App.vue
@@ -735,11 +735,19 @@
         })
       ) {
         try {
-          partyPunishmentChoices.value = createPartyPunishmentChoices(
+          const choices = createPartyPunishmentChoices(
             gameState.punishmentConfig,
             undefined,
             actConstraints
           )
+          partyPunishmentChoices.value = choices
+          if (multiDevice.isRemotePlayer(gameState.currentPlayerIndex)) {
+            multiDevice.requestAction(gameState.currentPlayerIndex, {
+              type: 'punishment_choice',
+              choiceA: choices[0].description,
+              choiceB: choices[1].description,
+            })
+          }
           pendingPartyLanding.value = {
             currentPlayer,
             fromPosition,
@@ -2960,6 +2968,7 @@
     gameFinished,
     isPartyGame,
     sessionPaused,
+    canRollDice,
     victoryConfig,
     overlayState: () => ({
       currentPunishment: Boolean(currentPunishment.value),

--- a/src/components/IntroPage.vue
+++ b/src/components/IntroPage.vue
@@ -460,6 +460,7 @@
             <div class="count-controls">
               <button
                 class="btn btn-secondary count-btn minus"
+                aria-label="减少玩家人数"
                 :disabled="playerCount <= 1"
                 @click="onPlayerCountChange(Math.max(1, playerCount - 1))"
               >
@@ -471,6 +472,7 @@
               </div>
               <button
                 class="btn btn-secondary count-btn plus"
+                aria-label="增加玩家人数"
                 @click="onPlayerCountChange(playerCount + 1)"
               >
                 <Plus :size="18" />

--- a/src/composables/useMultiDeviceHost.ts
+++ b/src/composables/useMultiDeviceHost.ts
@@ -54,9 +54,49 @@ export interface MultiDeviceHostDeps {
   gameFinished: Ref<boolean>
   isPartyGame: ComputedRef<boolean>
   sessionPaused: Ref<boolean>
+  canRollDice: ComputedRef<boolean>
   victoryConfig: Ref<VictoryConfig>
   overlayState: () => MultiDeviceOverlayState
   actions: MultiDeviceHostActions
+}
+
+export function controllerMessageMatchesRequiredAction(
+  message: ControllerMessage,
+  requiredAction: RequiredAction | null,
+  canRollDice: boolean
+): boolean {
+  switch (message.type) {
+    case 'join':
+      return false
+    case 'roll_dice':
+      return canRollDice && (requiredAction === null || requiredAction.type === 'roll_dice')
+    case 'predict':
+      return requiredAction?.type === 'predict'
+    case 'reaction_decision':
+      return requiredAction?.type === 'reaction_decision'
+    case 'reroll':
+      return requiredAction?.type === 'dice_decision' && requiredAction.canReroll
+    case 'continue_move':
+      return requiredAction?.type === 'dice_decision'
+    case 'select_punishment':
+    case 'skip_punishment_choice':
+      return requiredAction?.type === 'punishment_choice'
+    case 'punishment_intervention':
+      return (
+        requiredAction?.type === 'punishment_intervention' &&
+        requiredAction.actions.includes(message.action) &&
+        (message.action !== 'transfer' ||
+          requiredAction.transferTargets.some(
+            target => target.playerIndex === message.targetPlayerIndex
+          ))
+      )
+    case 'decline_punishment_intervention':
+      return requiredAction?.type === 'punishment_intervention'
+    case 'acknowledge':
+      return requiredAction?.type === 'acknowledge'
+    case 'tiebreak_roll':
+      return requiredAction?.type === 'tiebreak_roll'
+  }
 }
 
 export function useMultiDeviceHost(deps: MultiDeviceHostDeps) {
@@ -167,6 +207,11 @@ export function useMultiDeviceHost(deps: MultiDeviceHostDeps) {
   }
 
   function routeControllerAction(playerIndex: number, msg: ControllerMessage): void {
+    const requiredAction = requiredActionForPlayer(playerIndex)
+    const canRollDice = deps.canRollDice.value && deps.gameState.currentPlayerIndex === playerIndex
+    if (!controllerMessageMatchesRequiredAction(msg, requiredAction, canRollDice)) return
+    if (requiredAction?.type !== 'roll_dice') clearPendingAction(playerIndex)
+
     switch (msg.type) {
       case 'roll_dice':
         if (deps.gameState.currentPlayerIndex === playerIndex) {
@@ -247,7 +292,7 @@ export function useMultiDeviceHost(deps: MultiDeviceHostDeps) {
     for (const [peerId, playerIndex] of peerToPlayerIndex) {
       if (!network.isConnected(peerId)) continue
 
-      const action = pendingActions.value.get(playerIndex) ?? null
+      const action = requiredActionForPlayer(playerIndex)
       const view = projectPlayerView(
         playerIndex,
         deps.gameState,
@@ -257,6 +302,26 @@ export function useMultiDeviceHost(deps: MultiDeviceHostDeps) {
       )
       network.sendTo(peerId, { type: 'state_update', view })
     }
+  }
+
+  function requiredActionForPlayer(playerIndex: number): RequiredAction | null {
+    const explicitAction = pendingActions.value.get(playerIndex)
+    if (explicitAction) return explicitAction
+    if (
+      deps.canRollDice.value &&
+      deps.gameState.currentPlayerIndex === playerIndex &&
+      deps.gameStarted.value &&
+      !deps.gameFinished.value
+    ) {
+      return { type: 'roll_dice' }
+    }
+    if (
+      deps.gameState.currentPlayerIndex === playerIndex &&
+      Object.values(deps.overlayState()).some(Boolean)
+    ) {
+      return { type: 'acknowledge', message: deps.lastEffect.value || '请在主屏查看并确认当前操作' }
+    }
+    return null
   }
 
   function requestAction(playerIndex: number, action: RequiredAction): void {

--- a/src/services/syncProtocol.ts
+++ b/src/services/syncProtocol.ts
@@ -51,7 +51,28 @@ export function serializeHostMessage(msg: HostMessage): string {
 }
 
 export function deserializeHostMessage(data: string): HostMessage {
-  return JSON.parse(data) as HostMessage
+  const parsed = parseMessageObject(data, '主机消息格式无效')
+  const valid = (() => {
+    switch (parsed.type) {
+      case 'player_assigned':
+        return isNonNegativeInteger(parsed.playerIndex) && isPublicPlayerInfo(parsed.player)
+      case 'state_update':
+        return isPlayerView(parsed.view)
+      case 'game_ended':
+        return (
+          typeof parsed.winnerName === 'string' &&
+          (parsed.settlement === undefined || isVictorySettlement(parsed.settlement))
+        )
+      case 'room_closed':
+        return true
+      case 'error':
+        return typeof parsed.message === 'string'
+      default:
+        return false
+    }
+  })()
+  if (!valid) throw new Error('主机消息格式无效')
+  return parsed as HostMessage
 }
 
 export function serializeControllerMessage(msg: ControllerMessage): string {
@@ -59,5 +80,142 @@ export function serializeControllerMessage(msg: ControllerMessage): string {
 }
 
 export function deserializeControllerMessage(data: string): ControllerMessage {
-  return JSON.parse(data) as ControllerMessage
+  const message = parseMessageObject(data, '控制消息格式无效')
+  const valid = (() => {
+    switch (message.type) {
+      case 'join':
+        return message.preferredName === undefined || typeof message.preferredName === 'string'
+      case 'roll_dice':
+      case 'reroll':
+      case 'continue_move':
+      case 'skip_punishment_choice':
+      case 'decline_punishment_intervention':
+      case 'acknowledge':
+      case 'tiebreak_roll':
+        return true
+      case 'predict':
+        return message.prediction === 'low' || message.prediction === 'high'
+      case 'reaction_decision':
+        return message.decision === 'keep' || message.decision === 'mirror'
+      case 'select_punishment':
+        return message.index === 0 || message.index === 1
+      case 'punishment_intervention':
+        return (
+          (message.action === 'transfer' ||
+            message.action === 'amplify' ||
+            message.action === 'immunity') &&
+          (message.targetPlayerIndex === undefined || Number.isInteger(message.targetPlayerIndex))
+        )
+      default:
+        return false
+    }
+  })()
+  if (!valid) throw new Error('控制消息格式无效')
+  return message as ControllerMessage
+}
+
+function parseMessageObject(data: string, errorMessage: string): Record<string, unknown> {
+  if (!data || data.length > 16 * 1024) throw new Error(errorMessage)
+  try {
+    const parsed: unknown = JSON.parse(data)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+  } catch {
+    // Normalise syntax and shape failures to the protocol-level error below.
+  }
+  throw new Error(errorMessage)
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function isPublicPlayerInfo(value: unknown): value is PublicPlayerInfo {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const player = value as Record<string, unknown>
+  return (
+    isNonNegativeInteger(player.id) &&
+    typeof player.name === 'string' &&
+    typeof player.color === 'string' &&
+    isNonNegativeInteger(player.position) &&
+    typeof player.hasTakenOff === 'boolean' &&
+    typeof player.isWinner === 'boolean'
+  )
+}
+
+function isRequiredAction(value: unknown): value is RequiredAction {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const action = value as Record<string, unknown>
+  switch (action.type) {
+    case 'roll_dice':
+    case 'tiebreak_roll':
+      return true
+    case 'predict':
+      return isNonNegativeInteger(action.timeoutSeconds)
+    case 'reaction_decision':
+      return isFiniteNumber(action.rolledValue) && isNonNegativeInteger(action.timeoutSeconds)
+    case 'dice_decision':
+      return (
+        isFiniteNumber(action.diceValue) &&
+        typeof action.canReroll === 'boolean' &&
+        isNonNegativeInteger(action.timeoutSeconds)
+      )
+    case 'punishment_choice':
+      return typeof action.choiceA === 'string' && typeof action.choiceB === 'string'
+    case 'punishment_intervention':
+      return (
+        typeof action.targetName === 'string' &&
+        typeof action.countLabel === 'string' &&
+        Array.isArray(action.actions) &&
+        action.actions.every(item => ['transfer', 'amplify', 'immunity'].includes(String(item))) &&
+        Array.isArray(action.transferTargets) &&
+        action.transferTargets.every(target => {
+          if (!target || typeof target !== 'object' || Array.isArray(target)) return false
+          const candidate = target as Record<string, unknown>
+          return (
+            isNonNegativeInteger(candidate.playerIndex) && typeof candidate.playerName === 'string'
+          )
+        })
+      )
+    case 'acknowledge':
+      return typeof action.message === 'string'
+    default:
+      return false
+  }
+}
+
+function isPlayerView(value: unknown): value is PlayerView {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const view = value as Record<string, unknown>
+  return (
+    isNonNegativeInteger(view.myIndex) &&
+    typeof view.isMyTurn === 'boolean' &&
+    isNonNegativeInteger(view.tokensRemaining) &&
+    (view.diceValue === null || isFiniteNumber(view.diceValue)) &&
+    typeof view.gameStatus === 'string' &&
+    ['warmup', 'heating', 'finale'].includes(String(view.currentAct)) &&
+    Array.isArray(view.allPlayers) &&
+    view.allPlayers.every(isPublicPlayerInfo) &&
+    isNonNegativeInteger(view.boardSize) &&
+    isNonNegativeInteger(view.roundNumber) &&
+    (view.pendingAction === null || isRequiredAction(view.pendingAction)) &&
+    (view.lastEffect === null || typeof view.lastEffect === 'string') &&
+    typeof view.diceChangedThisTurn === 'boolean'
+  )
+}
+
+function isVictorySettlement(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const settlement = value as Record<string, unknown>
+  return (
+    typeof settlement.actionText === 'string' &&
+    isNonNegativeInteger(settlement.count) &&
+    typeof settlement.countUnit === 'string' &&
+    isNonNegativeInteger(settlement.place)
+  )
 }

--- a/src/tests/cache.test.ts
+++ b/src/tests/cache.test.ts
@@ -5,7 +5,9 @@ import {
   VICTORY_CONFIG_STORAGE_KEY,
   PARTY_EVENT_DECK_STORAGE_KEY,
   LOCAL_PROGRESS_STORAGE_KEY,
+  PLAYER_SETTINGS_STORAGE_KEY,
   loadGameMode,
+  loadPlayerSettings,
   loadPartyEventDeck,
   loadLocalProgress,
   loadVictoryConfig,
@@ -19,6 +21,19 @@ import { DEFAULT_PARTY_EVENT_DECK } from '../services/partyEvents'
 import { recordLocalProgress } from '../services/localProgress'
 
 describe('本地游戏数据清理', () => {
+  it('损坏的玩家设置不会作为可信数组进入启动流程', () => {
+    const values = new Map<string, string>([
+      [PLAYER_SETTINGS_STORAGE_KEY, JSON.stringify({ playerCount: 2, playerNames: null })],
+    ])
+    const storage = {
+      getItem(key: string) {
+        return values.get(key) ?? null
+      },
+    }
+
+    expect(loadPlayerSettings(storage)).toBeNull()
+  })
+
   it('清除配置、玩家、备份和引导偏好使用的实际键名', () => {
     const values = new Map<string, string>(LOCAL_GAME_STORAGE_KEYS.map(key => [key, 'saved']))
     const storage = {

--- a/src/tests/multiDeviceHost.test.ts
+++ b/src/tests/multiDeviceHost.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { controllerMessageMatchesRequiredAction } from '../composables/useMultiDeviceHost'
+
+describe('局域网手柄动作授权', () => {
+  it('只允许玩家提交其当前私密投影要求的动作', () => {
+    expect(
+      controllerMessageMatchesRequiredAction(
+        { type: 'reaction_decision', decision: 'mirror' },
+        { type: 'predict', timeoutSeconds: 5 },
+        false
+      )
+    ).toBe(false)
+    expect(
+      controllerMessageMatchesRequiredAction(
+        { type: 'predict', prediction: 'high' },
+        { type: 'predict', timeoutSeconds: 5 },
+        false
+      )
+    ).toBe(true)
+    expect(controllerMessageMatchesRequiredAction({ type: 'roll_dice' }, null, true)).toBe(true)
+    expect(controllerMessageMatchesRequiredAction({ type: 'roll_dice' }, null, false)).toBe(false)
+  })
+})

--- a/src/tests/syncProtocol.test.ts
+++ b/src/tests/syncProtocol.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { deserializeControllerMessage, deserializeHostMessage } from '../services/syncProtocol'
+
+describe('局域网手柄消息协议', () => {
+  it('拒绝类型名称合法但载荷越界的控制消息', () => {
+    expect(() =>
+      deserializeControllerMessage(JSON.stringify({ type: 'predict', prediction: 'sideways' }))
+    ).toThrow('控制消息格式无效')
+    expect(() =>
+      deserializeControllerMessage(JSON.stringify({ type: 'select_punishment', index: 99 }))
+    ).toThrow('控制消息格式无效')
+  })
+
+  it('拒绝字段缺失或嵌套状态损坏的主机消息', () => {
+    expect(() =>
+      deserializeHostMessage(JSON.stringify({ type: 'player_assigned', playerIndex: -1 }))
+    ).toThrow('主机消息格式无效')
+    expect(() =>
+      deserializeHostMessage(
+        JSON.stringify({
+          type: 'state_update',
+          view: { myIndex: 0, pendingAction: { type: 'predict', timeoutSeconds: -1 } },
+        })
+      )
+    ).toThrow('主机消息格式无效')
+  })
+})

--- a/src/tests/viteConfig.test.ts
+++ b/src/tests/viteConfig.test.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { resolveConfig } from 'vite'
+
+describe('Vite development server configuration', () => {
+  it('lets each CLI-selected port own its matching HMR endpoint', async () => {
+    const config = await resolveConfig(
+      {
+        configFile: fileURLToPath(new URL('../../vite.config.ts', import.meta.url)),
+        server: { port: 4175 },
+      },
+      'serve',
+      'test'
+    )
+
+    expect(config.server.port).toBe(4175)
+    expect(config.server.hmr).not.toMatchObject({ port: 5173 })
+  })
+})

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -122,6 +122,8 @@ export interface PlayerSettings {
   playerNames: string[]
 }
 
+type PlayerSettingsStorageReader = Pick<Storage, 'getItem'>
+
 export function savePlayerSettings(settings: PlayerSettings) {
   try {
     localStorage.setItem(PLAYER_SETTINGS_STORAGE_KEY, JSON.stringify(settings))
@@ -130,11 +132,28 @@ export function savePlayerSettings(settings: PlayerSettings) {
   }
 }
 
-export function loadPlayerSettings(): PlayerSettings | null {
-  const raw = localStorage.getItem(PLAYER_SETTINGS_STORAGE_KEY)
+export function loadPlayerSettings(
+  storage: PlayerSettingsStorageReader = localStorage
+): PlayerSettings | null {
+  const raw = storage.getItem(PLAYER_SETTINGS_STORAGE_KEY)
   if (!raw) return null
   try {
-    return JSON.parse(raw) as PlayerSettings
+    const value: unknown = JSON.parse(raw)
+    if (!value || typeof value !== 'object') return null
+    const candidate = value as Record<string, unknown>
+    if (
+      !Number.isSafeInteger(candidate.playerCount) ||
+      Number(candidate.playerCount) < 1 ||
+      !Array.isArray(candidate.playerNames) ||
+      candidate.playerNames.length !== candidate.playerCount ||
+      candidate.playerNames.some(name => typeof name !== 'string')
+    ) {
+      return null
+    }
+    return {
+      playerCount: Number(candidate.playerCount),
+      playerNames: [...candidate.playerNames],
+    }
   } catch (err) {
     console.warn('读取玩家设置失败:', err)
     return null

--- a/tests/e2e/board-ui.spec.ts
+++ b/tests/e2e/board-ui.spec.ts
@@ -22,6 +22,13 @@ async function startDefaultGame(page: Page) {
   await expect(page.locator('.game-board')).toBeVisible()
 }
 
+test('玩家人数图标按钮提供可读名称', async ({ page }) => {
+  await page.goto('/flying-chess/')
+
+  await expect(page.getByRole('button', { name: '减少玩家人数' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '增加玩家人数' })).toBeVisible()
+})
+
 test('手机上可轻点查看格子全文，并明确区分普通格和奖励格', async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== 'mobile-chrome')
 

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -323,6 +323,9 @@ test('native WebRTC pairs two phone controllers without cloud signalling', async
     await expect(controllerPage.locator('.controller-main')).toBeVisible()
     await expect(controllerPage.getByTitle('干预筹码')).toBeVisible()
   }
+  await expect(controllers[0].getByRole('button', { name: '🎲 掷骰子' })).toBeVisible()
+  await controllers[0].getByRole('button', { name: '🎲 掷骰子' }).click()
+  await expect(controllers[1].getByRole('button', { name: /小 \(1-3\)/ })).toBeVisible()
 })
 
 test('party mode preserves the classic custom configuration while running and after reset', async ({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -88,11 +88,6 @@ export default defineConfig(async ({ command, mode }) => {
       open: false,
       // 允许跨域
       cors: true,
-      // 热更新配置
-      hmr: {
-        host: 'localhost',
-        port: 5173,
-      },
     },
     build: {
       outDir: 'dist',


### PR DESCRIPTION
## Summary

- eliminate modulo bias in shared dice and board randomness
- validate LAN controller/host messages and authorize controller actions against each player's private pending action
- restore remote roll and punishment-choice flows, and clear stale pause requests after automatic host transfer
- reject corrupt cached player settings and add accessible names to player-count controls
- remove the fixed Vite HMR port and cap Playwright workers to avoid resource-driven false timeouts
- enforce zero-warning lint, update vulnerable transitive dependencies, and prepare the v1.14.1 Pages/room-server release metadata

## Root causes

Several trust boundaries relied on TypeScript casts rather than runtime validation, controller actions were routed without matching the player's assigned action, random integers used modulo reduction, and the development/test configuration assumed fixed local resources. The room failover path also cleared skip votes but retained pause votes.

## Impact

Classic remains the default and Party/online flows remain opt-in. The changes improve fairness, LAN controller correctness, failover behavior, startup resilience, accessibility, local development, CI stability, and dependency security.

## Validation

- `npm test` — 28 files / 236 tests passed
- `npm run test:e2e` — 63 passed / 55 conditional skips / 0 failed
- `npm run lint:check`
- `npm run type-check`
- `npm run format:check`
- `npm run validate-config`
- frontend and room-server production builds
- room-server load test — 20 rooms / 160 connections, p95 0.5 ms, RSS 78.4 MiB
- production and full `npm audit` — 0 vulnerabilities
- dual Vite instances verified on ports 4173 and 4175

## Release boundary

This PR prepares v1.14.1. After merge, the immutable tag will trigger GitHub Pages deployment and the room-server image will be deployed separately. Real iOS/Android and 4/6/8-person field acceptance remains a separate manual evidence gate.
