### PR TITLE
feat: harden online release operability for v1.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,38 @@ jobs:
           path: test-results
           if-no-files-found: ignore
           retention-days: 7
+
+  room-server-operability:
+    name: Room Server Operability
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build room server
+        run: npm run build:room-server
+
+      - name: Run room server tests
+        run: npm run test:room-server
+
+      - name: Run ephemeral release smoke
+        run: npm run test:room-server-smoke
+
+      - name: Run 20-room and 160-connection load test
+        run: npm run test:room-server-load
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Verify tests leave the checkout unchanged
+        run: git diff --exit-code

--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ npm install primevue primeicons
   猜拳和小游戏答案按玩家投影。刷新或短暂断网会自动恢复原席位，主持人只能在 90 秒保护期后、
   新回合安全节点移除离场玩家。
 - **房间服务**：构建、128 MiB 容量限制、Discourse Nginx/WSS 反代、监控和回滚步骤见
-  `deploy/room-server/README.md`。房间只在内存中保存，最长 2 小时；服务重启会结束房间。
+  `deploy/room-server/README.md`。协议版本、health/readiness、graceful drain、私有指标与
+  release smoke 合同见 [docs/ONLINE_OPERABILITY.md](docs/ONLINE_OPERABILITY.md)。房间只在内存中保存，最长 2 小时；服务重启会结束房间。
 - **Umami Cloud**：生产网站名为 `flying-chess-production`，域名为
   `atang-sp.github.io`；Replays、Heatmaps、Performance 与公开 Share URL 必须保持关闭。
 - **Vercel/Netlify**：直接连接仓库，构建命令 `npm run build`，输出目录 `dist`
@@ -222,6 +223,8 @@ npm install primevue primeicons
 - 共享游戏参数与惩罚规则详见 `packages/game-core/src/sharedConfig.ts` 和
   `packages/game-core/src/ruleResolution.ts`；浏览器端兼容入口见 `src/config/gameConfig.ts`
 - 匿名统计事件契约与隐私边界见 `src/services/gameTelemetry.ts`
+- 联机协议、运维、发布顺序与回滚合同见
+  [docs/ONLINE_OPERABILITY.md](docs/ONLINE_OPERABILITY.md)
 - 版本号注入逻辑见 `vite-plugin-version.ts`
 - 详细开发路线、更新日志请见 [ROADMAP.md] 和 [RELEASE_NOTES.md]（如有）
 

--- a/apps/room-server/Dockerfile
+++ b/apps/room-server/Dockerfile
@@ -16,11 +16,17 @@ RUN npm run build:room-server
 
 FROM node:24-alpine
 
+ARG ROOM_SERVER_VERSION=dev
+ARG ROOM_SERVER_BUILD_SHA=unknown
+
 WORKDIR /app
 ENV NODE_ENV=production \
     HOST=0.0.0.0 \
     PORT=8787 \
-    ALLOWED_ORIGINS=https://atang-sp.github.io
+    ALLOWED_ORIGINS=https://atang-sp.github.io \
+    ROOM_SERVER_VERSION=${ROOM_SERVER_VERSION} \
+    ROOM_SERVER_BUILD_SHA=${ROOM_SERVER_BUILD_SHA} \
+    ROOM_DRAIN_TIMEOUT_MS=1800000
 
 COPY --from=build --chown=node:node /app/apps/room-server/dist/server.mjs /app/server.mjs
 COPY --from=build --chown=node:node /app/node_modules/ws /app/node_modules/ws
@@ -28,6 +34,6 @@ COPY --from=build --chown=node:node /app/node_modules/ws /app/node_modules/ws
 USER node
 EXPOSE 8787
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:8787/ready >/dev/null || exit 1
+  CMD wget -qO- http://127.0.0.1:8787/health >/dev/null || exit 1
 
 CMD ["node", "/app/server.mjs"]

--- a/apps/room-server/package.json
+++ b/apps/room-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/room-server",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@flying-chess/game-core": "1.14.2",
+    "@flying-chess/game-core": "1.15.0",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/apps/room-server/src/cli.ts
+++ b/apps/room-server/src/cli.ts
@@ -1,4 +1,5 @@
 import { createRoomServer } from './server'
+import { readRoomServerEnvironment } from './serverConfig'
 import type { PartyEventCard } from '@flying-chess/game-core'
 
 const port = Number.parseInt(process.env.PORT ?? '8787', 10)
@@ -35,6 +36,7 @@ const quietTestEventDeck: readonly PartyEventCard[] | undefined =
     : undefined
 
 async function main(): Promise<void> {
+  const environment = readRoomServerEnvironment()
   const server = await createRoomServer({
     port,
     host,
@@ -49,16 +51,29 @@ async function main(): Promise<void> {
       process.env.NODE_ENV === 'test' && testReconnectGraceMs > 0
         ? testReconnectGraceMs
         : undefined,
+    version: environment.version,
+    buildSha: environment.buildSha,
+    drainTimeoutMs: environment.drainTimeoutMs,
+    metricsToken: environment.metricsToken,
   })
   console.info(`room server listening on port ${server.port}`)
 
-  async function shutdown(): Promise<void> {
-    await server.close()
-    process.exit(0)
+  let shutdownPromise: Promise<void> | undefined
+  function shutdown(): Promise<void> {
+    shutdownPromise ??= server
+      .beginDrain()
+      .then(() => {
+        process.exitCode = 0
+      })
+      .catch(() => {
+        console.error('room server failed to shut down cleanly')
+        process.exitCode = 1
+      })
+    return shutdownPromise
   }
 
-  process.once('SIGINT', () => void shutdown())
-  process.once('SIGTERM', () => void shutdown())
+  process.on('SIGINT', () => void shutdown())
+  process.on('SIGTERM', () => void shutdown())
 }
 
 void main().catch(() => {

--- a/apps/room-server/src/server.ts
+++ b/apps/room-server/src/server.ts
@@ -4,6 +4,7 @@ import {
   applyOnlineGameCommand,
   applyOnlineGameTimeout,
   cloneOnlineRoomSettings,
+  CURRENT_ONLINE_PROTOCOL_VERSION,
   createOnlineGame,
   DEFAULT_ONLINE_ROOM_SETTINGS,
   GameCommandError,
@@ -13,6 +14,7 @@ import {
   projectOnlineRoomSettings,
   projectOnlineGameView,
   removeOnlinePlayerAtSafeNode,
+  resolveOnlineProtocolVersion,
   type GameCommandDependencies,
   type OnlineGameCommand,
   type OnlineGameState,
@@ -27,6 +29,14 @@ import {
   validateGameCompletionClaimConfiguration,
   type GameCompletionClaimOptions,
 } from './gameCompletionClaims'
+import { createHealthResponse, createReadinessResponse } from './serverHealth'
+import { validateRoomServerBuildSha, validateRoomServerVersion } from './serverConfig'
+import {
+  isRoomDrainBlocking,
+  RoomServerLifecycle,
+  type RoomServerOperationalSnapshot,
+} from './serverLifecycle'
+import { isMetricsRequestAuthorized, ServerMetrics, validateMetricsToken } from './serverMetrics'
 
 const ROOM_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
 const DEFAULT_ROOM_TTL_MS = 2 * 60 * 60 * 1_000
@@ -39,6 +49,8 @@ const NICKNAME_MAX_LENGTH = 20
 const COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/
 const DEFAULT_MESSAGES_PER_SECOND = 30
 const DEFAULT_MESSAGE_BURST = 60
+const DEFAULT_DRAIN_TIMEOUT_MS = 30 * 60 * 1_000
+const MAX_DRAIN_TIMEOUT_MS = 24 * 60 * 60 * 1_000
 
 interface RoomPlayer {
   readonly id: string
@@ -83,11 +95,18 @@ export interface RoomServerOptions {
   readonly messagesPerSecond?: number
   readonly messageBurst?: number
   readonly achievementClaims?: GameCompletionClaimOptions & Readonly<{ claimUrl: string }>
+  readonly version?: string
+  readonly buildSha?: string
+  readonly drainTimeoutMs?: number
+  readonly metricsToken?: string
 }
 
 export interface RunningRoomServer {
   readonly port: number
   readonly wsUrl: string
+  beginDrain(): Promise<void>
+  isDraining(): boolean
+  getOperationalSnapshot(): RoomServerOperationalSnapshot
   close(): Promise<void>
 }
 
@@ -107,6 +126,7 @@ export async function createRoomServer(
   if (options.achievementClaims) {
     validateGameCompletionClaimConfiguration(options.achievementClaims)
   }
+  if (options.metricsToken !== undefined) validateMetricsToken(options.metricsToken)
   const now = options.now ?? Date.now
   const maxRooms = options.maxRooms ?? DEFAULT_MAX_ROOMS
   const roomTtlMs = options.roomTtlMs ?? DEFAULT_ROOM_TTL_MS
@@ -115,6 +135,19 @@ export async function createRoomServer(
   const messagesPerSecond = Math.max(1, options.messagesPerSecond ?? DEFAULT_MESSAGES_PER_SECOND)
   const messageBurst = Math.max(1, options.messageBurst ?? DEFAULT_MESSAGE_BURST)
   const startedAt = Date.now()
+  const metrics = new ServerMetrics(startedAt)
+  const serverVersion = options.version ?? 'dev'
+  const serverBuildSha = options.buildSha ?? 'unknown'
+  validateRoomServerVersion(serverVersion)
+  validateRoomServerBuildSha(serverBuildSha)
+  const drainTimeoutMs = options.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS
+  if (
+    !Number.isSafeInteger(drainTimeoutMs) ||
+    drainTimeoutMs < 1 ||
+    drainTimeoutMs > MAX_DRAIN_TIMEOUT_MS
+  ) {
+    throw new Error('drainTimeoutMs must be an integer between 1 and 86400000')
+  }
   const gameDependencies: GameCommandDependencies = {
     rollDice: options.rollDice ?? (() => randomInt(1, 7)),
     randomInt: (minimum, maximum) => randomInt(minimum, maximum + 1),
@@ -123,18 +156,64 @@ export async function createRoomServer(
   const rooms = new Map<string, Room>()
   const sessions = new Map<WebSocket, ConnectionSession>()
   let connectionCount = 0
+  const getOperationalSnapshot = (): RoomServerOperationalSnapshot => {
+    let activeGames = 0
+    let drainBlockingRooms = 0
+    for (const room of rooms.values()) {
+      if (room.game?.status === 'playing') activeGames += 1
+      const connectedSessions = room.players.filter(
+        player => player.socket?.readyState === WebSocket.OPEN
+      ).length
+      if (isRoomDrainBlocking(room.game?.status ?? 'lobby', connectedSessions)) {
+        drainBlockingRooms += 1
+      }
+    }
+    return {
+      rooms: rooms.size,
+      activeGames,
+      connections: connectionCount,
+      drainBlockingRooms,
+    }
+  }
   const httpServer = createServer((request, response) => {
-    if (request.method === 'GET' && (request.url === '/health' || request.url === '/ready')) {
+    if (request.method === 'GET' && request.url === '/internal/metrics') {
+      if (options.metricsToken === undefined) {
+        response.writeHead(404).end()
+        return
+      }
+      if (!isMetricsRequestAuthorized(request.headers.authorization, options.metricsToken)) {
+        response.writeHead(401, { 'www-authenticate': 'Bearer' }).end()
+        return
+      }
       response.writeHead(200, { 'content-type': 'application/json; charset=utf-8' })
       response.end(
-        JSON.stringify({
-          status: 'ok',
-          rooms: rooms.size,
-          connections: connectionCount,
-          uptimeSeconds: Math.floor((Date.now() - startedAt) / 1_000),
-          rssBytes: process.memoryUsage().rss,
-        })
+        JSON.stringify(metrics.snapshot(getOperationalSnapshot(), lifecycle.isDraining()))
       )
+      return
+    }
+    if (request.method === 'GET' && request.url === '/health') {
+      response.writeHead(200, { 'content-type': 'application/json; charset=utf-8' })
+      response.end(
+        JSON.stringify(
+          createHealthResponse(
+            {
+              version: serverVersion,
+              buildSha: serverBuildSha,
+              protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+              startedAt,
+            },
+            getOperationalSnapshot()
+          )
+        )
+      )
+      return
+    }
+    if (request.method === 'GET' && request.url === '/ready') {
+      const draining = lifecycle.isDraining()
+      response.writeHead(draining ? 503 : 200, {
+        'content-type': 'application/json; charset=utf-8',
+      })
+      response.end(JSON.stringify(createReadinessResponse(draining)))
       return
     }
     response.writeHead(404).end()
@@ -157,6 +236,8 @@ export async function createRoomServer(
           player.socket?.close(1001, 'room expired')
         }
         rooms.delete(code)
+        metrics.increment('roomsExpiredTotal')
+        lifecycle.notifyStateChanged()
       }
     },
     Math.min(roomTtlMs, 60_000)
@@ -192,8 +273,22 @@ export async function createRoomServer(
   }, 30_000)
   heartbeatTimer.unref()
 
+  const lifecycle = new RoomServerLifecycle({
+    drainTimeoutMs,
+    getSnapshot: getOperationalSnapshot,
+    closeResources: async () => {
+      clearInterval(cleanupTimer)
+      clearInterval(gameTimer)
+      clearInterval(heartbeatTimer)
+      for (const socket of webSocketServer.clients) socket.terminate()
+      await closeWebSocketServer(webSocketServer)
+      await closeHttpServer(httpServer)
+    },
+  })
+
   webSocketServer.on('connection', socket => {
     connectionCount += 1
+    metrics.increment('connectionsOpenedTotal')
     let availableMessageTokens = messageBurst
     let lastMessageRefillAt = Date.now()
     lastPongAt.set(socket, Date.now())
@@ -206,6 +301,7 @@ export async function createRoomServer(
       )
       lastMessageRefillAt = receivedAt
       if (availableMessageTokens < 1) {
+        metrics.increment('rateLimitedMessagesTotal')
         send(socket, {
           type: 'error',
           code: 'RATE_LIMITED',
@@ -222,6 +318,9 @@ export async function createRoomServer(
         handleMessage(socket, message)
       } catch (error) {
         const protocolError = normalizeError(error, requestId)
+        if (protocolError.code === 'INCOMPATIBLE_PROTOCOL') {
+          metrics.increment('protocolRejectedTotal')
+        }
         send(socket, {
           type: 'error',
           requestId: protocolError.requestId,
@@ -232,19 +331,31 @@ export async function createRoomServer(
     })
     socket.on('close', () => {
       connectionCount = Math.max(0, connectionCount - 1)
+      metrics.increment('connectionsClosedTotal')
       const session = sessions.get(socket)
       sessions.delete(socket)
-      if (!session || session.player.socket !== socket) return
+      if (!session || session.player.socket !== socket) {
+        lifecycle.notifyStateChanged()
+        return
+      }
       session.player.socket = null
       session.player.disconnectedAt = now()
       session.room.skipRequestedPlayerIds.delete(session.player.id)
       session.room.pauseRequestedPlayerIds.delete(session.player.id)
       if (rooms.get(session.room.code) === session.room) broadcastRoom(session.room)
+      lifecycle.notifyStateChanged()
     })
   })
 
   function handleMessage(socket: WebSocket, message: ClientMessage): void {
     if (message.type === 'create_room') {
+      if (lifecycle.isDraining()) {
+        throw new ProtocolError(
+          'SERVER_DRAINING',
+          '房间服务正在更新，暂时不能创建新房间；已有房间可继续。',
+          message.requestId
+        )
+      }
       if (sessions.has(socket))
         throw new ProtocolError('ALREADY_JOINED', '当前连接已经加入房间', message.requestId)
       if (rooms.size >= maxRooms)
@@ -266,8 +377,9 @@ export async function createRoomServer(
         achievementClaimUrls: new Map(),
       }
       rooms.set(code, room)
+      metrics.increment('roomsCreatedTotal')
       sessions.set(socket, { room, player })
-      sendSession(socket, room, player, message.requestId)
+      sendSession(socket, room, player, message.requestId, serverVersion, serverBuildSha)
       broadcastRoom(room)
       return
     }
@@ -293,9 +405,10 @@ export async function createRoomServer(
         player = { ...player, color: availableColor }
       }
       room.players.push(player)
+      metrics.increment('roomJoinsTotal')
       room.confirmedPlayerIds.clear()
       sessions.set(socket, { room, player })
-      sendSession(socket, room, player, message.requestId)
+      sendSession(socket, room, player, message.requestId, serverVersion, serverBuildSha)
       broadcastRoom(room)
       return
     }
@@ -318,7 +431,8 @@ export async function createRoomServer(
       player.disconnectedAt = null
       player.resumeToken = randomBytes(24).toString('base64url')
       sessions.set(socket, { room, player })
-      sendSession(socket, room, player, message.requestId)
+      metrics.increment('roomResumesTotal')
+      sendSession(socket, room, player, message.requestId, serverVersion, serverBuildSha)
       broadcastRoom(room)
       return
     }
@@ -342,6 +456,7 @@ export async function createRoomServer(
           message.requestId
         )
       }
+      if (room.hostPlayerId !== message.playerId) metrics.increment('hostTransfersTotal')
       room.hostPlayerId = message.playerId
       room.skipRequestedPlayerIds.clear()
       room.pauseRequestedPlayerIds.clear()
@@ -449,6 +564,7 @@ export async function createRoomServer(
         { startedAt: now(), eventDeck: options.eventDeck }
       )
       room.gameId = randomUUID()
+      metrics.increment('gamesStartedTotal')
       room.gameCompletedAt = null
       room.achievementClaimUrls.clear()
       broadcastRoom(room)
@@ -525,11 +641,13 @@ export async function createRoomServer(
     const wasFinished = room.game?.status === 'finished'
     room.game = nextGame
     if (!wasFinished && nextGame.status === 'finished') completeRoomGame(room)
+    lifecycle.notifyStateChanged()
   }
 
   function completeRoomGame(room: Room): void {
     if (!room.game || room.game.status !== 'finished' || room.gameCompletedAt !== null) return
     const completedAt = now()
+    metrics.increment('gamesFinishedTotal')
     room.gameCompletedAt = completedAt
     const claims = options.achievementClaims
     if (!claims || !room.gameId) return
@@ -567,6 +685,7 @@ export async function createRoomServer(
     )
     if (!successor) return false
     room.hostPlayerId = successor.id
+    metrics.increment('hostTransfersTotal')
     room.skipRequestedPlayerIds.clear()
     room.pauseRequestedPlayerIds.clear()
     return true
@@ -594,14 +713,10 @@ export async function createRoomServer(
   return {
     port: address.port,
     wsUrl: `ws://${host}:${address.port}`,
-    close: async () => {
-      clearInterval(cleanupTimer)
-      clearInterval(gameTimer)
-      clearInterval(heartbeatTimer)
-      for (const socket of webSocketServer.clients) socket.terminate()
-      await closeWebSocketServer(webSocketServer)
-      await closeHttpServer(httpServer)
-    },
+    beginDrain: () => lifecycle.beginDrain(),
+    isDraining: () => lifecycle.isDraining(),
+    getOperationalSnapshot,
+    close: () => lifecycle.close(),
   }
 }
 
@@ -686,10 +801,20 @@ function colorsMatch(left: string, right: string): boolean {
   return left.toLowerCase() === right.toLowerCase()
 }
 
-function sendSession(socket: WebSocket, room: Room, player: RoomPlayer, requestId: string): void {
+function sendSession(
+  socket: WebSocket,
+  room: Room,
+  player: RoomPlayer,
+  requestId: string,
+  serverVersion: string,
+  serverBuildSha: string
+): void {
   send(socket, {
     type: 'session',
     requestId,
+    protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+    serverVersion,
+    serverBuildSha,
     roomCode: room.code,
     playerId: player.id,
     resumeToken: player.resumeToken,
@@ -716,6 +841,7 @@ function parseClientMessage(raw: string): ClientMessage {
     throw new ProtocolError('INVALID_MESSAGE', 'requestId 无效')
   }
   if (message.type === 'create_room' || message.type === 'join_room') {
+    const protocolVersion = parseOnlineProtocolVersion(message.protocolVersion, requestId)
     if (typeof message.nickname !== 'string' || typeof message.color !== 'string') {
       throw new ProtocolError('INVALID_MESSAGE', '玩家资料无效', requestId)
     }
@@ -726,14 +852,22 @@ function parseClientMessage(raw: string): ClientMessage {
       return {
         type: 'join_room',
         requestId,
+        protocolVersion,
         roomCode: message.roomCode,
         nickname: message.nickname,
         color: message.color,
       }
     }
-    return { type: 'create_room', requestId, nickname: message.nickname, color: message.color }
+    return {
+      type: 'create_room',
+      requestId,
+      protocolVersion,
+      nickname: message.nickname,
+      color: message.color,
+    }
   }
   if (message.type === 'resume_room') {
+    const protocolVersion = parseOnlineProtocolVersion(message.protocolVersion, requestId)
     if (
       typeof message.roomCode !== 'string' ||
       !/^[A-Z2-9]{6}$/i.test(message.roomCode) ||
@@ -747,6 +881,7 @@ function parseClientMessage(raw: string): ClientMessage {
     return {
       type: 'resume_room',
       requestId,
+      protocolVersion,
       roomCode: message.roomCode,
       playerId: message.playerId,
       resumeToken: message.resumeToken,
@@ -902,6 +1037,18 @@ function parseClientMessage(raw: string): ClientMessage {
     return { type: message.type, requestId }
   }
   throw new ProtocolError('INVALID_MESSAGE', '未知消息类型', requestId)
+}
+
+function parseOnlineProtocolVersion(value: unknown, requestId: string): number {
+  const protocolVersion = resolveOnlineProtocolVersion(value)
+  if (protocolVersion === null) {
+    throw new ProtocolError(
+      'INCOMPATIBLE_PROTOCOL',
+      '联机协议版本不兼容，请刷新页面或关闭后重新打开。',
+      requestId
+    )
+  }
+  return protocolVersion
 }
 
 function createUniqueRoomCode(rooms: ReadonlyMap<string, Room>): string {

--- a/apps/room-server/src/serverConfig.ts
+++ b/apps/room-server/src/serverConfig.ts
@@ -1,0 +1,65 @@
+import { validateMetricsToken } from './serverMetrics'
+
+const DEFAULT_DRAIN_TIMEOUT_MS = 30 * 60 * 1_000
+const MAX_DRAIN_TIMEOUT_MS = 24 * 60 * 60 * 1_000
+const VERSION_PATTERN = /^[0-9A-Za-z][0-9A-Za-z.+-]{0,63}$/
+const BUILD_SHA_PATTERN = /^[0-9a-f]{7,64}$/i
+
+export function validateRoomServerVersion(version: string): void {
+  if (!VERSION_PATTERN.test(version)) {
+    throw new Error('ROOM_SERVER_VERSION must be a safe release identifier')
+  }
+}
+
+export function validateRoomServerBuildSha(buildSha: string): void {
+  if (buildSha !== 'unknown' && !BUILD_SHA_PATTERN.test(buildSha)) {
+    throw new Error('ROOM_SERVER_BUILD_SHA must be a public hexadecimal commit identifier')
+  }
+}
+
+export interface RoomServerEnvironmentConfig {
+  readonly version: string
+  readonly buildSha: string
+  readonly drainTimeoutMs: number
+  readonly metricsToken?: string
+}
+
+export function readRoomServerEnvironment(
+  environment: Readonly<Record<string, string | undefined>> = process.env
+): RoomServerEnvironmentConfig {
+  const version =
+    environment.ROOM_SERVER_VERSION === undefined ? 'dev' : environment.ROOM_SERVER_VERSION.trim()
+  validateRoomServerVersion(version)
+
+  const buildSha =
+    environment.ROOM_SERVER_BUILD_SHA === undefined
+      ? 'unknown'
+      : environment.ROOM_SERVER_BUILD_SHA.trim()
+  validateRoomServerBuildSha(buildSha)
+
+  const drainTimeoutRaw = environment.ROOM_DRAIN_TIMEOUT_MS
+  const drainTimeoutMs =
+    drainTimeoutRaw === undefined
+      ? DEFAULT_DRAIN_TIMEOUT_MS
+      : /^\d+$/.test(drainTimeoutRaw)
+        ? Number(drainTimeoutRaw)
+        : Number.NaN
+  if (
+    !Number.isSafeInteger(drainTimeoutMs) ||
+    drainTimeoutMs < 1 ||
+    drainTimeoutMs > MAX_DRAIN_TIMEOUT_MS
+  ) {
+    throw new Error('ROOM_DRAIN_TIMEOUT_MS must be an integer between 1 and 86400000')
+  }
+
+  const metricsToken =
+    environment.ROOM_METRICS_TOKEN === undefined ? undefined : environment.ROOM_METRICS_TOKEN.trim()
+  if (metricsToken !== undefined) validateMetricsToken(metricsToken)
+
+  return {
+    version,
+    buildSha,
+    drainTimeoutMs,
+    ...(metricsToken === undefined ? {} : { metricsToken }),
+  }
+}

--- a/apps/room-server/src/serverConfig.ts
+++ b/apps/room-server/src/serverConfig.ts
@@ -52,8 +52,7 @@ export function readRoomServerEnvironment(
     throw new Error('ROOM_DRAIN_TIMEOUT_MS must be an integer between 1 and 86400000')
   }
 
-  const metricsToken =
-    environment.ROOM_METRICS_TOKEN === undefined ? undefined : environment.ROOM_METRICS_TOKEN.trim()
+  const metricsToken = environment.ROOM_METRICS_TOKEN
   if (metricsToken !== undefined) validateMetricsToken(metricsToken)
 
   return {

--- a/apps/room-server/src/serverHealth.ts
+++ b/apps/room-server/src/serverHealth.ts
@@ -1,0 +1,40 @@
+import type { RoomServerOperationalSnapshot } from './serverLifecycle'
+
+interface ServerBuildInformation {
+  readonly version: string
+  readonly buildSha: string
+  readonly protocolVersion: number
+  readonly startedAt: number
+}
+
+export function createHealthResponse(
+  build: ServerBuildInformation,
+  snapshot: RoomServerOperationalSnapshot,
+  timestamp = Date.now(),
+  rssBytes = process.memoryUsage().rss
+): Readonly<Record<string, string | number>> {
+  return {
+    status: 'ok',
+    version: build.version,
+    buildSha: build.buildSha,
+    protocolVersion: build.protocolVersion,
+    uptimeSeconds: Math.max(0, Math.floor((timestamp - build.startedAt) / 1_000)),
+    rssBytes,
+    rooms: snapshot.rooms,
+    activeGames: snapshot.activeGames,
+    connections: snapshot.connections,
+    drainBlockingRooms: snapshot.drainBlockingRooms,
+  }
+}
+
+export function createReadinessResponse(draining: boolean): Readonly<{
+  status: 'ready' | 'draining'
+  acceptingNewRooms: boolean
+  draining: boolean
+}> {
+  return {
+    status: draining ? 'draining' : 'ready',
+    acceptingNewRooms: !draining,
+    draining,
+  }
+}

--- a/apps/room-server/src/serverLifecycle.ts
+++ b/apps/room-server/src/serverLifecycle.ts
@@ -1,0 +1,77 @@
+export interface RoomServerOperationalSnapshot {
+  readonly rooms: number
+  readonly activeGames: number
+  readonly connections: number
+  readonly drainBlockingRooms: number
+}
+
+export type OperationalRoomStatus = 'lobby' | 'playing' | 'finished'
+
+export function isRoomDrainBlocking(
+  status: OperationalRoomStatus,
+  connectedSessions: number
+): boolean {
+  return status === 'playing' || connectedSessions > 0
+}
+
+interface RoomServerLifecycleOptions {
+  readonly drainTimeoutMs: number
+  readonly getSnapshot: () => RoomServerOperationalSnapshot
+  readonly closeResources: () => Promise<void>
+}
+
+/** Coordinates one idempotent, bounded transition from serving to closed. */
+export class RoomServerLifecycle {
+  private draining = false
+  private closeStarted = false
+  private drainTimer: ReturnType<typeof setTimeout> | undefined
+  private shutdownPromise: Promise<void> | undefined
+  private resolveShutdown: (() => void) | undefined
+  private rejectShutdown: ((error: unknown) => void) | undefined
+
+  constructor(private readonly options: RoomServerLifecycleOptions) {}
+
+  isDraining(): boolean {
+    return this.draining
+  }
+
+  beginDrain(): Promise<void> {
+    const shutdown = this.ensureShutdownPromise()
+    if (this.draining) return shutdown
+    this.draining = true
+    this.drainTimer = setTimeout(() => this.startClose(), this.options.drainTimeoutMs)
+    this.drainTimer.unref?.()
+    this.notifyStateChanged()
+    return shutdown
+  }
+
+  notifyStateChanged(): void {
+    if (!this.draining || this.closeStarted) return
+    if (this.options.getSnapshot().drainBlockingRooms === 0) this.startClose()
+  }
+
+  close(): Promise<void> {
+    const shutdown = this.ensureShutdownPromise()
+    this.draining = true
+    this.startClose()
+    return shutdown
+  }
+
+  private ensureShutdownPromise(): Promise<void> {
+    if (!this.shutdownPromise) {
+      this.shutdownPromise = new Promise<void>((resolve, reject) => {
+        this.resolveShutdown = resolve
+        this.rejectShutdown = reject
+      })
+    }
+    return this.shutdownPromise
+  }
+
+  private startClose(): void {
+    if (this.closeStarted) return
+    this.closeStarted = true
+    if (this.drainTimer) clearTimeout(this.drainTimer)
+    this.drainTimer = undefined
+    void this.options.closeResources().then(this.resolveShutdown, this.rejectShutdown)
+  }
+}

--- a/apps/room-server/src/serverMetrics.ts
+++ b/apps/room-server/src/serverMetrics.ts
@@ -1,0 +1,107 @@
+import { createHash, timingSafeEqual } from 'node:crypto'
+import type { RoomServerOperationalSnapshot } from './serverLifecycle'
+
+const MIN_METRICS_TOKEN_BYTES = 32
+const MAX_METRICS_TOKEN_BYTES = 512
+
+export function validateMetricsToken(token: string): void {
+  const tokenBytes = Buffer.byteLength(token, 'utf8')
+  if (
+    tokenBytes < MIN_METRICS_TOKEN_BYTES ||
+    tokenBytes > MAX_METRICS_TOKEN_BYTES ||
+    /\s/.test(token)
+  ) {
+    throw new Error('ROOM_METRICS_TOKEN must contain 32-512 bytes without whitespace')
+  }
+}
+
+export function isMetricsRequestAuthorized(
+  authorizationHeader: string | undefined,
+  expectedToken: string
+): boolean {
+  const candidate = authorizationHeader?.startsWith('Bearer ')
+    ? authorizationHeader.slice('Bearer '.length)
+    : ''
+  const expectedDigest = createHash('sha256').update(expectedToken, 'utf8').digest()
+  const candidateDigest = createHash('sha256').update(candidate, 'utf8').digest()
+  return timingSafeEqual(expectedDigest, candidateDigest)
+}
+
+export const SERVER_METRIC_COUNTER_NAMES = [
+  'connectionsOpenedTotal',
+  'connectionsClosedTotal',
+  'roomsCreatedTotal',
+  'roomJoinsTotal',
+  'roomResumesTotal',
+  'gamesStartedTotal',
+  'gamesFinishedTotal',
+  'hostTransfersTotal',
+  'roomsExpiredTotal',
+  'protocolRejectedTotal',
+  'rateLimitedMessagesTotal',
+] as const
+
+export type ServerMetricCounterName = (typeof SERVER_METRIC_COUNTER_NAMES)[number]
+
+type ServerMetricCounters = Readonly<Record<ServerMetricCounterName, number>>
+
+export interface ServerMetricsSnapshot {
+  readonly schemaVersion: 1
+  readonly counters: ServerMetricCounters
+  readonly gauges: Readonly<{
+    rooms: number
+    activeGames: number
+    connections: number
+    drainBlockingRooms: number
+    draining: 0 | 1
+    rssBytes: number
+    uptimeSeconds: number
+  }>
+}
+
+function createEmptyCounters(): Record<ServerMetricCounterName, number> {
+  return {
+    connectionsOpenedTotal: 0,
+    connectionsClosedTotal: 0,
+    roomsCreatedTotal: 0,
+    roomJoinsTotal: 0,
+    roomResumesTotal: 0,
+    gamesStartedTotal: 0,
+    gamesFinishedTotal: 0,
+    hostTransfersTotal: 0,
+    roomsExpiredTotal: 0,
+    protocolRejectedTotal: 0,
+    rateLimitedMessagesTotal: 0,
+  }
+}
+
+export class ServerMetrics {
+  private readonly counters = createEmptyCounters()
+
+  constructor(private readonly startedAt: number) {}
+
+  increment(counter: ServerMetricCounterName): void {
+    this.counters[counter] += 1
+  }
+
+  snapshot(
+    operational: RoomServerOperationalSnapshot,
+    draining: boolean,
+    timestamp = Date.now(),
+    rssBytes = process.memoryUsage().rss
+  ): ServerMetricsSnapshot {
+    return {
+      schemaVersion: 1,
+      counters: { ...this.counters },
+      gauges: {
+        rooms: operational.rooms,
+        activeGames: operational.activeGames,
+        connections: operational.connections,
+        drainBlockingRooms: operational.drainBlockingRooms,
+        draining: draining ? 1 : 0,
+        rssBytes,
+        uptimeSeconds: Math.max(0, Math.floor((timestamp - this.startedAt) / 1_000)),
+      },
+    }
+  }
+}

--- a/apps/room-server/src/serverMetrics.ts
+++ b/apps/room-server/src/serverMetrics.ts
@@ -44,6 +44,7 @@ export const SERVER_METRIC_COUNTER_NAMES = [
 export type ServerMetricCounterName = (typeof SERVER_METRIC_COUNTER_NAMES)[number]
 
 type ServerMetricCounters = Readonly<Record<ServerMetricCounterName, number>>
+const SERVER_METRIC_COUNTER_NAME_SET: ReadonlySet<string> = new Set(SERVER_METRIC_COUNTER_NAMES)
 
 export interface ServerMetricsSnapshot {
   readonly schemaVersion: 1
@@ -81,6 +82,9 @@ export class ServerMetrics {
   constructor(private readonly startedAt: number) {}
 
   increment(counter: ServerMetricCounterName): void {
+    if (!SERVER_METRIC_COUNTER_NAME_SET.has(counter)) {
+      throw new Error('Unknown server metric counter')
+    }
     this.counters[counter] += 1
   }
 

--- a/apps/room-server/test/cli.test.ts
+++ b/apps/room-server/test/cli.test.ts
@@ -1,0 +1,108 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { afterEach, describe, expect, it } from 'vitest'
+import WebSocket from 'ws'
+import { CURRENT_ONLINE_PROTOCOL_VERSION } from '@flying-chess/game-core'
+
+function waitForListeningPort(child: ChildProcessWithoutNullStreams): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let output = ''
+    const timer = setTimeout(() => reject(new Error('room-server CLI did not start')), 5_000)
+    child.stdout.on('data', chunk => {
+      output += chunk.toString()
+      const match = output.match(/room server listening on port (\d+)/)
+      if (!match) return
+      clearTimeout(timer)
+      resolve(Number(match[1]))
+    })
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer)
+      reject(new Error(`room-server CLI exited before listening: ${code ?? signal}`))
+    })
+  })
+}
+
+async function waitForJsonMessage(socket: WebSocket): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('room-server message timed out')), 2_000)
+    socket.once('message', raw => {
+      clearTimeout(timer)
+      resolve(JSON.parse(raw.toString()) as Record<string, unknown>)
+    })
+  })
+}
+
+async function waitForDrainingReadiness(httpUrl: string): Promise<void> {
+  const deadline = Date.now() + 2_000
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${httpUrl}/ready`)
+      if (response.status === 503) return
+    } catch {
+      // A pre-change server can close before exposing drain; the deadline reports that failure.
+    }
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error('room-server CLI never exposed draining readiness')
+}
+
+describe('room server CLI lifecycle', () => {
+  let child: ChildProcessWithoutNullStreams | undefined
+  let socket: WebSocket | undefined
+
+  afterEach(async () => {
+    socket?.terminate()
+    if (child && child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL')
+      await new Promise(resolve => child?.once('exit', resolve))
+    }
+  })
+
+  it('handles repeated termination signals with one bounded graceful drain', async () => {
+    const runningChild = spawn(
+      process.execPath,
+      ['--import', 'tsx', 'apps/room-server/src/cli.ts'],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          NODE_ENV: 'test',
+          HOST: '127.0.0.1',
+          PORT: '0',
+          ROOM_DRAIN_TIMEOUT_MS: '100',
+          ROOM_SERVER_VERSION: '1.15.0-test',
+          ROOM_SERVER_BUILD_SHA: 'abc1234',
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }
+    )
+    child = runningChild
+    const port = await waitForListeningPort(runningChild)
+    const httpUrl = `http://127.0.0.1:${port}`
+    socket = new WebSocket(`ws://127.0.0.1:${port}`)
+    await new Promise<void>((resolve, reject) => {
+      socket?.once('open', resolve)
+      socket?.once('error', reject)
+    })
+    socket.send(
+      JSON.stringify({
+        type: 'create_room',
+        requestId: 'cli-drain-create',
+        protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+        nickname: '信号测试玩家',
+        color: '#ff6b6b',
+      })
+    )
+    expect(await waitForJsonMessage(socket)).toMatchObject({ type: 'session' })
+
+    const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(resolve =>
+      runningChild.once('exit', (code, signal) => resolve({ code, signal }))
+    )
+    runningChild.kill('SIGTERM')
+    await waitForDrainingReadiness(httpUrl)
+    runningChild.kill('SIGTERM')
+    const health = await fetch(`${httpUrl}/health`)
+    expect(health.status).toBe(200)
+
+    await expect(exited).resolves.toEqual({ code: 0, signal: null })
+  }, 10_000)
+})

--- a/apps/room-server/test/operability.test.ts
+++ b/apps/room-server/test/operability.test.ts
@@ -1,0 +1,380 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import WebSocket from 'ws'
+import { CURRENT_ONLINE_PROTOCOL_VERSION } from '@flying-chess/game-core'
+import { createRoomServer, type RunningRoomServer } from '../src/server'
+import type { ServerMessage } from '../src/protocol'
+
+class OperabilityClient {
+  private readonly buffered: ServerMessage[] = []
+  private readonly waiters: Array<{
+    predicate: (message: ServerMessage) => boolean
+    resolve: (message: ServerMessage) => void
+    reject: (error: Error) => void
+    timer: ReturnType<typeof setTimeout>
+  }> = []
+
+  private constructor(private readonly socket: WebSocket) {
+    socket.on('message', raw => {
+      const message = JSON.parse(raw.toString()) as ServerMessage
+      const waiterIndex = this.waiters.findIndex(waiter => waiter.predicate(message))
+      if (waiterIndex < 0) {
+        this.buffered.push(message)
+        return
+      }
+      const [waiter] = this.waiters.splice(waiterIndex, 1)
+      clearTimeout(waiter.timer)
+      waiter.resolve(message)
+    })
+  }
+
+  static async connect(url: string): Promise<OperabilityClient> {
+    const socket = new WebSocket(url)
+    await new Promise<void>((resolve, reject) => {
+      socket.once('open', resolve)
+      socket.once('error', reject)
+    })
+    return new OperabilityClient(socket)
+  }
+
+  send(message: object): void {
+    this.socket.send(JSON.stringify(message))
+  }
+
+  next(predicate: (message: ServerMessage) => boolean, timeoutMs = 2_000): Promise<ServerMessage> {
+    const bufferedIndex = this.buffered.findIndex(predicate)
+    if (bufferedIndex >= 0) {
+      const [message] = this.buffered.splice(bufferedIndex, 1)
+      return Promise.resolve(message)
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const waiterIndex = this.waiters.findIndex(waiter => waiter.timer === timer)
+        if (waiterIndex >= 0) this.waiters.splice(waiterIndex, 1)
+        reject(new Error('timed out waiting for room-server message'))
+      }, timeoutMs)
+      this.waiters.push({ predicate, resolve, reject, timer })
+    })
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.socket.readyState === WebSocket.CLOSED) return
+    const closed = new Promise<void>(resolve => this.socket.once('close', resolve))
+    this.socket.close()
+    await closed
+  }
+}
+
+function httpBase(server: RunningRoomServer): string {
+  return server.wsUrl.replace('ws://', 'http://')
+}
+
+describe('room server operability', () => {
+  let server: RunningRoomServer | undefined
+  const clients: OperabilityClient[] = []
+
+  afterEach(async () => {
+    await Promise.all(clients.map(client => client.disconnect()))
+    clients.length = 0
+    await server?.close()
+  })
+
+  it('keeps liveness healthy while readiness rejects new workload during drain', async () => {
+    server = await createRoomServer({
+      port: 0,
+      version: '1.15.0',
+      buildSha: 'abc1234',
+      drainTimeoutMs: 2_000,
+    })
+    const host = await OperabilityClient.connect(server.wsUrl)
+    clients.push(host)
+    host.send({
+      type: 'create_room',
+      requestId: 'health-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: '运维测试玩家',
+      color: '#ff6b6b',
+    })
+    await host.next(message => message.type === 'session')
+
+    const healthy = await fetch(`${httpBase(server)}/health`)
+    expect(healthy.status).toBe(200)
+    await expect(healthy.json()).resolves.toMatchObject({
+      status: 'ok',
+      version: '1.15.0',
+      buildSha: 'abc1234',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+    })
+    const ready = await fetch(`${httpBase(server)}/ready`)
+    expect(ready.status).toBe(200)
+    await expect(ready.json()).resolves.toMatchObject({
+      status: 'ready',
+      acceptingNewRooms: true,
+      draining: false,
+    })
+
+    const draining = server.beginDrain()
+    const drainingHealth = await fetch(`${httpBase(server)}/health`)
+    expect(drainingHealth.status).toBe(200)
+    const drainingReady = await fetch(`${httpBase(server)}/ready`)
+    expect(drainingReady.status).toBe(503)
+    await expect(drainingReady.json()).resolves.toMatchObject({
+      status: 'draining',
+      acceptingNewRooms: false,
+      draining: true,
+    })
+
+    await host.disconnect()
+    await draining
+  })
+
+  it('rejects new rooms while existing rooms can join, resume, and keep playing', async () => {
+    const metricsToken = 'drain-test-metrics-token-at-least-32-bytes'
+    server = await createRoomServer({ port: 0, drainTimeoutMs: 5_000, metricsToken })
+    const host = await OperabilityClient.connect(server.wsUrl)
+    clients.push(host)
+    host.send({
+      type: 'create_room',
+      requestId: 'drain-host-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: '排空主持人',
+      color: '#ff6b6b',
+    })
+    const created = await host.next(message => message.type === 'session')
+    if (created.type !== 'session') throw new Error('expected host session')
+
+    const draining = server.beginDrain()
+    const rejected = await OperabilityClient.connect(server.wsUrl)
+    clients.push(rejected)
+    rejected.send({
+      type: 'create_room',
+      requestId: 'drain-new-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: '新建玩家',
+      color: '#45b7d1',
+    })
+    await expect(
+      rejected.next(message => message.type === 'error' && message.code === 'SERVER_DRAINING')
+    ).resolves.toMatchObject({
+      type: 'error',
+      requestId: 'drain-new-create',
+      code: 'SERVER_DRAINING',
+    })
+
+    const guest = await OperabilityClient.connect(server.wsUrl)
+    clients.push(guest)
+    guest.send({
+      type: 'join_room',
+      requestId: 'drain-existing-join',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: created.roomCode,
+      nickname: '排空加入者',
+      color: '#4ecdc4',
+    })
+    const joined = await guest.next(message => message.type === 'session')
+    if (joined.type !== 'session') throw new Error('expected guest session')
+    await guest.disconnect()
+
+    const resumed = await OperabilityClient.connect(server.wsUrl)
+    clients.push(resumed)
+    resumed.send({
+      type: 'resume_room',
+      requestId: 'drain-existing-resume',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: joined.roomCode,
+      playerId: joined.playerId,
+      resumeToken: joined.resumeToken,
+    })
+    await expect(resumed.next(message => message.type === 'session')).resolves.toMatchObject({
+      type: 'session',
+      requestId: 'drain-existing-resume',
+      playerId: joined.playerId,
+    })
+
+    host.send({ type: 'confirm_settings', requestId: 'drain-confirm-host' })
+    resumed.send({ type: 'confirm_settings', requestId: 'drain-confirm-guest' })
+    await host.next(
+      message => message.type === 'room_state' && message.room.confirmedPlayerIds.length === 2
+    )
+    host.send({ type: 'start_game', requestId: 'drain-start' })
+    await host.next(
+      message => message.type === 'room_state' && message.room.game?.status === 'playing'
+    )
+    resumed.send({
+      type: 'submit_prediction',
+      requestId: 'drain-action',
+      prediction: 'high',
+    })
+    await expect(
+      host.next(
+        message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_roll'
+      )
+    ).resolves.toMatchObject({ type: 'room_state' })
+    expect(server.getOperationalSnapshot()).toMatchObject({
+      activeGames: 1,
+      drainBlockingRooms: 1,
+    })
+    const metricsResponse = await fetch(`${httpBase(server)}/internal/metrics`, {
+      headers: { authorization: `Bearer ${metricsToken}` },
+    })
+    const metrics = (await metricsResponse.json()) as {
+      counters: Record<string, number>
+    }
+    expect(metrics.counters).toMatchObject({
+      roomsCreatedTotal: 1,
+      roomJoinsTotal: 1,
+      roomResumesTotal: 1,
+      gamesStartedTotal: 1,
+    })
+
+    await server.close()
+    await draining
+  })
+
+  it('closes immediately without blockers and keeps repeated drain calls idempotent', async () => {
+    server = await createRoomServer({ port: 0, drainTimeoutMs: 2_000 })
+
+    const firstDrain = server.beginDrain()
+    const secondDrain = server.beginDrain()
+
+    expect(secondDrain).toBe(firstDrain)
+    await firstDrain
+    expect(server.isDraining()).toBe(true)
+    await expect(fetch(`${httpBase(server)}/health`)).rejects.toThrow()
+  })
+
+  it('does not close an active room immediately and force-closes at the bounded timeout', async () => {
+    server = await createRoomServer({ port: 0, drainTimeoutMs: 40 })
+    const host = await OperabilityClient.connect(server.wsUrl)
+    clients.push(host)
+    host.send({
+      type: 'create_room',
+      requestId: 'timeout-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: '超时测试玩家',
+      color: '#ff6b6b',
+    })
+    await host.next(message => message.type === 'session')
+
+    const startedAt = performance.now()
+    const draining = server.beginDrain()
+    await expect(
+      Promise.race([draining.then(() => 'closed'), Promise.resolve('still-draining')])
+    ).resolves.toBe('still-draining')
+    await draining
+
+    expect(performance.now() - startedAt).toBeLessThan(1_000)
+    expect(server.getOperationalSnapshot().connections).toBe(0)
+  })
+
+  it('rejects zero, unbounded, and non-integer drain timeouts', async () => {
+    await expect(createRoomServer({ port: 0, drainTimeoutMs: 0 })).rejects.toThrow('drainTimeoutMs')
+    await expect(
+      createRoomServer({ port: 0, drainTimeoutMs: Number.MAX_SAFE_INTEGER })
+    ).rejects.toThrow('drainTimeoutMs')
+    await expect(createRoomServer({ port: 0, drainTimeoutMs: 1.5 })).rejects.toThrow(
+      'drainTimeoutMs'
+    )
+  })
+
+  it('rejects unsafe service metadata before it can reach health or sessions', async () => {
+    await expect(createRoomServer({ port: 0, version: 'unsafe version' })).rejects.toThrow(
+      'ROOM_SERVER_VERSION'
+    )
+    await expect(createRoomServer({ port: 0, buildSha: 'not-a-public-commit' })).rejects.toThrow(
+      'ROOM_SERVER_BUILD_SHA'
+    )
+  })
+
+  it('hides metrics by default and exposes only authenticated aggregate allowlists', async () => {
+    const metricsToken = 'synthetic-metrics-token-at-least-32-bytes'
+    server = await createRoomServer({ port: 0, metricsToken })
+    const baseUrl = httpBase(server)
+
+    const missingToken = await fetch(`${baseUrl}/internal/metrics`)
+    expect(missingToken.status).toBe(401)
+    const wrongToken = await fetch(`${baseUrl}/internal/metrics`, {
+      headers: { authorization: 'Bearer wrong-synthetic-token-at-least-32-bytes' },
+    })
+    expect(wrongToken.status).toBe(401)
+
+    const host = await OperabilityClient.connect(server.wsUrl)
+    clients.push(host)
+    host.send({
+      type: 'create_room',
+      requestId: 'private-request-id',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: 'PrivateSynthetic',
+      color: '#ff6b6b',
+    })
+    const session = await host.next(message => message.type === 'session')
+    if (session.type !== 'session') throw new Error('expected session')
+
+    const incompatible = await OperabilityClient.connect(server.wsUrl)
+    clients.push(incompatible)
+    incompatible.send({
+      type: 'create_room',
+      requestId: 'private-incompatible-request',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION + 1,
+      nickname: 'PrivateMismatch',
+      color: '#45b7d1',
+    })
+    await incompatible.next(
+      message => message.type === 'error' && message.code === 'INCOMPATIBLE_PROTOCOL'
+    )
+
+    const response = await fetch(`${baseUrl}/internal/metrics`, {
+      headers: { authorization: `Bearer ${metricsToken}` },
+    })
+    expect(response.status).toBe(200)
+    const metrics = (await response.json()) as Record<string, unknown>
+    expect(Object.keys(metrics)).toEqual(['schemaVersion', 'counters', 'gauges'])
+    expect(Object.keys(metrics.counters as object)).toEqual([
+      'connectionsOpenedTotal',
+      'connectionsClosedTotal',
+      'roomsCreatedTotal',
+      'roomJoinsTotal',
+      'roomResumesTotal',
+      'gamesStartedTotal',
+      'gamesFinishedTotal',
+      'hostTransfersTotal',
+      'roomsExpiredTotal',
+      'protocolRejectedTotal',
+      'rateLimitedMessagesTotal',
+    ])
+    expect(Object.keys(metrics.gauges as object)).toEqual([
+      'rooms',
+      'activeGames',
+      'connections',
+      'drainBlockingRooms',
+      'draining',
+      'rssBytes',
+      'uptimeSeconds',
+    ])
+    expect(metrics.counters).toMatchObject({
+      connectionsOpenedTotal: 2,
+      roomsCreatedTotal: 1,
+      protocolRejectedTotal: 1,
+    })
+    const serialized = JSON.stringify(metrics)
+    for (const privateValue of [
+      'PrivateSynthetic',
+      'PrivateMismatch',
+      session.roomCode,
+      session.playerId,
+      session.resumeToken,
+      'private-request-id',
+      'private-incompatible-request',
+      metricsToken,
+    ]) {
+      expect(serialized).not.toContain(privateValue)
+    }
+  })
+
+  it('returns 404 for the metrics route when no token is configured', async () => {
+    server = await createRoomServer({ port: 0 })
+
+    const response = await fetch(`${httpBase(server)}/internal/metrics`)
+
+    expect(response.status).toBe(404)
+  })
+})

--- a/apps/room-server/test/serverConfig.test.ts
+++ b/apps/room-server/test/serverConfig.test.ts
@@ -47,6 +47,16 @@ describe('room server environment', () => {
     expect(() => readRoomServerEnvironment({ ROOM_METRICS_TOKEN: 'too-short' })).toThrow(
       'ROOM_METRICS_TOKEN'
     )
+    expect(() =>
+      readRoomServerEnvironment({
+        ROOM_METRICS_TOKEN: ' synthetic-metrics-token-at-least-32-bytes',
+      })
+    ).toThrow('ROOM_METRICS_TOKEN')
+    expect(() =>
+      readRoomServerEnvironment({
+        ROOM_METRICS_TOKEN: 'synthetic-metrics-token-at-least-32-bytes ',
+      })
+    ).toThrow('ROOM_METRICS_TOKEN')
     expect(
       readRoomServerEnvironment({
         ROOM_METRICS_TOKEN: 'synthetic-metrics-token-at-least-32-bytes',

--- a/apps/room-server/test/serverConfig.test.ts
+++ b/apps/room-server/test/serverConfig.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { readRoomServerEnvironment } from '../src/serverConfig'
+
+describe('room server environment', () => {
+  it('uses bounded development defaults and accepts explicit release metadata', () => {
+    expect(readRoomServerEnvironment({})).toEqual({
+      version: 'dev',
+      buildSha: 'unknown',
+      drainTimeoutMs: 30 * 60 * 1_000,
+    })
+    expect(
+      readRoomServerEnvironment({
+        ROOM_SERVER_VERSION: '1.15.0',
+        ROOM_SERVER_BUILD_SHA: 'abcdef1234567890',
+        ROOM_DRAIN_TIMEOUT_MS: '250',
+      })
+    ).toEqual({
+      version: '1.15.0',
+      buildSha: 'abcdef1234567890',
+      drainTimeoutMs: 250,
+    })
+  })
+
+  it.each(['0', '-1', '1.5', 'not-a-number', '90000000'])(
+    'rejects invalid ROOM_DRAIN_TIMEOUT_MS=%s',
+    value => {
+      expect(() => readRoomServerEnvironment({ ROOM_DRAIN_TIMEOUT_MS: value })).toThrow(
+        'ROOM_DRAIN_TIMEOUT_MS'
+      )
+    }
+  )
+
+  it('rejects explicitly blank or unsafe build metadata', () => {
+    expect(() => readRoomServerEnvironment({ ROOM_SERVER_VERSION: '' })).toThrow(
+      'ROOM_SERVER_VERSION'
+    )
+    expect(() => readRoomServerEnvironment({ ROOM_SERVER_BUILD_SHA: 'not-a-commit' })).toThrow(
+      'ROOM_SERVER_BUILD_SHA'
+    )
+  })
+
+  it('keeps metrics disabled by default and rejects weak configured tokens', () => {
+    expect(readRoomServerEnvironment({})).not.toHaveProperty('metricsToken')
+    expect(() => readRoomServerEnvironment({ ROOM_METRICS_TOKEN: '' })).toThrow(
+      'ROOM_METRICS_TOKEN'
+    )
+    expect(() => readRoomServerEnvironment({ ROOM_METRICS_TOKEN: 'too-short' })).toThrow(
+      'ROOM_METRICS_TOKEN'
+    )
+    expect(
+      readRoomServerEnvironment({
+        ROOM_METRICS_TOKEN: 'synthetic-metrics-token-at-least-32-bytes',
+      })
+    ).toMatchObject({ metricsToken: 'synthetic-metrics-token-at-least-32-bytes' })
+  })
+})

--- a/apps/room-server/test/serverHealth.test.ts
+++ b/apps/room-server/test/serverHealth.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { createHealthResponse, createReadinessResponse } from '../src/serverHealth'
+
+describe('server health payloads', () => {
+  it('keeps liveness and readiness on fixed aggregate allowlists', () => {
+    const health = createHealthResponse(
+      {
+        version: '1.15.0',
+        buildSha: 'abcdef1',
+        protocolVersion: 1,
+        startedAt: 1_000,
+      },
+      {
+        rooms: 2,
+        activeGames: 1,
+        connections: 4,
+        drainBlockingRooms: 2,
+      },
+      3_500,
+      12_345
+    )
+
+    expect(health).toEqual({
+      status: 'ok',
+      version: '1.15.0',
+      buildSha: 'abcdef1',
+      protocolVersion: 1,
+      uptimeSeconds: 2,
+      rssBytes: 12_345,
+      rooms: 2,
+      activeGames: 1,
+      connections: 4,
+      drainBlockingRooms: 2,
+    })
+    expect(createReadinessResponse(false)).toEqual({
+      status: 'ready',
+      acceptingNewRooms: true,
+      draining: false,
+    })
+    expect(createReadinessResponse(true)).toEqual({
+      status: 'draining',
+      acceptingNewRooms: false,
+      draining: true,
+    })
+  })
+})

--- a/apps/room-server/test/serverLifecycle.test.ts
+++ b/apps/room-server/test/serverLifecycle.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { isRoomDrainBlocking } from '../src/serverLifecycle'
+
+describe('room drain blockers', () => {
+  it.each([
+    ['connected lobby', 'lobby', 1, true],
+    ['running game with no connection', 'playing', 0, true],
+    ['finished result still being read', 'finished', 1, true],
+    ['disconnected lobby', 'lobby', 0, false],
+    ['disconnected finished room', 'finished', 0, false],
+  ] as const)('classifies %s explicitly', (_label, status, connectedSessions, expected) => {
+    expect(isRoomDrainBlocking(status, connectedSessions)).toBe(expected)
+  })
+})

--- a/apps/room-server/test/serverMetrics.test.ts
+++ b/apps/room-server/test/serverMetrics.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isMetricsRequestAuthorized,
+  ServerMetrics,
+  validateMetricsToken,
+} from '../src/serverMetrics'
+
+describe('server metrics', () => {
+  it('exposes only the fixed aggregate counter and gauge allowlists', () => {
+    const metrics = new ServerMetrics(1_000)
+    metrics.increment('connectionsOpenedTotal')
+    metrics.increment('roomsCreatedTotal')
+    metrics.increment('roomsCreatedTotal')
+
+    const snapshot = metrics.snapshot(
+      {
+        rooms: 2,
+        activeGames: 1,
+        connections: 3,
+        drainBlockingRooms: 1,
+      },
+      true,
+      5_500,
+      12_345
+    )
+
+    expect(Object.keys(snapshot)).toEqual(['schemaVersion', 'counters', 'gauges'])
+    expect(Object.keys(snapshot.counters)).toEqual([
+      'connectionsOpenedTotal',
+      'connectionsClosedTotal',
+      'roomsCreatedTotal',
+      'roomJoinsTotal',
+      'roomResumesTotal',
+      'gamesStartedTotal',
+      'gamesFinishedTotal',
+      'hostTransfersTotal',
+      'roomsExpiredTotal',
+      'protocolRejectedTotal',
+      'rateLimitedMessagesTotal',
+    ])
+    expect(snapshot.counters).toMatchObject({
+      connectionsOpenedTotal: 1,
+      roomsCreatedTotal: 2,
+      protocolRejectedTotal: 0,
+    })
+    expect(snapshot.gauges).toEqual({
+      rooms: 2,
+      activeGames: 1,
+      connections: 3,
+      drainBlockingRooms: 1,
+      draining: 1,
+      rssBytes: 12_345,
+      uptimeSeconds: 4,
+    })
+  })
+
+  it('validates token strength and compares bearer credentials through fixed-length digests', () => {
+    const token = 'synthetic-metrics-token-at-least-32-bytes'
+    expect(() => validateMetricsToken(token)).not.toThrow()
+    expect(() => validateMetricsToken('too-short')).toThrow('32-512 bytes')
+    expect(() => validateMetricsToken(`${token} with-space`)).toThrow('without whitespace')
+    expect(isMetricsRequestAuthorized(`Bearer ${token}`, token)).toBe(true)
+    expect(isMetricsRequestAuthorized('Bearer different-token', token)).toBe(false)
+    expect(isMetricsRequestAuthorized(undefined, token)).toBe(false)
+  })
+})

--- a/apps/room-server/test/serverMetrics.test.ts
+++ b/apps/room-server/test/serverMetrics.test.ts
@@ -11,6 +11,9 @@ describe('server metrics', () => {
     metrics.increment('connectionsOpenedTotal')
     metrics.increment('roomsCreatedTotal')
     metrics.increment('roomsCreatedTotal')
+    expect(() => metrics.increment('unexpectedCounter' as never)).toThrow(
+      'Unknown server metric counter'
+    )
 
     const snapshot = metrics.snapshot(
       {

--- a/apps/room-server/test/vertical-slice.test.ts
+++ b/apps/room-server/test/vertical-slice.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import WebSocket from 'ws'
-import { DEFAULT_ONLINE_ROOM_SETTINGS, type OnlineRoomSettings } from '@flying-chess/game-core'
+import {
+  CURRENT_ONLINE_PROTOCOL_VERSION,
+  DEFAULT_ONLINE_ROOM_SETTINGS,
+  type OnlineRoomSettings,
+} from '@flying-chess/game-core'
 import { createRoomServer, type RunningRoomServer } from '../src/server'
 import { verifyGameCompletionClaim } from '../src/gameCompletionClaims'
 import type { ServerMessage } from '../src/protocol'
@@ -88,6 +92,130 @@ describe('联网升温局服务器权威纵向切片', () => {
       status: 'ok',
       rooms: 0,
       connections: 1,
+    })
+  })
+
+  it('使用当前协议建房并在私有 session 中返回协议与服务版本', async () => {
+    server = await createRoomServer({ port: 0, version: '1.15.0', buildSha: 'abc1234' })
+    const host = await TestClient.connect(server.wsUrl)
+    clients.push(host)
+
+    host.send({
+      type: 'create_room',
+      requestId: 'versioned-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: '协议测试玩家',
+      color: '#ff6b6b',
+    })
+
+    await expect(host.next(message => message.type === 'session')).resolves.toMatchObject({
+      type: 'session',
+      requestId: 'versioned-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      serverVersion: '1.15.0',
+      serverBuildSha: 'abc1234',
+    })
+  })
+
+  it('使用当前协议加入和恢复原席位，且不会向其他玩家投影私有 session 字段', async () => {
+    server = await createRoomServer({ port: 0, version: '1.15.0' })
+    const host = await TestClient.connect(server.wsUrl)
+    const guest = await TestClient.connect(server.wsUrl)
+    clients.push(host, guest)
+
+    host.send({
+      type: 'create_room',
+      requestId: 'protocol-create-host',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: '协议主持人',
+      color: '#ff6b6b',
+    })
+    const created = await host.next(message => message.type === 'session')
+    if (created.type !== 'session') throw new Error('expected host session')
+
+    guest.send({
+      type: 'join_room',
+      requestId: 'protocol-join-guest',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: created.roomCode,
+      nickname: '协议加入者',
+      color: '#4ecdc4',
+    })
+    const joined = await guest.next(message => message.type === 'session')
+    if (joined.type !== 'session') throw new Error('expected guest session')
+    expect(joined.protocolVersion).toBe(CURRENT_ONLINE_PROTOCOL_VERSION)
+    const hostProjection = await host.next(
+      message => message.type === 'room_state' && message.room.players.length === 2
+    )
+    expect(JSON.stringify(hostProjection)).not.toContain(joined.resumeToken)
+
+    await guest.disconnect()
+    const resumed = await TestClient.connect(server.wsUrl)
+    clients.push(resumed)
+    resumed.send({
+      type: 'resume_room',
+      requestId: 'protocol-resume-guest',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: joined.roomCode,
+      playerId: joined.playerId,
+      resumeToken: joined.resumeToken,
+    })
+
+    await expect(resumed.next(message => message.type === 'session')).resolves.toMatchObject({
+      type: 'session',
+      requestId: 'protocol-resume-guest',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      serverVersion: '1.15.0',
+      playerId: joined.playerId,
+    })
+  })
+
+  it('临时兼容缺少协议字段的旧客户端', async () => {
+    server = await createRoomServer({ port: 0 })
+    const legacy = await TestClient.connect(server.wsUrl)
+    clients.push(legacy)
+
+    legacy.send({
+      type: 'create_room',
+      requestId: 'legacy-create',
+      nickname: '旧页面玩家',
+      color: '#ff6b6b',
+    })
+
+    await expect(legacy.next(message => message.type === 'session')).resolves.toMatchObject({
+      type: 'session',
+      requestId: 'legacy-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+    })
+  })
+
+  it.each([
+    ['too old', 0],
+    ['too new', CURRENT_ONLINE_PROTOCOL_VERSION + 1],
+    ['string', '1'],
+    ['fraction', 1.5],
+    ['negative', -1],
+    ['NaN', Number.NaN],
+    ['extremely large', Number.MAX_VALUE],
+  ])('拒绝 %s 的显式协议版本', async (_label, protocolVersion) => {
+    server = await createRoomServer({ port: 0 })
+    const client = await TestClient.connect(server.wsUrl)
+    clients.push(client)
+    client.send({
+      type: 'create_room',
+      requestId: 'incompatible-create',
+      protocolVersion,
+      nickname: '不兼容页面',
+      color: '#ff6b6b',
+    })
+
+    await expect(
+      client.next(message => message.type === 'error' && message.code === 'INCOMPATIBLE_PROTOCOL')
+    ).resolves.toMatchObject({
+      type: 'error',
+      requestId: 'incompatible-create',
+      code: 'INCOMPATIBLE_PROTOCOL',
+      message: '联机协议版本不兼容，请刷新页面或关闭后重新打开。',
     })
   })
 
@@ -288,6 +416,7 @@ describe('联网升温局服务器权威纵向切片', () => {
 
   it('终局后只向各自席位签发私有、可验证的论坛认领凭证', async () => {
     const claimSecret = 'room-server-integration-secret-with-at-least-32-bytes'
+    const metricsToken = 'claim-test-metrics-token-at-least-32-bytes'
     const diceValues = [6, 6, 6, 6, 6, 6, 6, 6, 1]
     server = await createRoomServer({
       port: 0,
@@ -297,6 +426,7 @@ describe('联网升温局服务器权威纵向切片', () => {
         secret: claimSecret,
         claimUrl: 'https://forum.example/where-is-my-friends/flying-chess/claim',
       },
+      metricsToken,
     })
     const host = await TestClient.connect(server.wsUrl)
     const guest = await TestClient.connect(server.wsUrl)
@@ -466,6 +596,13 @@ describe('联网升温局服务器权威纵向切片', () => {
     expect(guestClaim.game_id).toBe(hostClaim.game_id)
     expect(guestClaim.jti).not.toBe(hostClaim.jti)
     expect(guestUrl.toString()).not.toBe(hostUrl.toString())
+    const metricsResponse = await fetch(
+      `${server.wsUrl.replace('ws://', 'http://')}/internal/metrics`,
+      { headers: { authorization: `Bearer ${metricsToken}` } }
+    )
+    await expect(metricsResponse.json()).resolves.toMatchObject({
+      counters: { gamesStartedTotal: 1, gamesFinishedTotal: 1 },
+    })
   })
 
   it('设置变更会清空全员确认，未重新全员确认时服务器拒绝开局', async () => {
@@ -666,7 +803,8 @@ describe('联网升温局服务器权威纵向切片', () => {
   })
 
   it('主持人可以把管理角色转交给另一名玩家，权限立即随角色移动', async () => {
-    server = await createRoomServer({ port: 0 })
+    const metricsToken = 'transfer-test-metrics-token-at-least-32-bytes'
+    server = await createRoomServer({ port: 0, metricsToken })
     const host = await TestClient.connect(server.wsUrl)
     const successor = await TestClient.connect(server.wsUrl)
     clients.push(host, successor)
@@ -725,6 +863,13 @@ describe('联网升温局服务器权威纵向切片', () => {
           message.type === 'room_state' && message.room.settings.scenePreset === 'icebreaker'
       )
     ).resolves.toMatchObject({ type: 'room_state' })
+    const metricsResponse = await fetch(
+      `${server.wsUrl.replace('ws://', 'http://')}/internal/metrics`,
+      { headers: { authorization: `Bearer ${metricsToken}` } }
+    )
+    await expect(metricsResponse.json()).resolves.toMatchObject({
+      counters: { hostTransfersTotal: 1 },
+    })
   })
 
   it('不允许把主持权转交给离线玩家', async () => {
@@ -840,10 +985,12 @@ describe('联网升温局服务器权威纵向切片', () => {
   })
 
   it('单连接消息洪泛会被限速并断开', async () => {
+    const metricsToken = 'rate-test-metrics-token-at-least-32-bytes'
     server = await createRoomServer({
       port: 0,
       messagesPerSecond: 1,
       messageBurst: 2,
+      metricsToken,
     })
     const client = await TestClient.connect(server.wsUrl)
     clients.push(client)
@@ -860,6 +1007,13 @@ describe('联网升温局服务器权威纵向切片', () => {
     await expect(
       client.next(message => message.type === 'error' && message.code === 'RATE_LIMITED')
     ).resolves.toMatchObject({ type: 'error' })
+    const metricsResponse = await fetch(
+      `${server.wsUrl.replace('ws://', 'http://')}/internal/metrics`,
+      { headers: { authorization: `Bearer ${metricsToken}` } }
+    )
+    await expect(metricsResponse.json()).resolves.toMatchObject({
+      counters: { rateLimitedMessagesTotal: 1 },
+    })
   })
 
   it('八名玩家可在 60 秒门槛内加入并全员确认，第九名被容量门禁拒绝', async () => {
@@ -937,7 +1091,13 @@ describe('联网升温局服务器权威纵向切片', () => {
 
   it('房间寿命从创建时硬性计算，活跃消息不能把两小时上限续期', async () => {
     let now = 1_000
-    server = await createRoomServer({ port: 0, now: () => now, roomTtlMs: 40 })
+    const metricsToken = 'expiry-test-metrics-token-at-least-32-bytes'
+    server = await createRoomServer({
+      port: 0,
+      now: () => now,
+      roomTtlMs: 40,
+      metricsToken,
+    })
     const host = await TestClient.connect(server.wsUrl)
     clients.push(host)
     host.send({
@@ -958,6 +1118,14 @@ describe('联网升温局服务器权威纵向切片', () => {
     await expect(
       host.next(message => message.type === 'error' && message.code === 'ROOM_EXPIRED')
     ).resolves.toMatchObject({ type: 'error', code: 'ROOM_EXPIRED' })
+    const metricsResponse = await fetch(
+      `${server.wsUrl.replace('ws://', 'http://')}/internal/metrics`,
+      { headers: { authorization: `Bearer ${metricsToken}` } }
+    )
+    await expect(metricsResponse.json()).resolves.toMatchObject({
+      counters: { roomsExpiredTotal: 1 },
+      gauges: { rooms: 0, drainBlockingRooms: 0 },
+    })
   })
 
   it('主持人断线超过保护期后自动把管理角色交给在线玩家', async () => {

--- a/deploy/room-server/ACCEPTANCE.md
+++ b/deploy/room-server/ACCEPTANCE.md
@@ -1,5 +1,9 @@
 # 联机升温局发布验收
 
+当前目标：`v1.15.0`
+
+当前状态：`PENDING_MANUAL_ACCEPTANCE`
+
 这份流程是 v1.12 联机升温局的发布终点，不是自动化演示。自动浏览器、WebSocket 脚本、模拟客户端或代理人不能替代真实 iOS、Android 与 4/6/8 名真人参加者。任一门槛缺证据时，校验器必须失败，发布状态保持未完成。
 
 ## 前置条件
@@ -18,9 +22,9 @@
 证据不得提交到仓库。先复制模板到已被 `.gitignore` 排除的目录：
 
 ```bash
-mkdir -p .acceptance-evidence/v1.14.2/{evidence,artifacts}
+mkdir -p .acceptance-evidence/v1.15.0/{evidence,artifacts}
 cp deploy/room-server/acceptance-evidence.template.json \
-  .acceptance-evidence/v1.14.2/evidence.json
+  .acceptance-evidence/v1.15.0/evidence.json
 ```
 
 每个 `evidenceRefs` 都必须指向结构化 JSON 证明，可从 `acceptance-proof.template.json` 复制。证明必须包含同一个发布标签、UTC 时间、证明类别、与主清单完全一致的 `claims`，以及至少一个原始材料文件和它的 SHA-256。校验器会读取原始文件并重新计算摘要；空文件、目录、错误摘要、错误版本、错误类别、声明不一致或私人字段都会失败。
@@ -43,7 +47,7 @@ cp deploy/room-server/acceptance-evidence.template.json \
 计算摘要示例：
 
 ```bash
-sha256sum .acceptance-evidence/v1.14.2/artifacts/<已脱敏材料>
+sha256sum .acceptance-evidence/v1.15.0/artifacts/<已脱敏材料>
 ```
 
 生产资源证据至少在现场验收前、中、后各采样一次。`swapSamplesMiB` 至少填 3 个数；校验器将峰峰值不超过 128MiB 作为“无 swap 振荡”的保守可重复判据。
@@ -78,7 +82,7 @@ sha256sum .acceptance-evidence/v1.14.2/artifacts/<已脱敏材料>
 
 ```bash
 npm run verify:online-acceptance -- \
-  .acceptance-evidence/v1.14.2/evidence.json
+  .acceptance-evidence/v1.15.0/evidence.json
 ```
 
 退出码 `0` 且输出 `PASS` 才表示证据合同满足；退出码 `1` 表示一个或多个硬门槛失败，退出码 `2` 表示文件/JSON 用法错误。该命令只校验证据完整性，不会替代人工核对材料真实性。

--- a/deploy/room-server/README.md
+++ b/deploy/room-server/README.md
@@ -101,6 +101,7 @@ node scripts/room-server-release-smoke.mjs \
   --ws-url wss://rooms.atang-sp.run.place \
   --expected-server-version 1.15.0 \
   --expected-protocol-version 1 \
+  --origin https://atang-sp.github.io \
   --timeout-ms 5000
 ```
 

--- a/deploy/room-server/README.md
+++ b/deploy/room-server/README.md
@@ -1,13 +1,50 @@
 # 联机升温局房间服务部署
 
-生产拓扑：GitHub Pages 前端连接 `wss://rooms.atang-sp.run.place`；Discourse 容器内的 Nginx 终止 TLS，并反代到 Docker 网桥 `172.17.0.1:8787`。房间容器使用 host 网络并只监听该网桥地址，避免 Docker 发布端口在同机容器间被防火墙阻断，也不会把 `8787` 暴露到公网。房间服务不写磁盘，容器被限制为 128 MiB 内存、1 CPU、只读根文件系统。Nginx 对单 IP 限制 16 个并发连接和每秒 5 次握手（允许 20 次突发），应用层对单连接限制每秒 30 条消息（允许 60 条突发）。
+生产拓扑：GitHub Pages 前端连接 `wss://rooms.atang-sp.run.place`；Discourse 容器内的 Nginx 终止 TLS，并反代到 Docker 网桥 `172.17.0.1:8787`。房间容器使用 host 网络并只监听该网桥地址，避免 Docker 发布端口在同机容器间被防火墙阻断，也不会把 `8787` 暴露到公网。房间服务不写磁盘，容器限制为 128 MiB 内存、1 CPU、只读根文件系统。
 
-## 构建与安装
+完整协议、health/readiness、drain blocker、metrics、smoke、发布和回滚合同见
+[`docs/ONLINE_OPERABILITY.md`](../../docs/ONLINE_OPERABILITY.md)。本文件只记录生产操作形状；本轮 PR 不执行这些操作。
 
-在已检出不可变 `v1.14.2` 标签的仓库根目录执行：
+## 构建与版本注入
+
+在已检出不可变 `v1.15.0` 标签的仓库根目录构建同一 commit。`ROOM_SERVER_BUILD_SHA` 只能是公开 Git commit 标识：
 
 ```bash
-docker build -f apps/room-server/Dockerfile -t flying-chess-room:1.14.2 .
+docker build -f apps/room-server/Dockerfile \
+  --build-arg ROOM_SERVER_VERSION=1.15.0 \
+  --build-arg ROOM_SERVER_BUILD_SHA=<公开完整 commit SHA> \
+  -t flying-chess-room:1.15.0 .
+```
+
+不要把 metrics、achievement 或其他 secret 作为 build arg；它们不得进入镜像层。
+
+`/etc/flying-chess-room.env` 是服务启动的必需配置文件，必须为 root 所有且权限为
+`0600`。至少写入：
+
+```dotenv
+ROOM_SERVER_VERSION=1.15.0
+ROOM_SERVER_BUILD_SHA=<公开完整 commit SHA>
+ROOM_DRAIN_TIMEOUT_MS=1800000
+```
+
+启用内部 metrics 时可增加至少 32 字节的随机 token：
+
+```dotenv
+ROOM_METRICS_TOKEN=<root-only internal metrics token>
+```
+
+启用论坛成就认领时，还必须同时配置：
+
+```dotenv
+ACHIEVEMENT_CLAIM_SECRET=<与 Discourse 插件相同的至少 32 字节随机密钥>
+ACHIEVEMENT_CLAIM_URL=https://atang-sp.run.place/where-is-my-friends/flying-chess
+```
+
+成就两项缺一时服务拒绝启动；轮换密钥会令尚未认领的旧凭证失效。不得在环境文件中保存房间码、昵称、玩法设置或消息内容。认领凭证只放在 URL fragment 中，不会随论坛页面请求进入 HTTP access log。
+
+安装单元文件：
+
+```bash
 ufw allow in on docker0 from 172.17.0.0/16 to 172.17.0.1 port 8787 proto tcp comment "flying chess room from discourse"
 install -m 0644 deploy/room-server/flying-chess-room.service /etc/systemd/system/
 install -m 0644 deploy/room-server/flying-chess-room-health.service /etc/systemd/system/
@@ -16,41 +53,71 @@ systemctl daemon-reload
 systemctl enable --now flying-chess-room.service flying-chess-room-health.timer
 ```
 
-`/etc/flying-chess-room.env` 可覆盖 `ROOM_IMAGE`。启用论坛成就认领时，还必须同时配置：
+30 分钟 drain 要求 Docker stop timeout 和 systemd `TimeoutStopSec` 更长；示例单元分别使用 1860 秒和 1900 秒。不得缩短为十几秒，否则正常滚动停止会被强杀。
 
-```dotenv
-ACHIEVEMENT_CLAIM_SECRET=<与 Discourse 插件相同的至少 32 字节随机密钥>
-ACHIEVEMENT_CLAIM_URL=https://atang-sp.run.place/where-is-my-friends/flying-chess
-```
+## Health、readiness 与 metrics
 
-该文件必须为 root 所有且权限为 `0600`。两项缺一时服务拒绝启动；轮换密钥会令尚未认领的旧凭证失效。不得在这里放置房间码、昵称、玩法设置或消息内容。服务只输出启动状态；Nginx 对房间子域关闭 access log。认领凭证只放在 URL fragment 中，不会随论坛页面请求进入 HTTP access log。
+- Docker HEALTHCHECK 和 systemd timer 调用 `/health`；draining 时仍为 `200`。
+- 发布/流量切换单独调用 `/ready`；draining 时为 `503`。
+- `/internal/metrics` 无 token 时为 `404`，有 token但认证错误时为 `401`。
+- Nginx 公网 virtual host 对 `/internal/metrics` 固定返回 `404`；内部采集器只可直连受控监听地址。
+
+内部抓取必须从 root-only 配置取得 token，并发送 Bearer header；命令、日志和工单不得打印 token。health、ready 和 metrics 都不得包含房间码、昵称、player ID、resume token、玩法设置、惩罚或消息正文。
 
 ## Discourse 反代与证书
 
-先备份 `/var/discourse/containers/app.yml`，再把 `rooms.atang-sp.run.place` 加到 `DISCOURSE_HOSTNAME_ALIASES`，并在 `run:` 中将 `deploy/room-server/rooms.nginx.conf` 的内容写到 `/etc/nginx/conf.d/rooms.conf`。执行 `/var/discourse/launcher rebuild app` 后，Let's Encrypt 会签发包含主域与房间子域的同一证书。
+先备份 `/var/discourse/containers/app.yml`，再把 `rooms.atang-sp.run.place` 加到
+`DISCOURSE_HOSTNAME_ALIASES`，并在 `run:` 中将
+`deploy/room-server/rooms.nginx.conf` 的内容写到 `/etc/nginx/conf.d/rooms.conf`。该配置明确拒绝公网 metrics。执行 `/var/discourse/launcher rebuild app` 后，Let's Encrypt 会签发包含主域与房间子域的同一证书。
 
 重建前必须创建 Discourse 数据备份及 SHA-256 校验，并记录原容器、配置和插件版本。重建后验证：
 
 ```bash
 curl --fail https://atang-sp.run.place/srv/status
 curl --fail https://rooms.atang-sp.run.place/health
+curl --fail https://rooms.atang-sp.run.place/ready
 systemctl is-active flying-chess-room.service
 systemctl is-active flying-chess-room-health.timer
 docker inspect --format '{{.State.Health.Status}} {{.HostConfig.Memory}}' flying-chess-room
 docker exec app curl --fail http://172.17.0.1:8787/ready
 ```
 
-健康响应只有聚合的房间数、连接数、运行时长与 RSS，不包含房间码、昵称、玩法设置或消息正文。
+health 中的 `version`、`buildSha` 和 `protocolVersion` 必须与同一发布 commit 一致。
 
-## 回滚
+## 发布顺序
 
-先恢复时间戳备份的 `app.yml` 并重建 Discourse，使主域证书和 Nginx 恢复；随后执行：
+1. 从同一 commit 构建前端和 room server；
+2. 先部署向后兼容缺字段旧客户端的新 room server；
+3. 在内部地址检查 `/ready`，再运行目标版本 shallow smoke；
+4. 部署前端；
+5. 对公开 health/WSS 再运行 shallow smoke；
+6. 人工真机与 4/6/8 人现场验收保持 `PENDING_MANUAL_ACCEPTANCE`，另行执行。
+
+示例 shallow smoke：
+
+```bash
+node scripts/room-server-release-smoke.mjs \
+  --health-url https://rooms.atang-sp.run.place/health \
+  --ws-url wss://rooms.atang-sp.run.place \
+  --expected-server-version 1.15.0 \
+  --expected-protocol-version 1 \
+  --timeout-ms 5000
+```
+
+不要对生产地址增加 `--deep`；deep 会创建 synthetic 内存房间，仅用于本地或隔离环境。
+
+## Graceful stop 与回滚
+
+`systemctl stop` 或 `restart` 触发 SIGTERM：readiness 先变为 `503`，停止创建新房间，但已有房间可 join、resume 和继续完成。无 blocker 时立即退出；否则最多等待
+`ROOM_DRAIN_TIMEOUT_MS`，随后有界关闭。重复信号不会重复关闭。
+
+回滚时先恢复上一不可变 room server 镜像和 root-only 环境文件，启动后运行上一版本 shallow smoke；若协议需要，再恢复上一静态前端。房间只在内存中，强制关闭会结束剩余房间，不得尝试从磁盘或数据库恢复。
+
+若需要完全移除该服务，先恢复时间戳备份的 `app.yml` 并重建 Discourse，使主域证书和 Nginx 恢复；随后执行：
 
 ```bash
 systemctl disable --now flying-chess-room-health.timer flying-chess-room.service
 ufw delete allow in on docker0 from 172.17.0.0/16 to 172.17.0.1 port 8787 proto tcp
 ```
-
-停止服务会结束全部内存房间，这是协议的既定行为。不要尝试从磁盘恢复房间。
 
 发布后的真机与真人现场验收见 [ACCEPTANCE.md](./ACCEPTANCE.md)。缺少其中任一匿名证据时，发布不得判定完成。

--- a/deploy/room-server/acceptance-evidence.template.json
+++ b/deploy/room-server/acceptance-evidence.template.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "release": "v1.14.2",
+  "release": "v1.15.0",
   "publicGateway": {
     "dnsResolved": false,
     "certificateSans": [],

--- a/deploy/room-server/acceptance-proof.template.json
+++ b/deploy/room-server/acceptance-proof.template.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "release": "v1.14.2",
+  "release": "v1.15.0",
   "recordedAtUtc": "2026-08-02T00:00:00.000Z",
   "kind": "replace_with_required_kind",
   "artifacts": [

--- a/deploy/room-server/flying-chess-room-health.service
+++ b/deploy/room-server/flying-chess-room-health.service
@@ -4,5 +4,4 @@ After=flying-chess-room.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl --fail --silent --show-error --max-time 5 http://172.17.0.1:8787/ready
-
+ExecStart=/usr/bin/curl --fail --silent --show-error --max-time 5 http://172.17.0.1:8787/health

--- a/deploy/room-server/flying-chess-room.service
+++ b/deploy/room-server/flying-chess-room.service
@@ -6,15 +6,18 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=ROOM_IMAGE=flying-chess-room:1.14.2
-EnvironmentFile=-/etc/flying-chess-room.env
+Environment=ROOM_IMAGE=flying-chess-room:1.15.0
+Environment=ROOM_SERVER_VERSION=1.15.0
+Environment=ROOM_SERVER_BUILD_SHA=unknown
+Environment=ROOM_DRAIN_TIMEOUT_MS=1800000
+EnvironmentFile=/etc/flying-chess-room.env
 ExecStartPre=-/usr/bin/docker rm -f flying-chess-room
-ExecStart=/usr/bin/docker run --rm --name flying-chess-room --network host --read-only --tmpfs /tmp:rw,noexec,nosuid,size=8m --cap-drop ALL --security-opt no-new-privileges --pids-limit 128 --cpus 1 --memory 128m --memory-swap 192m --health-cmd "wget -qO- http://172.17.0.1:8787/ready >/dev/null || exit 1" --health-interval 30s --health-timeout 3s --health-start-period 5s --health-retries 3 --log-driver journald -e NODE_ENV=production -e HOST=172.17.0.1 -e PORT=8787 -e ALLOWED_ORIGINS=https://atang-sp.github.io -e ACHIEVEMENT_CLAIM_SECRET -e ACHIEVEMENT_CLAIM_URL ${ROOM_IMAGE}
-ExecStop=/usr/bin/docker stop --timeout 10 flying-chess-room
+ExecStart=/usr/bin/docker run --rm --name flying-chess-room --network host --read-only --tmpfs /tmp:rw,noexec,nosuid,size=8m --cap-drop ALL --security-opt no-new-privileges --pids-limit 128 --cpus 1 --memory 128m --memory-swap 192m --stop-timeout 1860 --health-cmd "wget -qO- http://172.17.0.1:8787/health >/dev/null || exit 1" --health-interval 30s --health-timeout 3s --health-start-period 5s --health-retries 3 --log-driver journald -e NODE_ENV=production -e HOST=172.17.0.1 -e PORT=8787 -e ALLOWED_ORIGINS=https://atang-sp.github.io -e ROOM_SERVER_VERSION -e ROOM_SERVER_BUILD_SHA -e ROOM_DRAIN_TIMEOUT_MS -e ROOM_METRICS_TOKEN -e ACHIEVEMENT_CLAIM_SECRET -e ACHIEVEMENT_CLAIM_URL ${ROOM_IMAGE}
+ExecStop=/usr/bin/docker stop --timeout 1860 flying-chess-room
 Restart=always
 RestartSec=3
 TimeoutStartSec=30
-TimeoutStopSec=20
+TimeoutStopSec=1900
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/room-server/rooms.nginx.conf
+++ b/deploy/room-server/rooms.nginx.conf
@@ -30,6 +30,11 @@ server {
   access_log off;
   client_max_body_size 16k;
 
+  # Metrics are internal-only even when the application token is configured.
+  location = /internal/metrics {
+    return 404;
+  }
+
   location / {
     limit_conn flying_chess_room_connections 16;
     limit_conn_status 429;

--- a/docs/ONLINE_OPERABILITY.md
+++ b/docs/ONLINE_OPERABILITY.md
@@ -1,0 +1,136 @@
+# 联机协议与可运维合同
+
+目标版本：`1.15.0`
+
+工程状态：自动化门槛由 CI 验证；真机与 4/6/8 人现场门槛保持
+`PENDING_MANUAL_ACCEPTANCE`。
+
+本文描述浏览器客户端与 room server 的版本、存活、就绪、排空、指标、冒烟、发布和回滚合同。房间仍为单实例内存状态；本文不引入持久化、多实例迁移或生产部署自动化。
+
+## 应用版本与协议版本
+
+- `appVersion` 是前端发布版本，用于展示和诊断，由 Vite 构建注入。
+- `serverVersion` 是 room server 发布版本，由 `ROOM_SERVER_VERSION` 或镜像构建参数注入。
+- `serverBuildSha`/`buildSha` 是可选的公开 Git commit 标识，由
+  `ROOM_SERVER_BUILD_SHA` 注入；不得使用 secret 或环境变量全集代替。
+- `protocolVersion` 只判断 WebSocket 消息兼容性，不从任何 package semver 推断。
+
+唯一协议版本定义位于
+`packages/game-core/src/onlineProtocolVersion.ts`：当前版本为 `1`，最低支持版本也为 `1`。
+新客户端的 `create_room`、`join_room` 和 `resume_room` 都必须发送整数
+`protocolVersion`；成功的私有 `session` 返回 `protocolVersion`、`serverVersion` 和
+`serverBuildSha`。
+
+首次引入协议版本时保留一条临时迁移路径：缺少字段按 v1 处理。显式字符串、小数、负数、不安全整数、低于最低版本或高于当前版本的值全部以
+`INCOMPATIBLE_PROTOCOL` fail closed。客户端收到该错误后停止重连，保留已有 session
+凭证，并提示刷新或关闭后重新打开，因此不会误删另一个仍有效的席位。
+
+未来移除 legacy compatibility 时，应按顺序：先确认旧静态页面缓存窗口结束；删除
+`resolveOnlineProtocolVersion()` 中仅处理 `undefined` 的迁移分支；增加缺字段拒绝测试；如需提高最低版本，先部署支持新旧版本的服务端，再部署新前端，最后提高
+`MIN_SUPPORTED_ONLINE_PROTOCOL_VERSION`。不得用应用 semver 替代这一步。
+
+## `/health` 与 `/ready`
+
+| 端点 | 含义 | 正常 | draining |
+| --- | --- | --- | --- |
+| `/health` | 进程能否处理 HTTP，供 Docker/systemd liveness 使用 | `200` | `200` |
+| `/ready` | 是否接受新房间工作负载，供发布和流量切换使用 | `200` | `503` |
+
+`/health` 只有固定的聚合 allowlist：`status`、`version`、`buildSha`、
+`protocolVersion`、`uptimeSeconds`、`rssBytes`、`rooms`、`activeGames`、
+`connections`、`drainBlockingRooms`。`/ready` 明确返回 `acceptingNewRooms` 和
+`draining`。单个房间已满不会被当作进程不健康。
+
+Docker `HEALTHCHECK`、systemd 定时健康检查均使用 `/health`，以免正常 drain 被容器编排误判为故障并强杀。发布工具在切换流量前单独检查 `/ready`。
+
+## Graceful drain
+
+`SIGTERM` 和 `SIGINT` 进入同一个幂等关闭 Promise：
+
+1. 立即把 readiness 切为 `503`；
+2. 新的 `create_room` 返回 `SERVER_DRAINING`；
+3. 已有房间仍可 join、resume 和执行全部既有游戏动作；
+4. 等待 drain blocker 自然消失；
+5. 到达 `ROOM_DRAIN_TIMEOUT_MS` 后有界关闭 WebSocket、HTTP 和全部 interval；
+6. 进程以正常状态退出。
+
+默认 timeout 为 `1800000` 毫秒（30 分钟），有效范围为 1 毫秒至 24 小时且必须是十进制整数。生产 systemd/Docker stop timeout 必须长于该值；当前示例分别使用 1900 秒与 1860 秒。重复信号不会开启第二次关闭或绕过等待。
+
+Drain blocker 定义如下：
+
+| 房间状态 | 是否阻塞 |
+| --- | --- |
+| 有连接玩家的 lobby | 是 |
+| 正在进行的游戏，即使所有玩家暂时断线 | 是 |
+| 已结束但仍有连接玩家读取结算 | 是 |
+| 所有玩家均断开的 lobby | 否 |
+| 所有玩家均断开的 finished 房间 | 否 |
+| 已过期房间 | 已从 Map 删除，不进入快照 |
+
+`rooms.size` 因而不是 drain 条件。房间、resume token 和游戏规则不会因开始 drain
+而改变；只有最终关闭进程时内存房间才结束。
+
+## 私有聚合指标
+
+`/internal/metrics` 默认关闭，未配置 token 时返回 `404`。启用时设置
+`ROOM_METRICS_TOKEN`：必须为 32–512 字节、不得含空白；请求使用
+`Authorization: Bearer <token>`。服务端比较固定长度 SHA-256 摘要并调用恒定时间比较，错误或缺失 token 返回 `401`。token 不写入镜像层、日志、health、测试快照或 PR。
+
+响应只有三个顶层字段：`schemaVersion`、`counters`、`gauges`。计数器 allowlist 为：
+
+- `connectionsOpenedTotal`、`connectionsClosedTotal`
+- `roomsCreatedTotal`、`roomJoinsTotal`、`roomResumesTotal`
+- `gamesStartedTotal`、`gamesFinishedTotal`、`hostTransfersTotal`、`roomsExpiredTotal`
+- `protocolRejectedTotal`、`rateLimitedMessagesTotal`
+
+仪表 allowlist 为 `rooms`、`activeGames`、`connections`、`drainBlockingRooms`、
+`draining`、`rssBytes`、`uptimeSeconds`。没有动态 label；未知错误不生成字段。响应不得包含昵称、房间码、player ID、resume/achievement token、request ID、设置、惩罚、消息正文或 URL fragment。
+
+公开 Nginx 配置对 `/internal/metrics` 固定返回 `404`，即使应用层启用了 token 也不得转发。内部采集器只能从受控主机直连监听地址，并从 root-only 配置读取 Bearer token。
+
+## Release smoke 与 CI
+
+Shallow smoke 只读 health/readiness 并完成一次 WebSocket 连接，不创建房间：
+
+```bash
+node scripts/room-server-release-smoke.mjs \
+  --health-url https://rooms.example/health \
+  --ws-url wss://rooms.example \
+  --expected-server-version 1.15.0 \
+  --expected-protocol-version 1 \
+  --timeout-ms 5000
+```
+
+`--deep` 额外执行 synthetic create、join、断线、resume、私有投影检查和不兼容协议拒绝。它会改变目标服务的内存状态，因此只能显式用于本地或隔离环境，不能默认指向生产。脚本日志只输出阶段和固定错误码，不输出房间码、token 或消息 payload。
+
+`npm run test:room-server-smoke` 会构建并启动临时 room server，运行 deep smoke，发送
+SIGTERM，确认进程正常退出且端口关闭。CI 的独立 `Room Server Operability` job 运行 room server build、targeted tests、release smoke、完整 20 房间/160 连接压测和
+`git diff --exit-code`。该压测在本轮基线约 0.7 秒，因此保留在 PR required 路径，不降级到较小样本。
+
+## 发布顺序
+
+本轮只实现并验证流程，不执行生产发布：
+
+1. 从同一个 commit 构建前端与 room server，并注入 release version 与公开 build SHA；
+2. 先部署仍兼容缺字段旧页面的新 room server；
+3. 在流量切换前检查 `/ready`，部署后运行目标版本的 shallow smoke；
+4. 再部署前端；
+5. 对公开地址再运行 shallow smoke；
+6. 真实 iOS Safari、Android Chrome 与 4/6/8 人现场验收另行执行；
+7. 只有匿名人工证据合同通过后，才可把完整发布状态标为完成。
+
+## 回滚顺序
+
+1. 停止把新房间流量送入待回滚服务并确认 `/ready` 语义；
+2. 对当前 room server 发出 SIGTERM，等待有界 drain；必要时只在 timeout 后强关；
+3. 恢复上一不可变 room server 镜像及其配置；
+4. 运行上一版本对应的 shallow smoke；
+5. 如前端协议不再兼容，再恢复上一静态前端；
+6. 不恢复数据库或磁盘房间，因为 room server 从未持久化房间。
+
+回滚和发布均不得公开 metrics 端点、打印 token 或把 Pages 成功误报为 room server 已部署。
+
+## 人工门槛
+
+真实 iPhone/iPad Safari、Android Chrome、4/6/8 人真人现场对局、截图/录像人工核对和真实 Discourse 成就认领均未由本工程 PR 执行。其状态必须保持
+`PENDING_MANUAL_ACCEPTANCE`，流程见 `deploy/room-server/ACCEPTANCE.md`。

--- a/docs/ONLINE_OPERABILITY.md
+++ b/docs/ONLINE_OPERABILITY.md
@@ -98,10 +98,11 @@ node scripts/room-server-release-smoke.mjs \
   --ws-url wss://rooms.example \
   --expected-server-version 1.15.0 \
   --expected-protocol-version 1 \
+  --origin https://atang-sp.github.io \
   --timeout-ms 5000
 ```
 
-`--deep` 额外执行 synthetic create、join、断线、resume、私有投影检查和不兼容协议拒绝。它会改变目标服务的内存状态，因此只能显式用于本地或隔离环境，不能默认指向生产。脚本日志只输出阶段和固定错误码，不输出房间码、token 或消息 payload。
+`--origin` 为配置了浏览器 Origin allowlist 的服务显式提供握手 Origin；参数只接受无凭据、路径、查询或 fragment 的 HTTP(S) origin。`--deep` 额外执行 synthetic create、join、断线、resume、私有投影检查和不兼容协议拒绝。它会改变目标服务的内存状态，因此只能显式用于本地或隔离环境，不能默认指向生产。脚本日志只输出阶段和固定错误码，不输出房间码、token 或消息 payload。
 
 `npm run test:room-server-smoke` 会构建并启动临时 room server，运行 deep smoke，发送
 SIGTERM，确认进程正常退出且端口关闭。CI 的独立 `Room Server Operability` job 运行 room server build、targeted tests、release smoke、完整 20 房间/160 连接压测和

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "1.14.2",
+      "version": "1.15.0",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -54,9 +54,9 @@
     },
     "apps/room-server": {
       "name": "@flying-chess/room-server",
-      "version": "1.14.2",
+      "version": "1.15.0",
       "dependencies": {
-        "@flying-chess/game-core": "1.14.2",
+        "@flying-chess/game-core": "1.15.0",
         "ws": "^8.18.3"
       },
       "devDependencies": {
@@ -7279,9 +7279,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -11186,7 +11186,7 @@
     },
     "packages/game-core": {
       "name": "@flying-chess/game-core",
-      "version": "1.14.2"
+      "version": "1.15.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "private": true,
   "workspaces": [
     "packages/*",
@@ -35,6 +35,7 @@
     "dev:room-server": "npm run dev --workspace @flying-chess/room-server",
     "build:room-server": "npm run build --workspace @flying-chess/room-server",
     "test:room-server-load": "npm run build:room-server && node scripts/room-server-load-test.mjs",
+    "test:room-server-smoke": "npm run build:room-server && node scripts/room-server-release-smoke-harness.mjs",
     "verify:online-acceptance": "node scripts/online-acceptance-evidence.mjs",
     "test:e2e": "playwright test tests/e2e"
   },
@@ -61,7 +62,8 @@
     "vue": "^3.5.13"
   },
   "overrides": {
-    "brace-expansion": "5.0.9"
+    "brace-expansion": "5.0.9",
+    "nanoid": "3.3.17"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/packages/game-core/package.json
+++ b/packages/game-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/game-core",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/game-core/src/index.ts
+++ b/packages/game-core/src/index.ts
@@ -35,6 +35,11 @@ import {
 } from './playerRules'
 import { canPlayerSkipOwnOnlineAction } from './onlineCommandPolicy'
 import { scheduleOnlineDeadline, timeoutDecisionPlayerId } from './onlineDeadline'
+export {
+  CURRENT_ONLINE_PROTOCOL_VERSION,
+  MIN_SUPPORTED_ONLINE_PROTOCOL_VERSION,
+  resolveOnlineProtocolVersion,
+} from './onlineProtocolVersion'
 import {
   createBoardConfig as createSharedBoardConfig,
   createModeConfig,

--- a/packages/game-core/src/onlineProtocol.ts
+++ b/packages/game-core/src/onlineProtocol.ts
@@ -7,12 +7,14 @@ export type OnlineClientMessage =
   | Readonly<{
       type: 'create_room'
       requestId: string
+      protocolVersion: number
       nickname: string
       color: string
     }>
   | Readonly<{
       type: 'join_room'
       requestId: string
+      protocolVersion: number
       roomCode: string
       nickname: string
       color: string
@@ -20,6 +22,7 @@ export type OnlineClientMessage =
   | Readonly<{
       type: 'resume_room'
       requestId: string
+      protocolVersion: number
       roomCode: string
       playerId: string
       resumeToken: string
@@ -121,6 +124,9 @@ export type OnlineServerMessage =
   | Readonly<{
       type: 'session'
       requestId: string
+      protocolVersion: number
+      serverVersion: string
+      serverBuildSha: string
       roomCode: string
       playerId: string
       resumeToken: string

--- a/packages/game-core/src/onlineProtocolVersion.test.ts
+++ b/packages/game-core/src/onlineProtocolVersion.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CURRENT_ONLINE_PROTOCOL_VERSION,
+  MIN_SUPPORTED_ONLINE_PROTOCOL_VERSION,
+  resolveOnlineProtocolVersion,
+} from './onlineProtocolVersion'
+
+describe('online protocol version contract', () => {
+  it('uses protocol v1 for the temporary missing-field migration path', () => {
+    expect(CURRENT_ONLINE_PROTOCOL_VERSION).toBe(1)
+    expect(MIN_SUPPORTED_ONLINE_PROTOCOL_VERSION).toBe(1)
+    expect(resolveOnlineProtocolVersion(undefined)).toBe(1)
+  })
+
+  it.each([
+    ['string', '1'],
+    ['fraction', 1.5],
+    ['negative', -1],
+    ['too old', 0],
+    ['too new', 2],
+    ['unsafe integer', Number.MAX_SAFE_INTEGER + 1],
+  ])('rejects an explicit %s protocol version', (_label, value) => {
+    expect(resolveOnlineProtocolVersion(value)).toBeNull()
+  })
+})

--- a/packages/game-core/src/onlineProtocolVersion.ts
+++ b/packages/game-core/src/onlineProtocolVersion.ts
@@ -1,0 +1,22 @@
+export const CURRENT_ONLINE_PROTOCOL_VERSION = 1
+export const MIN_SUPPORTED_ONLINE_PROTOCOL_VERSION = 1
+
+/**
+ * Resolves the protocol used by a session-establishing message.
+ *
+ * Missing values temporarily map to v1 so pages opened before protocol
+ * negotiation was introduced can still create, join, or resume. Remove this
+ * undefined branch when the documented legacy compatibility window closes.
+ */
+export function resolveOnlineProtocolVersion(value: unknown): number | null {
+  if (value === undefined) return CURRENT_ONLINE_PROTOCOL_VERSION
+  if (!Number.isSafeInteger(value)) return null
+  const version = Number(value)
+  if (
+    version < MIN_SUPPORTED_ONLINE_PROTOCOL_VERSION ||
+    version > CURRENT_ONLINE_PROTOCOL_VERSION
+  ) {
+    return null
+  }
+  return version
+}

--- a/scripts/room-server-release-smoke-harness.mjs
+++ b/scripts/room-server-release-smoke-harness.mjs
@@ -1,0 +1,134 @@
+import { spawn } from 'node:child_process'
+
+const expectedServerVersion = '1.15.0-smoke'
+const expectedProtocolVersion = 1
+
+function waitForListeningPort(child, timeoutMs = 5_000) {
+  return new Promise((resolve, reject) => {
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(
+      () => reject(new Error('ephemeral room server start timed out')),
+      timeoutMs
+    )
+    child.stdout.on('data', chunk => {
+      stdout += chunk.toString()
+      const match = stdout.match(/room server listening on port (\d+)/)
+      if (!match) return
+      clearTimeout(timer)
+      resolve(Number(match[1]))
+    })
+    child.stderr.on('data', chunk => {
+      stderr = `${stderr}${chunk.toString()}`.slice(-2_000)
+    })
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer)
+      reject(
+        new Error(`ephemeral room server exited before listening: ${code ?? signal} ${stderr}`)
+      )
+    })
+  })
+}
+
+function waitForExit(child, timeoutMs = 5_000) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode })
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('child process exit timed out')), timeoutMs)
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer)
+      resolve({ code, signal })
+    })
+  })
+}
+
+function runSmoke(arguments_) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['scripts/room-server-release-smoke.mjs', ...arguments_],
+      {
+        cwd: process.cwd(),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    )
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error('release smoke process timed out'))
+    }, 10_000)
+    child.stdout.on('data', chunk => {
+      stdout = `${stdout}${chunk.toString()}`.slice(-4_000)
+    })
+    child.stderr.on('data', chunk => {
+      stderr = `${stderr}${chunk.toString()}`.slice(-4_000)
+    })
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer)
+      if (code !== 0) {
+        reject(new Error(`release smoke failed: ${code ?? signal} ${stderr}`))
+        return
+      }
+      resolve(stdout)
+    })
+  })
+}
+
+const server = spawn(process.execPath, ['apps/room-server/dist/server.mjs'], {
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    NODE_ENV: 'production',
+    HOST: '127.0.0.1',
+    PORT: '0',
+    ROOM_SERVER_VERSION: expectedServerVersion,
+    ROOM_SERVER_BUILD_SHA: 'abcdef1234567890',
+    ROOM_DRAIN_TIMEOUT_MS: '500',
+  },
+  stdio: ['ignore', 'pipe', 'pipe'],
+})
+
+try {
+  const port = await waitForListeningPort(server)
+  const httpUrl = `http://127.0.0.1:${port}`
+  const commonArguments = [
+    '--health-url',
+    `${httpUrl}/health`,
+    '--ws-url',
+    `ws://127.0.0.1:${port}`,
+    '--expected-server-version',
+    expectedServerVersion,
+    '--expected-protocol-version',
+    String(expectedProtocolVersion),
+    '--timeout-ms',
+    '3000',
+  ]
+  const shallowOutput = await runSmoke(commonArguments)
+  if (!String(shallowOutput).includes('PASS mode=shallow')) {
+    throw new Error('release smoke did not report shallow PASS')
+  }
+  const deepOutput = await runSmoke([...commonArguments, '--deep'])
+  if (!String(deepOutput).includes('PASS mode=deep')) {
+    throw new Error('release smoke did not report deep PASS')
+  }
+
+  server.kill('SIGTERM')
+  const exit = await waitForExit(server)
+  if (exit.code !== 0 || exit.signal !== null) {
+    throw new Error(`ephemeral room server did not exit cleanly: ${exit.code ?? exit.signal}`)
+  }
+  await fetch(`${httpUrl}/health`).then(
+    () => {
+      throw new Error('ephemeral room server port remained open after shutdown')
+    },
+    () => undefined
+  )
+  console.log('room-server release smoke harness PASS')
+} finally {
+  if (server.exitCode === null && server.signalCode === null) {
+    server.kill('SIGKILL')
+    await waitForExit(server).catch(() => undefined)
+  }
+}

--- a/scripts/room-server-release-smoke-harness.mjs
+++ b/scripts/room-server-release-smoke-harness.mjs
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process'
 
 const expectedServerVersion = '1.15.0-smoke'
 const expectedProtocolVersion = 1
+const allowedOrigin = 'https://smoke.example'
 
 function waitForListeningPort(child, timeoutMs = 5_000) {
   return new Promise((resolve, reject) => {
@@ -86,6 +87,7 @@ const server = spawn(process.execPath, ['apps/room-server/dist/server.mjs'], {
     ROOM_SERVER_VERSION: expectedServerVersion,
     ROOM_SERVER_BUILD_SHA: 'abcdef1234567890',
     ROOM_DRAIN_TIMEOUT_MS: '500',
+    ALLOWED_ORIGINS: allowedOrigin,
   },
   stdio: ['ignore', 'pipe', 'pipe'],
 })
@@ -102,6 +104,8 @@ try {
     expectedServerVersion,
     '--expected-protocol-version',
     String(expectedProtocolVersion),
+    '--origin',
+    allowedOrigin,
     '--timeout-ms',
     '3000',
   ]

--- a/scripts/room-server-release-smoke.mjs
+++ b/scripts/room-server-release-smoke.mjs
@@ -27,6 +27,7 @@ function parseArguments(arguments_) {
     index += 1
     if (argument === '--health-url') options.healthUrl = value
     else if (argument === '--ws-url') options.wsUrl = value
+    else if (argument === '--origin') options.origin = value
     else if (argument === '--expected-server-version') options.expectedServerVersion = value
     else if (argument === '--expected-protocol-version') {
       options.expectedProtocolVersion = Number(value)
@@ -48,8 +49,9 @@ function parseArguments(arguments_) {
   }
   const healthUrl = parseSafeUrl(options.healthUrl, ['http:', 'https:'], 'arguments')
   const wsUrl = parseSafeUrl(options.wsUrl, ['ws:', 'wss:'], 'arguments')
+  const origin = options.origin === undefined ? undefined : parseOrigin(options.origin)
   if (!healthUrl.pathname.endsWith('/health')) fail('arguments', 'INVALID_HEALTH_PATH')
-  return { ...options, healthUrl, wsUrl }
+  return { ...options, healthUrl, wsUrl, origin }
 }
 
 function parseSafeUrl(value, protocols, stage) {
@@ -63,6 +65,12 @@ function parseSafeUrl(value, protocols, stage) {
     fail(stage, 'UNSAFE_URL')
   }
   return url
+}
+
+function parseOrigin(value) {
+  const url = parseSafeUrl(value, ['http:', 'https:'], 'arguments')
+  if (url.pathname !== '/') fail('arguments', 'INVALID_ORIGIN')
+  return url.origin
 }
 
 function withTimeout(timeoutMs, onTimeout) {
@@ -121,9 +129,9 @@ class SmokeClient {
     })
   }
 
-  static connect(url, timeoutMs, stage) {
+  static connect(url, timeoutMs, stage, origin) {
     return new Promise((resolve, reject) => {
-      const socket = new WebSocket(url)
+      const socket = new WebSocket(url, origin === undefined ? undefined : { origin })
       const timer = withTimeout(timeoutMs, () => {
         socket.terminate()
         reject(new SmokeFailure(stage, 'CONNECT_TIMEOUT'))
@@ -206,7 +214,12 @@ async function runShallow(options) {
   }
 
   if (!options.deep) {
-    const probe = await SmokeClient.connect(options.wsUrl, options.timeoutMs, 'websocket')
+    const probe = await SmokeClient.connect(
+      options.wsUrl,
+      options.timeoutMs,
+      'websocket',
+      options.origin
+    )
     await probe.close()
   }
 }
@@ -214,7 +227,12 @@ async function runShallow(options) {
 async function runDeep(options) {
   const clients = []
   try {
-    const host = await SmokeClient.connect(options.wsUrl, options.timeoutMs, 'deep.host.connect')
+    const host = await SmokeClient.connect(
+      options.wsUrl,
+      options.timeoutMs,
+      'deep.host.connect',
+      options.origin
+    )
     clients.push(host)
     host.send(
       {
@@ -234,7 +252,12 @@ async function runDeep(options) {
       fail('deep.host.session', 'VERSION_MISMATCH')
     }
 
-    const guest = await SmokeClient.connect(options.wsUrl, options.timeoutMs, 'deep.guest.connect')
+    const guest = await SmokeClient.connect(
+      options.wsUrl,
+      options.timeoutMs,
+      'deep.guest.connect',
+      options.origin
+    )
     clients.push(guest)
     guest.send(
       {
@@ -265,7 +288,8 @@ async function runDeep(options) {
     const resumed = await SmokeClient.connect(
       options.wsUrl,
       options.timeoutMs,
-      'deep.resume.connect'
+      'deep.resume.connect',
+      options.origin
     )
     clients.push(resumed)
     resumed.send(
@@ -308,7 +332,8 @@ async function runDeep(options) {
     const incompatible = await SmokeClient.connect(
       options.wsUrl,
       options.timeoutMs,
-      'deep.protocol.connect'
+      'deep.protocol.connect',
+      options.origin
     )
     clients.push(incompatible)
     incompatible.send(
@@ -340,7 +365,7 @@ export async function runRoomServerReleaseSmoke(options) {
 
 function printUsage() {
   console.log(
-    'Usage: node scripts/room-server-release-smoke.mjs --health-url <url> --ws-url <url> --expected-server-version <version> --expected-protocol-version <integer> [--timeout-ms <ms>] [--deep]'
+    'Usage: node scripts/room-server-release-smoke.mjs --health-url <url> --ws-url <url> --expected-server-version <version> --expected-protocol-version <integer> [--origin <http-origin>] [--timeout-ms <ms>] [--deep]'
   )
 }
 

--- a/scripts/room-server-release-smoke.mjs
+++ b/scripts/room-server-release-smoke.mjs
@@ -1,0 +1,375 @@
+import WebSocket from 'ws'
+import { fileURLToPath } from 'node:url'
+
+class SmokeFailure extends Error {
+  constructor(stage, code) {
+    super(`${stage}:${code}`)
+    this.stage = stage
+    this.code = code
+  }
+}
+
+function fail(stage, code) {
+  throw new SmokeFailure(stage, code)
+}
+
+function parseArguments(arguments_) {
+  const options = { deep: false, timeoutMs: 5_000 }
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index]
+    if (argument === '--deep') {
+      options.deep = true
+      continue
+    }
+    if (argument === '--help') return { help: true }
+    const value = arguments_[index + 1]
+    if (!value || value.startsWith('--')) fail('arguments', 'MISSING_VALUE')
+    index += 1
+    if (argument === '--health-url') options.healthUrl = value
+    else if (argument === '--ws-url') options.wsUrl = value
+    else if (argument === '--expected-server-version') options.expectedServerVersion = value
+    else if (argument === '--expected-protocol-version') {
+      options.expectedProtocolVersion = Number(value)
+    } else if (argument === '--timeout-ms') options.timeoutMs = Number(value)
+    else fail('arguments', 'UNKNOWN_ARGUMENT')
+  }
+
+  if (
+    !options.healthUrl ||
+    !options.wsUrl ||
+    !options.expectedServerVersion ||
+    !Number.isSafeInteger(options.expectedProtocolVersion) ||
+    options.expectedProtocolVersion < 1 ||
+    !Number.isSafeInteger(options.timeoutMs) ||
+    options.timeoutMs < 100 ||
+    options.timeoutMs > 60_000
+  ) {
+    fail('arguments', 'INVALID_ARGUMENT')
+  }
+  const healthUrl = parseSafeUrl(options.healthUrl, ['http:', 'https:'], 'arguments')
+  const wsUrl = parseSafeUrl(options.wsUrl, ['ws:', 'wss:'], 'arguments')
+  if (!healthUrl.pathname.endsWith('/health')) fail('arguments', 'INVALID_HEALTH_PATH')
+  return { ...options, healthUrl, wsUrl }
+}
+
+function parseSafeUrl(value, protocols, stage) {
+  let url
+  try {
+    url = new URL(value)
+  } catch {
+    fail(stage, 'INVALID_URL')
+  }
+  if (!protocols.includes(url.protocol) || url.username || url.password || url.search || url.hash) {
+    fail(stage, 'UNSAFE_URL')
+  }
+  return url
+}
+
+function withTimeout(timeoutMs, onTimeout) {
+  const timer = setTimeout(onTimeout, timeoutMs)
+  timer.unref?.()
+  return timer
+}
+
+async function fetchJson(url, stage, timeoutMs) {
+  const controller = new AbortController()
+  const timer = withTimeout(timeoutMs, () => controller.abort())
+  try {
+    const response = await fetch(url, { signal: controller.signal })
+    let body
+    try {
+      body = await response.json()
+    } catch {
+      fail(stage, 'INVALID_JSON')
+    }
+    return { response, body }
+  } catch (error) {
+    if (error instanceof SmokeFailure) throw error
+    fail(stage, 'HTTP_FAILED')
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+class SmokeClient {
+  constructor(socket, timeoutMs) {
+    this.socket = socket
+    this.timeoutMs = timeoutMs
+    this.messages = []
+    this.waiters = []
+    socket.on('message', raw => {
+      let message
+      try {
+        message = JSON.parse(raw.toString())
+      } catch {
+        return
+      }
+      const waiterIndex = this.waiters.findIndex(waiter => waiter.predicate(message))
+      if (waiterIndex < 0) {
+        this.messages.push(message)
+        return
+      }
+      const [waiter] = this.waiters.splice(waiterIndex, 1)
+      clearTimeout(waiter.timer)
+      waiter.resolve(message)
+    })
+    socket.on('close', () => {
+      for (const waiter of this.waiters.splice(0)) {
+        clearTimeout(waiter.timer)
+        waiter.reject(new SmokeFailure(waiter.stage, 'CONNECTION_CLOSED'))
+      }
+    })
+  }
+
+  static connect(url, timeoutMs, stage) {
+    return new Promise((resolve, reject) => {
+      const socket = new WebSocket(url)
+      const timer = withTimeout(timeoutMs, () => {
+        socket.terminate()
+        reject(new SmokeFailure(stage, 'CONNECT_TIMEOUT'))
+      })
+      socket.once('open', () => {
+        clearTimeout(timer)
+        resolve(new SmokeClient(socket, timeoutMs))
+      })
+      socket.once('error', () => {
+        clearTimeout(timer)
+        reject(new SmokeFailure(stage, 'CONNECT_FAILED'))
+      })
+    })
+  }
+
+  send(message, stage) {
+    if (this.socket.readyState !== WebSocket.OPEN) fail(stage, 'NOT_CONNECTED')
+    this.socket.send(JSON.stringify(message))
+  }
+
+  next(predicate, stage) {
+    const bufferedIndex = this.messages.findIndex(predicate)
+    if (bufferedIndex >= 0) {
+      const [message] = this.messages.splice(bufferedIndex, 1)
+      return Promise.resolve(message)
+    }
+    return new Promise((resolve, reject) => {
+      const timer = withTimeout(this.timeoutMs, () => {
+        const waiterIndex = this.waiters.findIndex(waiter => waiter.timer === timer)
+        if (waiterIndex >= 0) this.waiters.splice(waiterIndex, 1)
+        reject(new SmokeFailure(stage, 'MESSAGE_TIMEOUT'))
+      })
+      this.waiters.push({ predicate, stage, resolve, reject, timer })
+    })
+  }
+
+  close() {
+    if (this.socket.readyState === WebSocket.CLOSED) return Promise.resolve()
+    return new Promise(resolve => {
+      const timer = withTimeout(this.timeoutMs, () => {
+        this.socket.terminate()
+        resolve()
+      })
+      this.socket.once('close', () => {
+        clearTimeout(timer)
+        resolve()
+      })
+      this.socket.close()
+    })
+  }
+}
+
+function assertPublicProjection(message, privateValues, stage) {
+  const serialized = JSON.stringify(message)
+  if (Object.hasOwn(message, 'resumeToken') || serialized.includes('resumeToken')) {
+    fail(stage, 'PRIVATE_FIELD_EXPOSED')
+  }
+  if (privateValues.some(value => value && serialized.includes(value))) {
+    fail(stage, 'PRIVATE_VALUE_EXPOSED')
+  }
+}
+
+async function runShallow(options) {
+  const health = await fetchJson(options.healthUrl, 'health', options.timeoutMs)
+  if (health.response.status !== 200) fail('health', 'UNEXPECTED_STATUS')
+  if (health.body?.version !== options.expectedServerVersion) fail('health', 'VERSION_MISMATCH')
+  if (health.body?.protocolVersion !== options.expectedProtocolVersion) {
+    fail('health', 'PROTOCOL_MISMATCH')
+  }
+
+  const readyUrl = new URL(options.healthUrl)
+  readyUrl.pathname = readyUrl.pathname.replace(/\/health$/, '/ready')
+  const readiness = await fetchJson(readyUrl, 'readiness', options.timeoutMs)
+  if (
+    readiness.response.status !== 200 ||
+    readiness.body?.acceptingNewRooms !== true ||
+    readiness.body?.draining !== false
+  ) {
+    fail('readiness', 'NOT_READY')
+  }
+
+  if (!options.deep) {
+    const probe = await SmokeClient.connect(options.wsUrl, options.timeoutMs, 'websocket')
+    await probe.close()
+  }
+}
+
+async function runDeep(options) {
+  const clients = []
+  try {
+    const host = await SmokeClient.connect(options.wsUrl, options.timeoutMs, 'deep.host.connect')
+    clients.push(host)
+    host.send(
+      {
+        type: 'create_room',
+        requestId: 'smoke-create',
+        protocolVersion: options.expectedProtocolVersion,
+        nickname: 'SmokeHost',
+        color: '#ff6b6b',
+      },
+      'deep.host.create'
+    )
+    const hostSession = await host.next(message => message.type === 'session', 'deep.host.session')
+    if (
+      hostSession.protocolVersion !== options.expectedProtocolVersion ||
+      hostSession.serverVersion !== options.expectedServerVersion
+    ) {
+      fail('deep.host.session', 'VERSION_MISMATCH')
+    }
+
+    const guest = await SmokeClient.connect(options.wsUrl, options.timeoutMs, 'deep.guest.connect')
+    clients.push(guest)
+    guest.send(
+      {
+        type: 'join_room',
+        requestId: 'smoke-join',
+        protocolVersion: options.expectedProtocolVersion,
+        roomCode: hostSession.roomCode,
+        nickname: 'SmokeGuest',
+        color: '#4ecdc4',
+      },
+      'deep.guest.join'
+    )
+    const guestSession = await guest.next(
+      message => message.type === 'session',
+      'deep.guest.session'
+    )
+    const hostProjection = await host.next(
+      message => message.type === 'room_state' && message.room?.players?.length === 2,
+      'deep.host.projection'
+    )
+    assertPublicProjection(
+      hostProjection,
+      [guestSession.resumeToken, guestSession.roomCode],
+      'deep.host.projection'
+    )
+
+    await guest.close()
+    const resumed = await SmokeClient.connect(
+      options.wsUrl,
+      options.timeoutMs,
+      'deep.resume.connect'
+    )
+    clients.push(resumed)
+    resumed.send(
+      {
+        type: 'resume_room',
+        requestId: 'smoke-resume',
+        protocolVersion: options.expectedProtocolVersion,
+        roomCode: guestSession.roomCode,
+        playerId: guestSession.playerId,
+        resumeToken: guestSession.resumeToken,
+      },
+      'deep.resume.send'
+    )
+    const resumedSession = await resumed.next(
+      message => message.type === 'session',
+      'deep.resume.session'
+    )
+    if (
+      resumedSession.playerId !== guestSession.playerId ||
+      !resumedSession.resumeToken ||
+      resumedSession.resumeToken === guestSession.resumeToken
+    ) {
+      fail('deep.resume.session', 'PRIVATE_SESSION_MISMATCH')
+    }
+    const resumedProjection = await resumed.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room?.players?.some(
+          player => player.id === guestSession.playerId && player.connected === true
+        ),
+      'deep.resume.projection'
+    )
+    if (
+      Object.hasOwn(resumedProjection.room?.settings ?? {}, 'punishmentConfig') ||
+      Object.hasOwn(resumedProjection.room?.settings ?? {}, 'traps')
+    ) {
+      fail('deep.resume.projection', 'HOST_PRIVATE_SETTINGS_EXPOSED')
+    }
+
+    const incompatible = await SmokeClient.connect(
+      options.wsUrl,
+      options.timeoutMs,
+      'deep.protocol.connect'
+    )
+    clients.push(incompatible)
+    incompatible.send(
+      {
+        type: 'create_room',
+        requestId: 'smoke-incompatible',
+        protocolVersion: options.expectedProtocolVersion + 1,
+        nickname: 'SmokeMismatch',
+        color: '#45b7d1',
+      },
+      'deep.protocol.send'
+    )
+    const rejected = await incompatible.next(
+      message => message.type === 'error',
+      'deep.protocol.error'
+    )
+    if (rejected.code !== 'INCOMPATIBLE_PROTOCOL') {
+      fail('deep.protocol.error', 'UNSTABLE_ERROR_CODE')
+    }
+  } finally {
+    await Promise.all(clients.map(client => client.close()))
+  }
+}
+
+export async function runRoomServerReleaseSmoke(options) {
+  await runShallow(options)
+  if (options.deep) await runDeep(options)
+}
+
+function printUsage() {
+  console.log(
+    'Usage: node scripts/room-server-release-smoke.mjs --health-url <url> --ws-url <url> --expected-server-version <version> --expected-protocol-version <integer> [--timeout-ms <ms>] [--deep]'
+  )
+}
+
+async function runCli() {
+  let options
+  try {
+    options = parseArguments(process.argv.slice(2))
+  } catch (error) {
+    const failure = error instanceof SmokeFailure ? error : new SmokeFailure('arguments', 'FAILED')
+    console.error(`[room-server-smoke] FAIL stage=${failure.stage} code=${failure.code}`)
+    process.exitCode = 2
+    return
+  }
+  if (options.help) {
+    printUsage()
+    return
+  }
+  try {
+    await runRoomServerReleaseSmoke(options)
+    console.log(
+      `[room-server-smoke] PASS mode=${options.deep ? 'deep' : 'shallow'} serverVersion=${options.expectedServerVersion} protocolVersion=${options.expectedProtocolVersion}`
+    )
+  } catch (error) {
+    const failure = error instanceof SmokeFailure ? error : new SmokeFailure('unknown', 'FAILED')
+    console.error(`[room-server-smoke] FAIL stage=${failure.stage} code=${failure.code}`)
+    process.exitCode = 1
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await runCli()
+}

--- a/src/multiplayer/App.vue
+++ b/src/multiplayer/App.vue
@@ -4,6 +4,7 @@
   import {
     ONLINE_TURN_DURATION_OPTIONS,
     ONLINE_PLAYER_COLORS,
+    CURRENT_ONLINE_PROTOCOL_VERSION,
     cloneOnlineRoomSettings,
     createOnlineBoardConfig,
     type BoardCell,
@@ -96,6 +97,7 @@
         client.send({
           type: 'resume_room',
           requestId: requestId('resume'),
+          protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
           ...storedSession,
         })
       }
@@ -291,6 +293,7 @@
     send({
       type: 'create_room',
       requestId: requestId('create'),
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
       nickname: nickname.value,
       color: color.value,
     })
@@ -300,6 +303,7 @@
     send({
       type: 'join_room',
       requestId: requestId('join'),
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
       roomCode: roomCodeInput.value.trim().toUpperCase(),
       nickname: nickname.value,
       color: color.value,

--- a/src/multiplayer/roomClient.ts
+++ b/src/multiplayer/roomClient.ts
@@ -29,7 +29,14 @@ export class OnlineRoomClient {
     socket.addEventListener('message', event => {
       if (typeof event.data !== 'string') return
       try {
-        this.callbacks.onMessage(JSON.parse(event.data) as OnlineServerMessage)
+        const message = JSON.parse(event.data) as OnlineServerMessage
+        if (message.type === 'error' && message.code === 'INCOMPATIBLE_PROTOCOL') {
+          this.stopReconnecting()
+        }
+        this.callbacks.onMessage(message)
+        if (message.type === 'error' && message.code === 'INCOMPATIBLE_PROTOCOL') {
+          socket.close(1008, 'incompatible protocol')
+        }
       } catch {
         // A malformed server frame is ignored; the next authoritative state can still recover the UI.
       }
@@ -69,11 +76,15 @@ export class OnlineRoomClient {
   }
 
   close(): void {
+    this.stopReconnecting()
+    this.socket?.close()
+    this.socket = null
+  }
+
+  private stopReconnecting(): void {
     this.manuallyClosed = true
     if (this.reconnectTimer !== null) window.clearTimeout(this.reconnectTimer)
     this.reconnectTimer = null
-    this.socket?.close()
-    this.socket = null
   }
 
   private scheduleReconnect(): void {

--- a/src/tests/roomClient.test.ts
+++ b/src/tests/roomClient.test.ts
@@ -67,4 +67,42 @@ describe('OnlineRoomClient', () => {
     expect(statuses.at(-1)).toBe('connected')
     expect(vi.getTimerCount()).toBe(0)
   })
+
+  it('收到协议不兼容错误后停止重连并保留可操作提示', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    vi.stubGlobal('window', {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+    })
+    const messages: unknown[] = []
+    const client = new OnlineRoomClient('ws://example.test', {
+      onStatus: () => undefined,
+      onMessage: message => messages.push(message),
+    })
+
+    const connection = client.connect()
+    const socket = FakeWebSocket.instances[0]
+    if (!socket) throw new Error('expected socket')
+    socket.emit('open')
+    await connection
+    socket.emit(
+      'message',
+      JSON.stringify({
+        type: 'error',
+        code: 'INCOMPATIBLE_PROTOCOL',
+        message: '联机协议版本不兼容，请刷新页面或关闭后重新打开。',
+      })
+    )
+    socket.emit('close')
+
+    expect(messages).toEqual([
+      {
+        type: 'error',
+        code: 'INCOMPATIBLE_PROTOCOL',
+        message: '联机协议版本不兼容，请刷新页面或关闭后重新打开。',
+      },
+    ])
+    expect(vi.getTimerCount()).toBe(0)
+  })
 })


### PR DESCRIPTION
## Background

The online room server is authoritative and intentionally single-instance/in-memory, but the 1.14.2 release shape did not expose an explicit protocol contract, separate liveness/readiness semantics, bounded graceful drain, private aggregate metrics, or a reusable release smoke gate. This PR prepares the 1.15.0 engineering and release-safety slice without deploying it.

## Root cause / current gap

Application semver was the only visible version signal, `/health` and `/ready` were effectively equivalent, process signals closed the service without a room-aware drain contract, and there was no authenticated operability surface or production-shaped smoke harness. That made compatibility and rolling-stop behavior implicit and difficult to verify before a release.

## Protocol compatibility

- Adds one shared online protocol source in `@flying-chess/game-core`: current/minimum version 1.
- `create_room`, `join_room`, and `resume_room` carry `protocolVersion`; private `session` responses include protocol/server/build versions.
- Missing protocol fields temporarily resolve to v1 for already-open legacy pages. Explicit unsupported, non-integer, negative, string, NaN, and unsafe values fail closed with `INCOMPATIBLE_PROTOCOL` and an actionable Chinese refresh/reopen prompt.
- The browser client stops reconnecting on incompatibility and preserves stored session credentials instead of deleting a potentially valid seat.
- Application semver and protocol version remain independent.

## Health/readiness semantics

- `/health` is liveness: fixed aggregate allowlist, version/build/protocol diagnostics, always 200 while the process can serve HTTP, including during drain.
- `/ready` is new-room readiness: 200 normally and 503 with `acceptingNewRooms=false` while draining.
- Docker and systemd health checks use `/health`; release/traffic-switch procedures use `/ready`.

## Drain behavior

- `SIGTERM` and `SIGINT` enter one idempotent drain promise.
- New room creation fails with `SERVER_DRAINING`; existing room join, resume, and game actions remain available.
- Connected lobbies, any playing game (including temporarily disconnected players), and connected finished rooms block drain; disconnected lobby/finished and expired rooms do not.
- Default timeout is 30 minutes, strictly bounded to 1 ms–24 h and injectable for tests. Timeout closes WebSocket/HTTP servers and timers with a normal process exit.
- Production-shaped Docker/systemd stop timeouts are longer than the application drain timeout.

## Metrics privacy boundary

- `/internal/metrics` is 404 by default and requires a validated 32–512-byte no-whitespace Bearer token when enabled; incorrect credentials return 401.
- Authentication compares fixed-length SHA-256 digests with constant-time comparison.
- Runtime-enforced fixed counter/gauge allowlists contain only aggregate values; unknown counter names fail before mutation. No dynamic labels, room/player/request identifiers, content, tokens, settings, or URL fragments are emitted.
- Public Nginx returns 404 for the exact metrics path even when the application token is configured. Metrics secrets are runtime-only and absent from image args, health, logs, snapshots, and this PR.

## Automated smoke

- Adds bounded shallow/deep release smoke with explicit health URL, WebSocket URL, expected server/protocol versions, timeout, and optional validated WebSocket Origin.
- Shallow mode is the default and does not create a room. Deep mode must be explicitly selected and covers synthetic create/join/disconnect/resume, projection privacy, and incompatible-protocol rejection.
- The local harness starts an origin-restricted ephemeral server, runs both modes, sends SIGTERM, and verifies clean exit plus closed port. Logs expose only stage/fixed code and PASS metadata.

## CI changes

Adds an independent Node 24 `Room Server Operability` job for room-server build/tests, origin-aware release smoke, the full 20-room/160-connection load test, production dependency audit, and `git diff --exit-code`. CI does not access production, use production secrets, deploy, create a Git Tag, or change manual acceptance status.

## Validation commands and actual results

- `npm ci` — PASS
- `npm run format:check` — PASS
- `npm run lint:check` — PASS
- `npm run type-check` — PASS
- `npm run validate-config` — PASS
- `npm test` — PASS, 41 files / 310 tests (43 new cases over the 267-test starting point)
- `npm run build` — PASS
- `npm run build:room-server` — PASS
- `npm run test:room-server` — PASS, 8 files / 55 tests
- `npm run test:room-server-load` — PASS, 20 rooms / 160 connections / 320 samples, RSS 77.4 MiB, P95 1.1 ms
- `npm run test:room-server-smoke` — PASS, origin-restricted shallow and deep harness
- `npm run test:e2e` — PASS, 67 passed / 59 project-conditional skipped; no skip scope was expanded
- `npm audit --omit=dev --audit-level=high` — PASS, 0 vulnerabilities
- `git diff --check origin/master...HEAD` — PASS
- Independent Standards and Spec reviews — PASS after all three findings were fixed and re-reviewed

## Docker verification

Built a local-only test image from `d775c0a8c76668899f489781411226e7f40b871f` with server version 1.15.0. Verified `USER node`, read-only root filesystem, 128 MiB/1 CPU limits, healthy `/health`, ready `/ready`, exact version/build/protocol values, metrics route 404 by default, no metrics token in image/container environment, and logs containing only the listening line. Origin-aware deep smoke passed. An idle SIGTERM exited 0 in 0.29 s; with a connected lobby blocker, `/health` remained 200, `/ready` returned 503, and the container exited 0 at the injected 2 s bound. All test containers were removed.

## Manual gates explicitly not executed

Manual physical-device and 4/6/8-person field acceptance remain
PENDING_MANUAL_ACCEPTANCE and are intentionally outside this PR.

No real iPhone/iPad Safari, Android Chrome, 4/6/8-person field game, screenshot/video review, production Discourse achievement claim, production secret operation, or production infrastructure/service change was performed. Acceptance files remain pending. No formal Git Tag was created.

## Deployment ordering

Build the web client and room server from one immutable commit; deploy the legacy-compatible room server first; verify internal readiness and target-version shallow smoke; deploy the frontend; repeat public shallow smoke; then run the separate physical-device and field-acceptance process. Do not mark the release complete before its anonymous evidence contract passes.

## Rollback

Stop new-room traffic, trigger bounded drain, restore the previous immutable room-server image/configuration, run that version's shallow smoke, and restore the previous static frontend only if protocol compatibility requires it. Rooms are in-memory and are not restored from disk/database. Never expose metrics or print credentials during rollback.

## Follow-ups

- Execute the separate iOS Safari, Android Chrome, and 4/6/8-person field acceptance after an authorized production release.
- Remove the temporary missing-protocol-to-v1 branch only after the old-page cache window is demonstrably closed.
- Create `v1.15.0` and deploy only in a separately authorized release operation after this PR is merged and all release gates are satisfied.
