### PR TITLE
test: stabilize WebRTC pairing readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,12 @@ jobs:
 
       - name: Run browser tests
         run: npm run test:e2e
+
+      - name: Upload browser failure traces
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-traces-${{ github.run_attempt }}
+          path: test-results
+          if-no-files-found: ignore
+          retention-days: 7

--- a/tests/e2e/reliability.spec.ts
+++ b/tests/e2e/reliability.spec.ts
@@ -313,9 +313,10 @@ test('native WebRTC pairs two phone controllers without cloud signalling', async
 
     await page.getByTestId('lan-pairing-answer-input').fill(await answerField.inputValue())
     await page.getByTestId('lan-pairing-submit').click()
-    if (index === 0) {
-      await expect.poll(() => page.locator('.connection-item.connected').count()).toBe(1)
-    }
+    await expect(
+      page.getByTitle(`多设备模式 - ${index + 1}/2 已连接`),
+      `controller ${index + 1} should finish its WebRTC handshake`
+    ).toBeVisible({ timeout: 15_000 })
   }
 
   await expect(lobby).toBeHidden()


### PR DESCRIPTION
## Summary

- wait for each phone controller's persistent connected status before asserting that the pairing lobby closes
- allow up to 15 seconds for the native WebRTC handshake under CI load
- retain Playwright failure traces for seven days when Browser E2E fails

## Root cause

The master Browser E2E run submitted the second pairing answer and immediately relied on Playwright's default five-second visibility timeout. The WebRTC data channel and controller join can complete after that timeout on a loaded runner even though the application remains in the correct waiting state.

The identical tree passed on the PR branch, the failed master job passed on rerun, and the original test passed 23 targeted local repetitions. This change makes the readiness condition explicit and preserves diagnostics if a future failure is genuine.

## Impact

CI and test diagnostics only. Production code and the v1.14.1 release are unchanged.

## Validation

- targeted WebRTC E2E: 20/20 with 2 workers after the change
- full Playwright suite: 63 passed, 55 skipped
- Vitest: 236 passed
- formatting, ESLint, type checks, configuration validation, web build, room-server build, and git diff check passed
- failed master CI run 31175472118 passed when rerun
