### PR TITLE
test: add field-readiness and safe diagnostics automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,40 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  mobile-webkit-smoke:
+    name: Mobile WebKit Smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install WebKit
+        run: npx playwright install --with-deps webkit
+
+      - name: Run iPhone WebKit smoke
+        run: npm run test:e2e:webkit-smoke
+
+      - name: Upload WebKit failure traces
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-webkit-traces-${{ github.run_attempt }}
+          path: test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
   room-server-operability:
     name: Room Server Operability
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ npm install primevue primeicons
 - 匿名统计事件契约与隐私边界见 `src/services/gameTelemetry.ts`
 - 联机协议、运维、发布顺序与回滚合同见
   [docs/ONLINE_OPERABILITY.md](docs/ONLINE_OPERABILITY.md)
+- 生产核验时的固定 allowlist 报告与禁止采集项见
+  [docs/SAFE_PRODUCTION_DIAGNOSTICS.md](docs/SAFE_PRODUCTION_DIAGNOSTICS.md)
 - 版本号注入逻辑见 `vite-plugin-version.ts`
 - 详细开发路线、更新日志请见 [ROADMAP.md] 和 [RELEASE_NOTES.md]（如有）
 

--- a/apps/room-server/src/server.ts
+++ b/apps/room-server/src/server.ts
@@ -51,6 +51,13 @@ const DEFAULT_MESSAGES_PER_SECOND = 30
 const DEFAULT_MESSAGE_BURST = 60
 const DEFAULT_DRAIN_TIMEOUT_MS = 30 * 60 * 1_000
 const MAX_DRAIN_TIMEOUT_MS = 24 * 60 * 60 * 1_000
+const MAX_TRACKED_REQUEST_IDS = 1_024
+const PROTOCOL_ACCEPTANCE = Symbol('protocolAcceptance')
+
+type ProtocolAcceptance = 'legacy' | 'explicit'
+type ParsedClientMessage = ClientMessage & {
+  readonly [PROTOCOL_ACCEPTANCE]?: ProtocolAcceptance
+}
 
 interface RoomPlayer {
   readonly id: string
@@ -59,6 +66,7 @@ interface RoomPlayer {
   readonly color: string
   socket: WebSocket | null
   disconnectedAt: number | null
+  readonly acceptedRequestIds: Set<string>
 }
 
 interface Room {
@@ -99,6 +107,8 @@ export interface RoomServerOptions {
   readonly buildSha?: string
   readonly drainTimeoutMs?: number
   readonly metricsToken?: string
+  readonly scheduleGameMaintenance?: (callback: () => void) => () => void
+  readonly scheduleClientMessageHandling?: (callback: () => void) => void
 }
 
 export interface RunningRoomServer {
@@ -244,7 +254,7 @@ export async function createRoomServer(
   )
   cleanupTimer.unref()
 
-  const gameTimer = setInterval(() => {
+  const runGameMaintenance = () => {
     const timestamp = now()
     for (const room of rooms.values()) {
       let changed = transferExpiredHost(room, timestamp)
@@ -257,8 +267,14 @@ export async function createRoomServer(
       }
       if (changed) broadcastRoom(room)
     }
-  }, 100)
-  gameTimer.unref()
+  }
+  const stopGameMaintenance = options.scheduleGameMaintenance
+    ? options.scheduleGameMaintenance(runGameMaintenance)
+    : (() => {
+        const timer = setInterval(runGameMaintenance, 100)
+        timer.unref()
+        return () => clearInterval(timer)
+      })()
 
   const lastPongAt = new WeakMap<WebSocket, number>()
   const heartbeatTimer = setInterval(() => {
@@ -278,7 +294,7 @@ export async function createRoomServer(
     getSnapshot: getOperationalSnapshot,
     closeResources: async () => {
       clearInterval(cleanupTimer)
-      clearInterval(gameTimer)
+      stopGameMaintenance()
       clearInterval(heartbeatTimer)
       for (const socket of webSocketServer.clients) socket.terminate()
       await closeWebSocketServer(webSocketServer)
@@ -291,6 +307,7 @@ export async function createRoomServer(
     metrics.increment('connectionsOpenedTotal')
     let availableMessageTokens = messageBurst
     let lastMessageRefillAt = Date.now()
+    const acceptedInitialRequestIds = new Set<string>()
     lastPongAt.set(socket, Date.now())
     socket.on('pong', () => lastPongAt.set(socket, Date.now()))
     socket.on('message', raw => {
@@ -311,22 +328,47 @@ export async function createRoomServer(
         return
       }
       availableMessageTokens -= 1
-      let requestId: string | undefined
-      try {
-        const message = parseClientMessage(raw.toString())
-        requestId = message.requestId
-        handleMessage(socket, message)
-      } catch (error) {
-        const protocolError = normalizeError(error, requestId)
-        if (protocolError.code === 'INCOMPATIBLE_PROTOCOL') {
-          metrics.increment('protocolRejectedTotal')
+      const handleAcceptedFrame = () => {
+        let requestId: string | undefined
+        try {
+          const message = parseClientMessage(raw.toString())
+          requestId = message.requestId
+          const protocolAcceptance = message[PROTOCOL_ACCEPTANCE]
+          const playerForRequestTracking = protocolAcceptance
+            ? undefined
+            : sessions.get(socket)?.player
+          if (protocolAcceptance) {
+            acceptTrackedRequestId(acceptedInitialRequestIds, message.requestId)
+            metrics.increment(
+              protocolAcceptance === 'legacy'
+                ? 'legacyProtocolAcceptedTotal'
+                : 'explicitProtocolAcceptedTotal'
+            )
+          } else if (playerForRequestTracking) {
+            assertRequestIdCanBeAccepted(
+              playerForRequestTracking.acceptedRequestIds,
+              message.requestId
+            )
+          }
+          handleMessage(socket, message)
+          playerForRequestTracking?.acceptedRequestIds.add(message.requestId)
+        } catch (error) {
+          const protocolError = normalizeError(error, requestId)
+          if (protocolError.code === 'INCOMPATIBLE_PROTOCOL') {
+            metrics.increment('protocolRejectedTotal')
+          }
+          send(socket, {
+            type: 'error',
+            requestId: protocolError.requestId,
+            code: protocolError.code,
+            message: protocolError.message,
+          })
         }
-        send(socket, {
-          type: 'error',
-          requestId: protocolError.requestId,
-          code: protocolError.code,
-          message: protocolError.message,
-        })
+      }
+      if (options.scheduleClientMessageHandling) {
+        options.scheduleClientMessageHandling(handleAcceptedFrame)
+      } else {
+        handleAcceptedFrame()
       }
     })
     socket.on('close', () => {
@@ -414,33 +456,39 @@ export async function createRoomServer(
     }
 
     if (message.type === 'resume_room') {
-      if (sessions.has(socket)) {
-        throw new ProtocolError('ALREADY_JOINED', '当前连接已经加入房间', message.requestId)
+      metrics.increment('roomResumeAttemptsTotal')
+      try {
+        if (sessions.has(socket)) {
+          throw new ProtocolError('ALREADY_JOINED', '当前连接已经加入房间', message.requestId)
+        }
+        const room = rooms.get(message.roomCode.toUpperCase())
+        if (!room) throw new ProtocolError('ROOM_NOT_FOUND', '房间不存在', message.requestId)
+        const player = room.players.find(candidate => candidate.id === message.playerId)
+        if (!player || player.resumeToken !== message.resumeToken) {
+          throw new ProtocolError('INVALID_RESUME_TOKEN', '恢复凭证无效', message.requestId)
+        }
+        if (player.socket) {
+          sessions.delete(player.socket)
+          player.socket.close(4001, 'session resumed elsewhere')
+        }
+        player.socket = socket
+        player.disconnectedAt = null
+        player.resumeToken = randomBytes(24).toString('base64url')
+        sessions.set(socket, { room, player })
+        metrics.increment('roomResumesTotal')
+        sendSession(socket, room, player, message.requestId, serverVersion, serverBuildSha)
+        metrics.increment('roomResumeSucceededTotal')
+        broadcastRoom(room)
+        return
+      } catch (error) {
+        if (error instanceof ProtocolError) metrics.increment('roomResumeRejectedTotal')
+        throw error
       }
-      const room = rooms.get(message.roomCode.toUpperCase())
-      if (!room) throw new ProtocolError('ROOM_NOT_FOUND', '房间不存在', message.requestId)
-      const player = room.players.find(candidate => candidate.id === message.playerId)
-      if (!player || player.resumeToken !== message.resumeToken) {
-        throw new ProtocolError('INVALID_RESUME_TOKEN', '恢复凭证无效', message.requestId)
-      }
-      if (player.socket) {
-        sessions.delete(player.socket)
-        player.socket.close(4001, 'session resumed elsewhere')
-      }
-      player.socket = socket
-      player.disconnectedAt = null
-      player.resumeToken = randomBytes(24).toString('base64url')
-      sessions.set(socket, { room, player })
-      metrics.increment('roomResumesTotal')
-      sendSession(socket, room, player, message.requestId, serverVersion, serverBuildSha)
-      broadcastRoom(room)
-      return
     }
 
     const session = sessions.get(socket)
     if (!session) throw new ProtocolError('NOT_IN_ROOM', '请先创建或加入房间', message.requestId)
     const { room, player } = session
-
     if (message.type === 'transfer_host') {
       if (room.hostPlayerId !== player.id) {
         throw new ProtocolError('HOST_ONLY', '只有主持人可以转交管理角色', message.requestId)
@@ -794,7 +842,26 @@ function createPlayer(
     color,
     socket,
     disconnectedAt: null,
+    acceptedRequestIds: new Set(),
   }
+}
+
+function assertRequestIdCanBeAccepted(requestIds: ReadonlySet<string>, requestId: string): void {
+  if (requestIds.has(requestId)) {
+    throw new ProtocolError('DUPLICATE_REQUEST', '该请求已经处理，不会重复修改房间状态', requestId)
+  }
+  if (requestIds.size >= MAX_TRACKED_REQUEST_IDS) {
+    throw new ProtocolError(
+      'REQUEST_TRACKING_LIMIT_REACHED',
+      '请求追踪容量已满，已拒绝新请求',
+      requestId
+    )
+  }
+}
+
+function acceptTrackedRequestId(requestIds: Set<string>, requestId: string): void {
+  assertRequestIdCanBeAccepted(requestIds, requestId)
+  requestIds.add(requestId)
 }
 
 function colorsMatch(left: string, right: string): boolean {
@@ -826,7 +893,7 @@ function send(socket: WebSocket | null, message: ServerMessage): void {
   if (socket?.readyState === WebSocket.OPEN) socket.send(JSON.stringify(message))
 }
 
-function parseClientMessage(raw: string): ClientMessage {
+function parseClientMessage(raw: string): ParsedClientMessage {
   let value: unknown
   try {
     value = JSON.parse(raw)
@@ -841,7 +908,10 @@ function parseClientMessage(raw: string): ClientMessage {
     throw new ProtocolError('INVALID_MESSAGE', 'requestId 无效')
   }
   if (message.type === 'create_room' || message.type === 'join_room') {
-    const protocolVersion = parseOnlineProtocolVersion(message.protocolVersion, requestId)
+    const { protocolVersion, protocolAcceptance } = parseOnlineProtocolVersion(
+      message.protocolVersion,
+      requestId
+    )
     if (typeof message.nickname !== 'string' || typeof message.color !== 'string') {
       throw new ProtocolError('INVALID_MESSAGE', '玩家资料无效', requestId)
     }
@@ -856,6 +926,7 @@ function parseClientMessage(raw: string): ClientMessage {
         roomCode: message.roomCode,
         nickname: message.nickname,
         color: message.color,
+        [PROTOCOL_ACCEPTANCE]: protocolAcceptance,
       }
     }
     return {
@@ -864,10 +935,14 @@ function parseClientMessage(raw: string): ClientMessage {
       protocolVersion,
       nickname: message.nickname,
       color: message.color,
+      [PROTOCOL_ACCEPTANCE]: protocolAcceptance,
     }
   }
   if (message.type === 'resume_room') {
-    const protocolVersion = parseOnlineProtocolVersion(message.protocolVersion, requestId)
+    const { protocolVersion, protocolAcceptance } = parseOnlineProtocolVersion(
+      message.protocolVersion,
+      requestId
+    )
     if (
       typeof message.roomCode !== 'string' ||
       !/^[A-Z2-9]{6}$/i.test(message.roomCode) ||
@@ -885,6 +960,7 @@ function parseClientMessage(raw: string): ClientMessage {
       roomCode: message.roomCode,
       playerId: message.playerId,
       resumeToken: message.resumeToken,
+      [PROTOCOL_ACCEPTANCE]: protocolAcceptance,
     }
   }
   if (message.type === 'update_settings') {
@@ -1039,7 +1115,10 @@ function parseClientMessage(raw: string): ClientMessage {
   throw new ProtocolError('INVALID_MESSAGE', '未知消息类型', requestId)
 }
 
-function parseOnlineProtocolVersion(value: unknown, requestId: string): number {
+function parseOnlineProtocolVersion(
+  value: unknown,
+  requestId: string
+): Readonly<{ protocolVersion: number; protocolAcceptance: ProtocolAcceptance }> {
   const protocolVersion = resolveOnlineProtocolVersion(value)
   if (protocolVersion === null) {
     throw new ProtocolError(
@@ -1048,7 +1127,10 @@ function parseOnlineProtocolVersion(value: unknown, requestId: string): number {
       requestId
     )
   }
-  return protocolVersion
+  return {
+    protocolVersion,
+    protocolAcceptance: value === undefined ? 'legacy' : 'explicit',
+  }
 }
 
 function createUniqueRoomCode(rooms: ReadonlyMap<string, Room>): string {

--- a/apps/room-server/src/serverMetrics.ts
+++ b/apps/room-server/src/serverMetrics.ts
@@ -39,6 +39,11 @@ export const SERVER_METRIC_COUNTER_NAMES = [
   'roomsExpiredTotal',
   'protocolRejectedTotal',
   'rateLimitedMessagesTotal',
+  'legacyProtocolAcceptedTotal',
+  'explicitProtocolAcceptedTotal',
+  'roomResumeAttemptsTotal',
+  'roomResumeSucceededTotal',
+  'roomResumeRejectedTotal',
 ] as const
 
 export type ServerMetricCounterName = (typeof SERVER_METRIC_COUNTER_NAMES)[number]
@@ -47,7 +52,7 @@ type ServerMetricCounters = Readonly<Record<ServerMetricCounterName, number>>
 const SERVER_METRIC_COUNTER_NAME_SET: ReadonlySet<string> = new Set(SERVER_METRIC_COUNTER_NAMES)
 
 export interface ServerMetricsSnapshot {
-  readonly schemaVersion: 1
+  readonly schemaVersion: 2
   readonly counters: ServerMetricCounters
   readonly gauges: Readonly<{
     rooms: number
@@ -73,6 +78,11 @@ function createEmptyCounters(): Record<ServerMetricCounterName, number> {
     roomsExpiredTotal: 0,
     protocolRejectedTotal: 0,
     rateLimitedMessagesTotal: 0,
+    legacyProtocolAcceptedTotal: 0,
+    explicitProtocolAcceptedTotal: 0,
+    roomResumeAttemptsTotal: 0,
+    roomResumeSucceededTotal: 0,
+    roomResumeRejectedTotal: 0,
   }
 }
 
@@ -95,7 +105,7 @@ export class ServerMetrics {
     rssBytes = process.memoryUsage().rss
   ): ServerMetricsSnapshot {
     return {
-      schemaVersion: 1,
+      schemaVersion: 2,
       counters: { ...this.counters },
       gauges: {
         rooms: operational.rooms,

--- a/apps/room-server/test/lifecycle-chaos.test.ts
+++ b/apps/room-server/test/lifecycle-chaos.test.ts
@@ -1,0 +1,828 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import WebSocket from 'ws'
+import {
+  CURRENT_ONLINE_PROTOCOL_VERSION,
+  DEFAULT_ONLINE_ROOM_SETTINGS,
+  type OnlineRoomView,
+} from '@flying-chess/game-core'
+import { createRoomServer, type RunningRoomServer } from '../src/server'
+import type { ServerMessage } from '../src/protocol'
+
+const quietEventDeck = [
+  {
+    id: 'quiet-chaos-test',
+    title: '测试占位事件',
+    description: '确定性 lifecycle 测试不触发事件',
+    tags: ['test'],
+    trigger: { kind: 'every_n_turns' as const, interval: 100 },
+    effect: { kind: 'punishment_multiplier' as const, multiplier: 1, durationTurns: 1 },
+  },
+]
+
+class ChaosClient {
+  private readonly buffered: ServerMessage[] = []
+  private readonly history: ServerMessage[] = []
+  private readonly closed: Promise<void>
+  private readonly waiters: Array<{
+    predicate: (message: ServerMessage) => boolean
+    resolve: (message: ServerMessage) => void
+    reject: (error: Error) => void
+    timer: ReturnType<typeof setTimeout>
+  }> = []
+
+  private constructor(private readonly socket: WebSocket) {
+    this.closed = new Promise(resolve => socket.once('close', resolve))
+    socket.on('message', raw => {
+      const message = JSON.parse(raw.toString()) as ServerMessage
+      this.history.push(message)
+      const waiterIndex = this.waiters.findIndex(waiter => waiter.predicate(message))
+      if (waiterIndex < 0) {
+        this.buffered.push(message)
+        return
+      }
+      const [waiter] = this.waiters.splice(waiterIndex, 1)
+      clearTimeout(waiter.timer)
+      waiter.resolve(message)
+    })
+  }
+
+  static async connect(url: string): Promise<ChaosClient> {
+    const socket = new WebSocket(url)
+    await new Promise<void>((resolve, reject) => {
+      socket.once('open', resolve)
+      socket.once('error', reject)
+    })
+    return new ChaosClient(socket)
+  }
+
+  send(message: object): void {
+    this.socket.send(JSON.stringify(message))
+  }
+
+  receivedMessages(): readonly ServerMessage[] {
+    return this.history
+  }
+
+  waitForClose(): Promise<void> {
+    return this.socket.readyState === WebSocket.CLOSED ? Promise.resolve() : this.closed
+  }
+
+  next(predicate: (message: ServerMessage) => boolean, timeoutMs = 2_000): Promise<ServerMessage> {
+    const bufferedIndex = this.buffered.findIndex(predicate)
+    if (bufferedIndex >= 0) {
+      const [message] = this.buffered.splice(bufferedIndex, 1)
+      return Promise.resolve(message)
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const waiterIndex = this.waiters.findIndex(waiter => waiter.timer === timer)
+        if (waiterIndex >= 0) this.waiters.splice(waiterIndex, 1)
+        reject(new Error('timed out waiting for deterministic room-server message'))
+      }, timeoutMs)
+      this.waiters.push({ predicate, resolve, reject, timer })
+    })
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.socket.readyState === WebSocket.CLOSED) return
+    this.socket.close()
+    await this.closed
+  }
+}
+
+interface StartedRoom {
+  readonly host: ChaosClient
+  readonly guest: ChaosClient
+  readonly hostSession: Extract<ServerMessage, { type: 'session' }>
+  readonly guestSession: Extract<ServerMessage, { type: 'session' }>
+}
+
+async function createStartedRoom(
+  server: RunningRoomServer,
+  clients: ChaosClient[]
+): Promise<StartedRoom> {
+  const host = await ChaosClient.connect(server.wsUrl)
+  const guest = await ChaosClient.connect(server.wsUrl)
+  clients.push(host, guest)
+  host.send({
+    type: 'create_room',
+    requestId: 'chaos-create',
+    protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+    nickname: '主持人',
+    color: '#ff6b6b',
+  })
+  const hostSession = await host.next(message => message.type === 'session')
+  if (hostSession.type !== 'session') throw new Error('expected host session')
+  guest.send({
+    type: 'join_room',
+    requestId: 'chaos-join',
+    protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+    roomCode: hostSession.roomCode,
+    nickname: '玩家二',
+    color: '#4ecdc4',
+  })
+  const guestSession = await guest.next(message => message.type === 'session')
+  if (guestSession.type !== 'session') throw new Error('expected guest session')
+  host.send({ type: 'confirm_settings', requestId: 'chaos-confirm-host' })
+  guest.send({ type: 'confirm_settings', requestId: 'chaos-confirm-guest' })
+  await host.next(
+    message => message.type === 'room_state' && message.room.confirmedPlayerIds.length === 2
+  )
+  host.send({ type: 'start_game', requestId: 'chaos-start' })
+  await host.next(
+    message => message.type === 'room_state' && message.room.game?.status === 'playing'
+  )
+  return { host, guest, hostSession, guestSession }
+}
+
+function expectValidPlayingProjection(room: OnlineRoomView): void {
+  expect(room.status).toBe('playing')
+  expect(room.game?.status).toBe('playing')
+  expect(room.game?.players.some(player => player.id === room.game?.currentPlayerId)).toBe(true)
+  expect(JSON.stringify(room).includes('resumeToken')).toBe(false)
+}
+
+async function advanceHostToMove(host: ChaosClient, guest: ChaosClient, prefix: string) {
+  guest.send({
+    type: 'submit_prediction',
+    requestId: `${prefix}-prediction`,
+    prediction: 'high',
+  })
+  await host.next(
+    message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_roll'
+  )
+  host.send({ type: 'roll_dice', requestId: `${prefix}-roll` })
+  await guest.next(
+    message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_reaction'
+  )
+  guest.send({
+    type: 'decide_reaction',
+    requestId: `${prefix}-reaction`,
+    decision: 'keep',
+  })
+  return host.next(
+    message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_move'
+  )
+}
+
+describe('deterministic room lifecycle and chaos handling', () => {
+  let server: RunningRoomServer | undefined
+  const clients: ChaosClient[] = []
+  const unhandledRejections: unknown[] = []
+  const recordUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason)
+
+  beforeEach(() => {
+    process.on('unhandledRejection', recordUnhandledRejection)
+  })
+
+  afterEach(async () => {
+    process.off('unhandledRejection', recordUnhandledRejection)
+    await Promise.allSettled(clients.map(client => client.disconnect()))
+    clients.length = 0
+    await server?.close()
+    if (server) expect(server.getOperationalSnapshot().connections).toBe(0)
+    expect(unhandledRejections).toEqual([])
+    unhandledRejections.length = 0
+  })
+
+  it('applies a repeated move request at most once and returns a stable duplicate error', async () => {
+    server = await createRoomServer({ port: 0, rollDice: () => 6, eventDeck: quietEventDeck })
+    const { host, guest } = await createStartedRoom(server, clients)
+    await advanceHostToMove(host, guest, 'duplicate')
+
+    host.send({ type: 'move', requestId: 'same-move-request' })
+    const moved = await host.next(
+      message => message.type === 'room_state' && message.room.game?.players[0]?.position === 1
+    )
+    host.send({ type: 'move', requestId: 'same-move-request' })
+    await expect(
+      host.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'same-move-request' &&
+          message.code === 'DUPLICATE_REQUEST'
+      )
+    ).resolves.toMatchObject({ type: 'error', code: 'DUPLICATE_REQUEST' })
+
+    if (moved.type !== 'room_state') throw new Error('expected moved room state')
+    expect(moved.room.game?.players[0]?.position).toBe(1)
+    expectValidPlayingProjection(moved.room)
+  })
+
+  it('consumes a reroll token only once when the same request is delivered twice', async () => {
+    server = await createRoomServer({ port: 0, rollDice: () => 6, eventDeck: quietEventDeck })
+    const { host, guest } = await createStartedRoom(server, clients)
+    await advanceHostToMove(host, guest, 'duplicate-reroll')
+
+    host.send({ type: 'reroll', requestId: 'same-reroll-request' })
+    const rerolled = await host.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.game?.phase === 'awaiting_move' &&
+        message.room.game.myTokensRemaining === 1
+    )
+    host.send({ type: 'reroll', requestId: 'same-reroll-request' })
+    await expect(
+      host.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'same-reroll-request' &&
+          message.code === 'DUPLICATE_REQUEST'
+      )
+    ).resolves.toMatchObject({ type: 'error', code: 'DUPLICATE_REQUEST' })
+
+    if (rerolled.type !== 'room_state') throw new Error('expected rerolled room state')
+    expect(rerolled.room.game?.myTokensRemaining).toBe(1)
+    expectValidPlayingProjection(rerolled.room)
+  })
+
+  it('fails closed at request tracking capacity without forgetting the earliest accepted ID', async () => {
+    server = await createRoomServer({
+      port: 0,
+      rollDice: () => 6,
+      eventDeck: quietEventDeck,
+      messagesPerSecond: 2_048,
+      messageBurst: 2_048,
+    })
+    const host = await ChaosClient.connect(server.wsUrl)
+    clients.push(host)
+    host.send({
+      type: 'create_room',
+      requestId: 'capacity-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: '容量主持人',
+      color: '#ff6b6b',
+    })
+    const hostSession = await host.next(message => message.type === 'session')
+    if (hostSession.type !== 'session') throw new Error('expected capacity host session')
+
+    host.send({ type: 'confirm_settings', requestId: 'capacity-oldest-accepted-request' })
+    await host.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.confirmedPlayerIds.includes(hostSession.playerId)
+    )
+
+    for (let index = 0; index < 1_023; index += 1) {
+      host.send({ type: 'confirm_settings', requestId: `capacity-fill-${index}` })
+    }
+    host.send({ type: 'confirm_settings', requestId: 'capacity-overflow-request' })
+    await expect(
+      host.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'capacity-overflow-request' &&
+          message.code === 'REQUEST_TRACKING_LIMIT_REACHED',
+        5_000
+      )
+    ).resolves.toMatchObject({ type: 'error', code: 'REQUEST_TRACKING_LIMIT_REACHED' })
+
+    host.send({ type: 'confirm_settings', requestId: 'capacity-oldest-accepted-request' })
+    await expect(
+      host.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'capacity-oldest-accepted-request' &&
+          message.code === 'DUPLICATE_REQUEST'
+      )
+    ).resolves.toMatchObject({ type: 'error', code: 'DUPLICATE_REQUEST' })
+
+    const guest = await ChaosClient.connect(server.wsUrl)
+    clients.push(guest)
+    guest.send({
+      type: 'join_room',
+      requestId: 'capacity-state-probe',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: hostSession.roomCode,
+      nickname: '容量玩家二',
+      color: '#4ecdc4',
+    })
+    const guestSession = await guest.next(message => message.type === 'session')
+    if (guestSession.type !== 'session') throw new Error('expected capacity guest session')
+    const probed = await host.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.players.some(player => player.id === guestSession.playerId)
+    )
+    if (probed.type !== 'room_state') throw new Error('expected capacity probe room state')
+    expect(probed.room.status).toBe('lobby')
+    expect(probed.room.players.some(player => player.id === probed.room.hostPlayerId)).toBe(true)
+    expect(JSON.stringify(probed.room).includes('resumeToken')).toBe(false)
+  })
+
+  it('fences a stale socket after resume and sends the new private session only to its owner', async () => {
+    let delayNextMessage = false
+    let delayedMessageHandler: (() => void) | undefined
+    let markDelayedMessageReceived: (() => void) | undefined
+    const delayedMessageReceived = new Promise<void>(resolve => {
+      markDelayedMessageReceived = resolve
+    })
+    server = await createRoomServer({
+      port: 0,
+      rollDice: () => 6,
+      eventDeck: quietEventDeck,
+      scheduleClientMessageHandling: callback => {
+        if (!delayNextMessage) {
+          callback()
+          return
+        }
+        delayNextMessage = false
+        delayedMessageHandler = callback
+        markDelayedMessageReceived?.()
+      },
+    })
+    const { host, guest, guestSession } = await createStartedRoom(server, clients)
+    delayNextMessage = true
+    guest.send({
+      type: 'submit_prediction',
+      requestId: 'stale-socket-late-prediction',
+      prediction: 'high',
+    })
+    await delayedMessageReceived
+
+    const resumed = await ChaosClient.connect(server.wsUrl)
+    clients.push(resumed)
+    resumed.send({
+      type: 'resume_room',
+      requestId: 'stale-socket-resume',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: guestSession.roomCode,
+      playerId: guestSession.playerId,
+      resumeToken: guestSession.resumeToken,
+    })
+    const resumedSession = await resumed.next(message => message.type === 'session')
+    if (resumedSession.type !== 'session') throw new Error('expected resumed session')
+
+    if (!delayedMessageHandler) throw new Error('expected delayed stale message handler')
+    delayedMessageHandler()
+    await guest.waitForClose()
+    resumed.send({ type: 'pause_game', requestId: 'stale-socket-state-probe' })
+    const probed = await host.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.pauseRequestedPlayerIds.includes(guestSession.playerId)
+    )
+    if (probed.type !== 'room_state') throw new Error('expected probed room state')
+    expect(probed.room.game?.phase).toBe('awaiting_prediction')
+    expectValidPlayingProjection(probed.room)
+
+    const serializedHost = JSON.stringify(host.receivedMessages())
+    const serializedStaleGuest = JSON.stringify(guest.receivedMessages())
+    const serializedResumed = JSON.stringify(resumed.receivedMessages())
+    expect(serializedHost.includes(resumedSession.resumeToken)).toBe(false)
+    expect(serializedStaleGuest.includes(resumedSession.resumeToken)).toBe(false)
+    expect(serializedResumed.includes(resumedSession.resumeToken)).toBe(true)
+
+    resumed.send({
+      type: 'submit_prediction',
+      requestId: 'resumed-socket-valid-prediction',
+      prediction: 'high',
+    })
+    await expect(
+      host.next(
+        message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_roll'
+      )
+    ).resolves.toMatchObject({ type: 'room_state' })
+  })
+
+  it('preserves a private RPS action across disconnects without exposing the hidden choice', async () => {
+    server = await createRoomServer({
+      port: 0,
+      rollDice: () => 6,
+      eventDeck: [
+        {
+          id: 'chaos-private-rps',
+          title: '全员猜拳',
+          description: '秘密出拳后统一揭晓',
+          tags: ['test'],
+          trigger: { kind: 'every_n_turns', interval: 1 },
+          effect: { kind: 'rock_paper_scissors' },
+        },
+      ],
+    })
+    const { host, guest, guestSession } = await createStartedRoom(server, clients)
+    await advanceHostToMove(host, guest, 'private-rps')
+    host.send({ type: 'move', requestId: 'private-rps-move' })
+    await guest.next(
+      message =>
+        message.type === 'room_state' && message.room.game?.pendingAction?.kind === 'event_rps'
+    )
+
+    await guest.disconnect()
+    const firstResume = await ChaosClient.connect(server.wsUrl)
+    clients.push(firstResume)
+    firstResume.send({
+      type: 'resume_room',
+      requestId: 'private-rps-first-resume',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: guestSession.roomCode,
+      playerId: guestSession.playerId,
+      resumeToken: guestSession.resumeToken,
+    })
+    const firstResumedSession = await firstResume.next(message => message.type === 'session')
+    if (firstResumedSession.type !== 'session') throw new Error('expected first resumed session')
+    await firstResume.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.game?.pendingAction?.kind === 'event_rps' &&
+        message.room.game.allowedCommands.includes('rps')
+    )
+
+    firstResume.send({ type: 'rps', requestId: 'private-rps-choice', choice: 'scissors' })
+    const publicSubmission = await host.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.game?.pendingAction?.kind === 'event_rps' &&
+        message.room.game.pendingAction.submittedCount === 1
+    )
+    expect(JSON.stringify(publicSubmission).includes('scissors')).toBe(false)
+    expect(JSON.stringify(publicSubmission).includes('choices')).toBe(false)
+
+    await firstResume.disconnect()
+    const secondResume = await ChaosClient.connect(server.wsUrl)
+    clients.push(secondResume)
+    secondResume.send({
+      type: 'resume_room',
+      requestId: 'private-rps-second-resume',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: firstResumedSession.roomCode,
+      playerId: firstResumedSession.playerId,
+      resumeToken: firstResumedSession.resumeToken,
+    })
+    await secondResume.next(message => message.type === 'session')
+    const restoredPrivateView = await secondResume.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.game?.pendingAction?.kind === 'event_rps' &&
+        message.room.game.pendingAction.hasSubmitted === true
+    )
+    expect(JSON.stringify(restoredPrivateView).includes('scissors')).toBe(false)
+    if (restoredPrivateView.type !== 'room_state') throw new Error('expected restored room state')
+    expect(restoredPrivateView.room.game?.allowedCommands.includes('rps')).toBe(false)
+    expectValidPlayingProjection(restoredPrivateView.room)
+
+    host.send({ type: 'rps', requestId: 'private-rps-host-choice', choice: 'rock' })
+    await expect(
+      secondResume.next(
+        message =>
+          message.type === 'room_state' && message.room.game?.pendingAction?.kind === 'event_result'
+      )
+    ).resolves.toMatchObject({ type: 'room_state' })
+  })
+
+  it('transfers host once at grace expiry and never lets the original host reclaim it on resume', async () => {
+    let now = 1_000
+    let runMaintenance: (() => void) | undefined
+    let maintenanceStopped = false
+    server = await createRoomServer({
+      port: 0,
+      now: () => now,
+      reconnectGraceMs: 100,
+      rollDice: () => 6,
+      eventDeck: quietEventDeck,
+      scheduleGameMaintenance: callback => {
+        runMaintenance = callback
+        return () => {
+          maintenanceStopped = true
+        }
+      },
+    })
+    const { host, guest, hostSession, guestSession } = await createStartedRoom(server, clients)
+    await host.disconnect()
+    now += 100
+    if (!runMaintenance) throw new Error('expected deterministic maintenance callback')
+    runMaintenance()
+
+    const transferred = await guest.next(
+      message =>
+        message.type === 'room_state' && message.room.hostPlayerId === guestSession.playerId
+    )
+    if (transferred.type !== 'room_state') throw new Error('expected transferred room state')
+    expect(
+      transferred.room.players.filter(player => player.id === transferred.room.hostPlayerId)
+    ).toHaveLength(1)
+    expectValidPlayingProjection(transferred.room)
+
+    const originalHostResumed = await ChaosClient.connect(server.wsUrl)
+    clients.push(originalHostResumed)
+    originalHostResumed.send({
+      type: 'resume_room',
+      requestId: 'host-race-resume-original',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: hostSession.roomCode,
+      playerId: hostSession.playerId,
+      resumeToken: hostSession.resumeToken,
+    })
+    const resumedSession = await originalHostResumed.next(message => message.type === 'session')
+    if (resumedSession.type !== 'session') throw new Error('expected original host resume session')
+    expect(resumedSession.isHost).toBe(false)
+    const resumedRoom = await originalHostResumed.next(
+      message =>
+        message.type === 'room_state' && message.room.hostPlayerId === guestSession.playerId
+    )
+    if (resumedRoom.type !== 'room_state') throw new Error('expected resumed room state')
+    expect(
+      resumedRoom.room.players.filter(player => player.id === resumedRoom.room.hostPlayerId)
+    ).toHaveLength(1)
+
+    originalHostResumed.send({
+      type: 'transfer_host',
+      requestId: 'host-race-old-host-transfer',
+      playerId: hostSession.playerId,
+    })
+    await expect(
+      originalHostResumed.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'host-race-old-host-transfer' &&
+          message.code === 'HOST_ONLY'
+      )
+    ).resolves.toMatchObject({ type: 'error', code: 'HOST_ONLY' })
+
+    await server.close()
+    expect(maintenanceStopped).toBe(true)
+  })
+
+  it('applies the user action once when it reaches the deadline boundary before the timer tick', async () => {
+    let now = 1_000
+    let runMaintenance: (() => void) | undefined
+    server = await createRoomServer({
+      port: 0,
+      now: () => now,
+      rollDice: () => 6,
+      eventDeck: quietEventDeck,
+      scheduleGameMaintenance: callback => {
+        runMaintenance = callback
+        return () => undefined
+      },
+    })
+    const { host, guest, guestSession } = await createStartedRoom(server, clients)
+    const waiting = await guest.next(
+      message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_prediction'
+    )
+    if (waiting.type !== 'room_state' || waiting.room.game?.deadlineAt == null) {
+      throw new Error('expected prediction deadline')
+    }
+    now = waiting.room.game.deadlineAt
+
+    guest.send({
+      type: 'submit_prediction',
+      requestId: 'race-action-first-prediction',
+      prediction: 'high',
+    })
+    const actionResult = await host.next(
+      message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_roll'
+    )
+    if (!runMaintenance) throw new Error('expected deterministic maintenance callback')
+    runMaintenance()
+    guest.send({ type: 'pause_game', requestId: 'race-action-first-probe' })
+    const probed = await host.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.pauseRequestedPlayerIds.includes(guestSession.playerId)
+    )
+    if (actionResult.type !== 'room_state' || probed.type !== 'room_state') {
+      throw new Error('expected action-first room states')
+    }
+    expect(probed.room.game?.phase).toBe('awaiting_roll')
+    expect(probed.room.game?.revision).toBe(actionResult.room.game?.revision)
+    expect(probed.room.game?.pendingAction).toBeNull()
+    expectValidPlayingProjection(probed.room)
+  })
+
+  it('applies the timeout once and rejects the late user action at the same deadline boundary', async () => {
+    let now = 1_000
+    let runMaintenance: (() => void) | undefined
+    server = await createRoomServer({
+      port: 0,
+      now: () => now,
+      rollDice: () => 6,
+      eventDeck: quietEventDeck,
+      scheduleGameMaintenance: callback => {
+        runMaintenance = callback
+        return () => undefined
+      },
+    })
+    const { host, guest, guestSession } = await createStartedRoom(server, clients)
+    const waiting = await guest.next(
+      message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_prediction'
+    )
+    if (waiting.type !== 'room_state' || waiting.room.game?.deadlineAt == null) {
+      throw new Error('expected prediction deadline')
+    }
+    now = waiting.room.game.deadlineAt
+    if (!runMaintenance) throw new Error('expected deterministic maintenance callback')
+    runMaintenance()
+    const timeoutResult = await host.next(
+      message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_roll'
+    )
+
+    guest.send({
+      type: 'submit_prediction',
+      requestId: 'race-timeout-first-late-prediction',
+      prediction: 'high',
+    })
+    await expect(
+      guest.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'race-timeout-first-late-prediction' &&
+          message.code === 'INVALID_PHASE'
+      )
+    ).resolves.toMatchObject({ type: 'error', code: 'INVALID_PHASE' })
+    guest.send({ type: 'pause_game', requestId: 'race-timeout-first-probe' })
+    const probed = await host.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.pauseRequestedPlayerIds.includes(guestSession.playerId)
+    )
+    if (timeoutResult.type !== 'room_state' || probed.type !== 'room_state') {
+      throw new Error('expected timeout-first room states')
+    }
+    expect(probed.room.game?.phase).toBe('awaiting_roll')
+    expect(probed.room.game?.revision).toBe(timeoutResult.room.game?.revision)
+    expect(probed.room.game?.pendingAction).toBeNull()
+    expectValidPlayingProjection(probed.room)
+  })
+
+  it('drains deterministically while an existing room joins, resumes, plays, and finishes once', async () => {
+    let now = 0
+    const diceValues = [6, 6, 2, 5]
+    const metricsToken = 'FAKE_METRICS_TOKEN_FOR_CHAOS_TEST_ONLY_32_BYTES'
+    server = await createRoomServer({
+      port: 0,
+      now: () => now,
+      rollDice: () => diceValues.shift() ?? 1,
+      eventDeck: quietEventDeck,
+      drainTimeoutMs: 5_000,
+      metricsToken,
+      scheduleGameMaintenance: () => () => undefined,
+    })
+    const host = await ChaosClient.connect(server.wsUrl)
+    clients.push(host)
+    host.send({
+      type: 'create_room',
+      requestId: 'drain-chaos-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: '排空主持人',
+      color: '#ff6b6b',
+    })
+    const hostSession = await host.next(message => message.type === 'session')
+    if (hostSession.type !== 'session') throw new Error('expected drain host session')
+
+    const draining = server.beginDrain()
+    const baseUrl = server.wsUrl.replace('ws://', 'http://')
+    const health = await fetch(`${baseUrl}/health`)
+    const ready = await fetch(`${baseUrl}/ready`)
+    expect(health.status).toBe(200)
+    expect(ready.status).toBe(503)
+
+    const rejected = await ChaosClient.connect(server.wsUrl)
+    clients.push(rejected)
+    rejected.send({
+      type: 'create_room',
+      requestId: 'drain-chaos-rejected-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: '排空后新玩家',
+      color: '#45b7d1',
+    })
+    await expect(
+      rejected.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'drain-chaos-rejected-create' &&
+          message.code === 'SERVER_DRAINING'
+      )
+    ).resolves.toMatchObject({ type: 'error', code: 'SERVER_DRAINING' })
+
+    const guest = await ChaosClient.connect(server.wsUrl)
+    clients.push(guest)
+    guest.send({
+      type: 'join_room',
+      requestId: 'drain-chaos-existing-join',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: hostSession.roomCode,
+      nickname: '排空房间玩家二',
+      color: '#4ecdc4',
+    })
+    const guestSession = await guest.next(message => message.type === 'session')
+    if (guestSession.type !== 'session') throw new Error('expected drain guest session')
+    host.send({
+      type: 'update_settings',
+      requestId: 'drain-chaos-settings',
+      settings: {
+        ...DEFAULT_ONLINE_ROOM_SETTINGS,
+        boardConfig: {
+          punishmentCells: 0,
+          chainPunishmentCells: 0,
+          bonusCells: 0,
+          reverseCells: 0,
+          restCells: 0,
+          restartCells: 0,
+          trapCells: 0,
+          qaCells: 0,
+          dareCells: 0,
+          totalCells: 20,
+        },
+      },
+    })
+    await host.next(
+      message =>
+        message.type === 'room_state' && message.room.settings.boardConfig.totalCells === 20
+    )
+
+    await guest.disconnect()
+    const resumed = await ChaosClient.connect(server.wsUrl)
+    clients.push(resumed)
+    resumed.send({
+      type: 'resume_room',
+      requestId: 'drain-chaos-existing-resume',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: guestSession.roomCode,
+      playerId: guestSession.playerId,
+      resumeToken: guestSession.resumeToken,
+    })
+    await resumed.next(message => message.type === 'session')
+    host.send({ type: 'confirm_settings', requestId: 'drain-chaos-confirm-host' })
+    resumed.send({ type: 'confirm_settings', requestId: 'drain-chaos-confirm-guest' })
+    await host.next(
+      message => message.type === 'room_state' && message.room.confirmedPlayerIds.length === 2
+    )
+    host.send({ type: 'start_game', requestId: 'drain-chaos-start' })
+    await host.next(
+      message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_prediction'
+    )
+
+    now = 20 * 60_000 + 1
+    resumed.send({
+      type: 'submit_prediction',
+      requestId: 'drain-chaos-prediction',
+      prediction: 'high',
+    })
+    await host.next(
+      message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_roll'
+    )
+    host.send({ type: 'roll_dice', requestId: 'drain-chaos-host-roll' })
+    await resumed.next(
+      message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_reaction'
+    )
+    resumed.send({
+      type: 'decide_reaction',
+      requestId: 'drain-chaos-reaction',
+      decision: 'keep',
+    })
+    await host.next(
+      message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_move'
+    )
+    host.send({ type: 'move', requestId: 'drain-chaos-host-move' })
+    await resumed.next(
+      message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_roll'
+    )
+    resumed.send({ type: 'roll_dice', requestId: 'drain-chaos-guest-roll' })
+    await resumed.next(
+      message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_move'
+    )
+    resumed.send({ type: 'move', requestId: 'drain-chaos-guest-move' })
+    await host.next(
+      message => message.type === 'room_state' && message.room.game?.phase === 'awaiting_tiebreak'
+    )
+    host.send({ type: 'tiebreak_roll', requestId: 'drain-chaos-host-tiebreak' })
+    await resumed.next(
+      message =>
+        message.type === 'room_state' &&
+        message.room.game?.phase === 'awaiting_tiebreak' &&
+        message.room.game.currentPlayerId === guestSession.playerId
+    )
+    resumed.send({ type: 'tiebreak_roll', requestId: 'drain-chaos-final-tiebreak' })
+    const finished = await host.next(
+      message => message.type === 'room_state' && message.room.game?.status === 'finished'
+    )
+    if (finished.type !== 'room_state') throw new Error('expected finished room state')
+    expect(finished.room.status).toBe('finished')
+    expect(finished.room.game?.status).toBe('finished')
+
+    resumed.send({ type: 'tiebreak_roll', requestId: 'drain-chaos-final-tiebreak' })
+    await expect(
+      resumed.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'drain-chaos-final-tiebreak' &&
+          message.code === 'DUPLICATE_REQUEST'
+      )
+    ).resolves.toMatchObject({ type: 'error', code: 'DUPLICATE_REQUEST' })
+    const metricsResponse = await fetch(`${baseUrl}/internal/metrics`, {
+      headers: { authorization: `Bearer ${metricsToken}` },
+    })
+    await expect(metricsResponse.json()).resolves.toMatchObject({
+      counters: { gamesFinishedTotal: 1 },
+    })
+
+    await Promise.all([host.disconnect(), resumed.disconnect()])
+    await draining
+    expect(server.getOperationalSnapshot()).toMatchObject({
+      activeGames: 0,
+      connections: 0,
+      drainBlockingRooms: 0,
+    })
+  })
+})

--- a/apps/room-server/test/operability.test.ts
+++ b/apps/room-server/test/operability.test.ts
@@ -328,6 +328,7 @@ describe('room server operability', () => {
     expect(response.status).toBe(200)
     const metrics = (await response.json()) as Record<string, unknown>
     expect(Object.keys(metrics)).toEqual(['schemaVersion', 'counters', 'gauges'])
+    expect(metrics.schemaVersion).toBe(2)
     expect(Object.keys(metrics.counters as object)).toEqual([
       'connectionsOpenedTotal',
       'connectionsClosedTotal',
@@ -340,6 +341,11 @@ describe('room server operability', () => {
       'roomsExpiredTotal',
       'protocolRejectedTotal',
       'rateLimitedMessagesTotal',
+      'legacyProtocolAcceptedTotal',
+      'explicitProtocolAcceptedTotal',
+      'roomResumeAttemptsTotal',
+      'roomResumeSucceededTotal',
+      'roomResumeRejectedTotal',
     ])
     expect(Object.keys(metrics.gauges as object)).toEqual([
       'rooms',
@@ -376,5 +382,246 @@ describe('room server operability', () => {
     const response = await fetch(`${httpBase(server)}/internal/metrics`)
 
     expect(response.status).toBe(404)
+  })
+
+  it('counts legacy and explicit protocol acceptance once per initial request', async () => {
+    const metricsToken = 'FAKE_METRICS_TOKEN_FOR_PROTOCOL_COUNT_TEST_ONLY_32_BYTES'
+    server = await createRoomServer({ port: 0, metricsToken })
+    const legacyHost = await OperabilityClient.connect(server.wsUrl)
+    const explicitGuest = await OperabilityClient.connect(server.wsUrl)
+    const explicitHost = await OperabilityClient.connect(server.wsUrl)
+    const incompatible = await OperabilityClient.connect(server.wsUrl)
+    clients.push(legacyHost, explicitGuest, explicitHost, incompatible)
+
+    legacyHost.send({
+      type: 'create_room',
+      requestId: 'metrics-legacy-create',
+      nickname: '旧协议主持人',
+      color: '#ff6b6b',
+    })
+    const legacySession = await legacyHost.next(message => message.type === 'session')
+    if (legacySession.type !== 'session') throw new Error('expected legacy session')
+    explicitGuest.send({
+      type: 'join_room',
+      requestId: 'metrics-explicit-join',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: legacySession.roomCode,
+      nickname: '显式协议加入者',
+      color: '#4ecdc4',
+    })
+    await explicitGuest.next(message => message.type === 'session')
+    explicitHost.send({
+      type: 'create_room',
+      requestId: 'metrics-explicit-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: '显式协议主持人',
+      color: '#45b7d1',
+    })
+    await explicitHost.next(message => message.type === 'session')
+    explicitHost.send({
+      type: 'create_room',
+      requestId: 'metrics-explicit-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: '显式协议主持人',
+      color: '#45b7d1',
+    })
+    await expect(
+      explicitHost.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'metrics-explicit-create' &&
+          message.code === 'DUPLICATE_REQUEST'
+      )
+    ).resolves.toMatchObject({ type: 'error', code: 'DUPLICATE_REQUEST' })
+    incompatible.send({
+      type: 'create_room',
+      requestId: 'metrics-incompatible-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION + 1,
+      nickname: '不兼容协议',
+      color: '#96ceb4',
+    })
+    await incompatible.next(
+      message => message.type === 'error' && message.code === 'INCOMPATIBLE_PROTOCOL'
+    )
+
+    const response = await fetch(`${httpBase(server)}/internal/metrics`, {
+      headers: { authorization: `Bearer ${metricsToken}` },
+    })
+    await expect(response.json()).resolves.toMatchObject({
+      schemaVersion: 2,
+      counters: {
+        legacyProtocolAcceptedTotal: 1,
+        explicitProtocolAcceptedTotal: 2,
+        protocolRejectedTotal: 1,
+        roomsCreatedTotal: 2,
+        roomJoinsTotal: 1,
+      },
+    })
+  })
+
+  it('counts resume attempts, successes, and business rejections without incompatible or duplicate inflation', async () => {
+    const metricsToken = 'FAKE_METRICS_TOKEN_FOR_RESUME_COUNT_TEST_ONLY_32_BYTES'
+    server = await createRoomServer({ port: 0, metricsToken })
+    const host = await OperabilityClient.connect(server.wsUrl)
+    const guest = await OperabilityClient.connect(server.wsUrl)
+    clients.push(host, guest)
+    host.send({
+      type: 'create_room',
+      requestId: 'resume-metrics-create',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      nickname: '恢复指标主持人',
+      color: '#ff6b6b',
+    })
+    const hostSession = await host.next(message => message.type === 'session')
+    if (hostSession.type !== 'session') throw new Error('expected metrics host session')
+    guest.send({
+      type: 'join_room',
+      requestId: 'resume-metrics-legacy-join',
+      roomCode: hostSession.roomCode,
+      nickname: '恢复指标玩家',
+      color: '#4ecdc4',
+    })
+    const guestSession = await guest.next(message => message.type === 'session')
+    if (guestSession.type !== 'session') throw new Error('expected metrics guest session')
+    await guest.disconnect()
+
+    const resumed = await OperabilityClient.connect(server.wsUrl)
+    clients.push(resumed)
+    const successfulResume = {
+      type: 'resume_room',
+      requestId: 'resume-metrics-success',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: guestSession.roomCode,
+      playerId: guestSession.playerId,
+      resumeToken: guestSession.resumeToken,
+    }
+    resumed.send(successfulResume)
+    await resumed.next(message => message.type === 'session')
+    resumed.send(successfulResume)
+    await expect(
+      resumed.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'resume-metrics-success' &&
+          message.code === 'DUPLICATE_REQUEST'
+      )
+    ).resolves.toMatchObject({ type: 'error', code: 'DUPLICATE_REQUEST' })
+
+    const invalidToken = await OperabilityClient.connect(server.wsUrl)
+    clients.push(invalidToken)
+    invalidToken.send({
+      type: 'resume_room',
+      requestId: 'resume-metrics-invalid-token',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: guestSession.roomCode,
+      playerId: guestSession.playerId,
+      resumeToken: 'FAKE_INVALID_RESUME_TOKEN_FOR_METRICS_TEST_ONLY',
+    })
+    await invalidToken.next(
+      message => message.type === 'error' && message.code === 'INVALID_RESUME_TOKEN'
+    )
+
+    const missingRoom = await OperabilityClient.connect(server.wsUrl)
+    clients.push(missingRoom)
+    missingRoom.send({
+      type: 'resume_room',
+      requestId: 'resume-metrics-missing-room',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: 'ZZZ999',
+      playerId: guestSession.playerId,
+      resumeToken: 'FAKE_RESUME_TOKEN_FOR_MISSING_ROOM_TEST_ONLY',
+    })
+    await missingRoom.next(message => message.type === 'error' && message.code === 'ROOM_NOT_FOUND')
+
+    const incompatible = await OperabilityClient.connect(server.wsUrl)
+    clients.push(incompatible)
+    incompatible.send({
+      type: 'resume_room',
+      requestId: 'resume-metrics-incompatible',
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION + 1,
+      roomCode: guestSession.roomCode,
+      playerId: guestSession.playerId,
+      resumeToken: 'FAKE_RESUME_TOKEN_FOR_INCOMPATIBLE_TEST_ONLY',
+    })
+    await incompatible.next(
+      message => message.type === 'error' && message.code === 'INCOMPATIBLE_PROTOCOL'
+    )
+
+    const response = await fetch(`${httpBase(server)}/internal/metrics`, {
+      headers: { authorization: `Bearer ${metricsToken}` },
+    })
+    await expect(response.json()).resolves.toMatchObject({
+      schemaVersion: 2,
+      counters: {
+        legacyProtocolAcceptedTotal: 1,
+        explicitProtocolAcceptedTotal: 4,
+        roomResumeAttemptsTotal: 3,
+        roomResumeSucceededTotal: 1,
+        roomResumeRejectedTotal: 2,
+        roomResumesTotal: 1,
+        protocolRejectedTotal: 1,
+      },
+    })
+  })
+
+  it('fails closed at initial request tracking capacity without recounting an evicted ID', async () => {
+    const metricsToken = 'FAKE_METRICS_TOKEN_FOR_CAPACITY_TEST_ONLY_32_BYTES'
+    server = await createRoomServer({
+      port: 0,
+      metricsToken,
+      messagesPerSecond: 2_048,
+      messageBurst: 2_048,
+    })
+    const client = await OperabilityClient.connect(server.wsUrl)
+    clients.push(client)
+    const initialRequest = (requestId: string) => ({
+      type: 'join_room',
+      requestId,
+      protocolVersion: CURRENT_ONLINE_PROTOCOL_VERSION,
+      roomCode: 'ZZZ999',
+      nickname: '容量测试玩家',
+      color: '#ff6b6b',
+    })
+
+    for (let index = 0; index < 1_024; index += 1) {
+      client.send(initialRequest(`protocol-capacity-${index}`))
+    }
+    await client.next(
+      message =>
+        message.type === 'error' &&
+        message.requestId === 'protocol-capacity-1023' &&
+        message.code === 'ROOM_NOT_FOUND'
+    )
+
+    client.send(initialRequest('protocol-capacity-0'))
+    await expect(
+      client.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'protocol-capacity-0' &&
+          message.code === 'DUPLICATE_REQUEST'
+      )
+    ).resolves.toMatchObject({ type: 'error', code: 'DUPLICATE_REQUEST' })
+
+    client.send(initialRequest('protocol-capacity-overflow'))
+    await expect(
+      client.next(
+        message =>
+          message.type === 'error' &&
+          message.requestId === 'protocol-capacity-overflow' &&
+          message.code === 'REQUEST_TRACKING_LIMIT_REACHED'
+      )
+    ).resolves.toMatchObject({ type: 'error', code: 'REQUEST_TRACKING_LIMIT_REACHED' })
+
+    const response = await fetch(`${httpBase(server)}/internal/metrics`, {
+      headers: { authorization: `Bearer ${metricsToken}` },
+    })
+    await expect(response.json()).resolves.toMatchObject({
+      schemaVersion: 2,
+      counters: {
+        explicitProtocolAcceptedTotal: 1_024,
+        roomJoinsTotal: 0,
+      },
+    })
   })
 })

--- a/apps/room-server/test/serverMetrics.test.ts
+++ b/apps/room-server/test/serverMetrics.test.ts
@@ -28,6 +28,7 @@ describe('server metrics', () => {
     )
 
     expect(Object.keys(snapshot)).toEqual(['schemaVersion', 'counters', 'gauges'])
+    expect(snapshot.schemaVersion).toBe(2)
     expect(Object.keys(snapshot.counters)).toEqual([
       'connectionsOpenedTotal',
       'connectionsClosedTotal',
@@ -40,11 +41,21 @@ describe('server metrics', () => {
       'roomsExpiredTotal',
       'protocolRejectedTotal',
       'rateLimitedMessagesTotal',
+      'legacyProtocolAcceptedTotal',
+      'explicitProtocolAcceptedTotal',
+      'roomResumeAttemptsTotal',
+      'roomResumeSucceededTotal',
+      'roomResumeRejectedTotal',
     ])
     expect(snapshot.counters).toMatchObject({
       connectionsOpenedTotal: 1,
       roomsCreatedTotal: 2,
       protocolRejectedTotal: 0,
+      legacyProtocolAcceptedTotal: 0,
+      explicitProtocolAcceptedTotal: 0,
+      roomResumeAttemptsTotal: 0,
+      roomResumeSucceededTotal: 0,
+      roomResumeRejectedTotal: 0,
     })
     expect(snapshot.gauges).toEqual({
       rooms: 2,

--- a/docs/ONLINE_OPERABILITY.md
+++ b/docs/ONLINE_OPERABILITY.md
@@ -76,17 +76,36 @@ Drain blocker 定义如下：
 `ROOM_METRICS_TOKEN`：必须为 32–512 字节、不得含空白；请求使用
 `Authorization: Bearer <token>`。服务端比较固定长度 SHA-256 摘要并调用恒定时间比较，错误或缺失 token 返回 `401`。token 不写入镜像层、日志、health、测试快照或 PR。
 
-响应只有三个顶层字段：`schemaVersion`、`counters`、`gauges`。计数器 allowlist 为：
+响应 schema version 为 `2`，只有三个顶层字段：`schemaVersion`、`counters`、`gauges`。
+计数器 allowlist 为：
 
 - `connectionsOpenedTotal`、`connectionsClosedTotal`
 - `roomsCreatedTotal`、`roomJoinsTotal`、`roomResumesTotal`
 - `gamesStartedTotal`、`gamesFinishedTotal`、`hostTransfersTotal`、`roomsExpiredTotal`
 - `protocolRejectedTotal`、`rateLimitedMessagesTotal`
+- `legacyProtocolAcceptedTotal`、`explicitProtocolAcceptedTotal`
+- `roomResumeAttemptsTotal`、`roomResumeSucceededTotal`、`roomResumeRejectedTotal`
 
 仪表 allowlist 为 `rooms`、`activeGames`、`connections`、`drainBlockingRooms`、
 `draining`、`rssBytes`、`uptimeSeconds`。没有动态 label；未知错误不生成字段。响应不得包含昵称、房间码、player ID、resume/achievement token、request ID、设置、惩罚、消息正文或 URL fragment。
 
 公开 Nginx 配置对 `/internal/metrics` 固定返回 `404`，即使应用层启用了 token 也不得转发。内部采集器只能从受控主机直连监听地址，并从 root-only 配置读取 Bearer token。
+
+协议迁移与恢复计数的语义固定如下：
+
+- `legacyProtocolAcceptedTotal`：create/join/resume 缺少 `protocolVersion`，且经临时兼容分支按
+  v1 解析成功；同一连接上的同一初始 `requestId` 最多计一次。
+- `explicitProtocolAcceptedTotal`：create/join/resume 显式携带受支持的整数协议版本并通过版本
+  校验；业务层随后拒绝（例如房间不存在）仍代表一次已识别协议使用，但重复 `requestId` 不重计。
+- `roomResumeAttemptsTotal`：协议解析成功、去重后进入 resume 业务分支时增加；协议不兼容请求
+  不计入。
+- `roomResumeSucceededTotal`：服务端成功轮换恢复凭证并向该席位返回新的私有 `session` 后增加。
+- `roomResumeRejectedTotal`：进入 resume 业务分支后因房间/玩家不存在、凭证错误、连接已占用或
+  其他固定业务拒绝而增加。
+
+这些 counter 没有 label，拒绝原因不会动态进入字段名。暂时不能删除缺字段 compatibility：只有
+内部指标在连续观察窗口内确认 `legacyProtocolAcceptedTotal` 不再增长，并且旧 PWA/静态页面缓存
+窗口已经结束，后续版本才可移除。schema v2 只提供观测能力，本 PR 不移除兼容分支。
 
 ## Release smoke 与 CI
 
@@ -107,6 +126,13 @@ node scripts/room-server-release-smoke.mjs \
 `npm run test:room-server-smoke` 会构建并启动临时 room server，运行 deep smoke，发送
 SIGTERM，确认进程正常退出且端口关闭。CI 的独立 `Room Server Operability` job 运行 room server build、targeted tests、release smoke、完整 20 房间/160 连接压测和
 `git diff --exit-code`。该压测在本轮基线约 0.7 秒，因此保留在 PR required 路径，不降级到较小样本。
+
+CI 另有独立 `Mobile WebKit Smoke` job，使用 Playwright 内置 `iPhone 13` 配置和真实 WebKit
+engine 验证首页/version、联机建房加入、开局、断线恢复、私有 session 投影、联机页刷新及不兼容
+协议停止重连。现有 Chrome Browser E2E job 保持不变，WebKit failure trace 保留 7 天，测试只访问
+本地 Vite 与临时 room server。
+
+Automated WebKit coverage does not replace real iOS Safari acceptance.
 
 ## 发布顺序
 

--- a/docs/SAFE_PRODUCTION_DIAGNOSTICS.md
+++ b/docs/SAFE_PRODUCTION_DIAGNOSTICS.md
@@ -1,0 +1,60 @@
+# 安全生产诊断报告
+
+`scripts/collect-safe-production-diagnostics.mjs` 只把固定、低敏感度的运行状态写入
+schema v1 JSON。它用于替代复制 launcher 启动行、完整进程参数、容器配置或原始命令输出的
+诊断方式。
+
+## 安全边界
+
+报告只允许以下结构：
+
+- `schemaVersion`、`capturedAt`、固定错误码列表；
+- room server 的 service/container 布尔状态、镜像名、内存上限、health/ready HTTP 状态、
+  公开版本、协议版本和公开 build SHA；
+- Discourse 可达性、HTTP 状态和待执行 migration 数量；
+- 可用磁盘字节数和内核累计 OOM 事件数。
+
+采集适配器只有固定命令，没有调用者可传入的命令或 shell 片段。每条命令限时 5 秒：
+
+- `systemctl show` 只读取 room service 的 `ActiveState`；
+- Docker 只通过 `inspect --format` 读取 running、health、image 和 memory limit；
+- `curl` 只访问固定 health/readiness 地址并提取 HTTP 状态及 health 的公开字段；
+- migration 检查只输出非负整数；
+- `df` 和 `/proc/vmstat` 检查只输出非负整数。
+
+stderr、完整命令、环境变量、Docker `.Config.Env`/`.Path`/`.Args`、HTTP header 和原始响应
+都不会进入报告。命令失败只留下固定错误码。
+
+以下数据永远不在 schema 内：SMTP 配置、密码、API key、Bearer/metrics/achievement token、
+Authorization header、room code、昵称、player ID、resume token、成就认领内容、玩法设置、
+惩罚或聊天正文、Nginx 完整配置、`app.yml`、日志正文和 launcher 参数。
+
+写入前会同时执行三层检查：固定 schema allowlist、递归 forbidden-key 检查、credential-like
+字符串检查。任一检查失败即停止；报告通过同目录临时文件和 atomic rename 写入，最终权限固定为
+`0600`，失败路径清理临时文件。工具不会创建不存在的目标目录。
+
+严禁把未经该 allowlist 处理的命令输出复制到聊天、Issue、PR 或工单中。尤其不得读取或粘贴：
+
+- `/var/discourse/containers/app.yml`；
+- 完整环境变量、`docker inspect` JSON、进程命令行或 shell history；
+- launcher 完整启动参数或 systemd `Environment=` 原始值；
+- Mailgun、Discourse、metrics 或 achievement secret。
+
+## 本地 fixture 验证
+
+本仓库的 synthetic fixture 只包含明显虚假的 `FAKE_*_FOR_REDACTION_TEST_ONLY` 文本：
+
+```bash
+npm run test:safe-diagnostics
+node scripts/collect-safe-production-diagnostics.mjs \
+  --fixture scripts/fixtures/safe-production-diagnostics.synthetic.json \
+  --output /tmp/flying-chess-safe-diagnostics.json
+```
+
+第二条命令要求目标目录已存在。本轮工程迭代只执行 fixture/dry-run 测试，不运行真实生产采集。
+
+未来经授权进行生产核验时才可省略 `--fixture`，并且仍必须指定 `--output`。报告只能用于聚合状态
+核验，不能证明真人验收或 SMTP credential 已轮换。
+
+SMTP credential 轮换状态保持 `SMTP_CREDENTIAL_ROTATION_REQUIRED_MANUAL`；本工具不会读取、
+打印、修改或保存 SMTP credential。

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "test:room-server-smoke": "npm run build:room-server && node scripts/room-server-release-smoke-harness.mjs",
     "test:safe-diagnostics": "vitest run scripts/collect-safe-production-diagnostics.test.mjs",
     "verify:online-acceptance": "node scripts/online-acceptance-evidence.mjs",
-    "test:e2e": "playwright test tests/e2e"
+    "test:e2e": "playwright test tests/e2e",
+    "test:e2e:webkit-smoke": "playwright test --config=playwright.webkit.config.ts"
   },
   "lint-staged": {
     "*.{js,ts,vue}": [

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build:room-server": "npm run build --workspace @flying-chess/room-server",
     "test:room-server-load": "npm run build:room-server && node scripts/room-server-load-test.mjs",
     "test:room-server-smoke": "npm run build:room-server && node scripts/room-server-release-smoke-harness.mjs",
+    "test:safe-diagnostics": "vitest run scripts/collect-safe-production-diagnostics.test.mjs",
     "verify:online-acceptance": "node scripts/online-acceptance-evidence.mjs",
     "test:e2e": "playwright test tests/e2e"
   },

--- a/playwright.webkit.config.ts
+++ b/playwright.webkit.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+
+const packageVersion = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'))
+  .version as string
+
+export default defineConfig({
+  testDir: './tests/webkit',
+  testMatch: 'webkit-smoke.spec.ts',
+  timeout: 60_000,
+  workers: 1,
+  use: {
+    baseURL: 'http://127.0.0.1:4176',
+    trace: 'retain-on-failure',
+  },
+  webServer: [
+    {
+      command: `VITE_APP_VERSION=${packageVersion} VITE_ROOM_SERVER_URL=ws://127.0.0.1:8788 npm run dev -- --host 127.0.0.1 --port 4176`,
+      url: 'http://127.0.0.1:4176/flying-chess/',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+    {
+      command:
+        'NODE_ENV=test HOST=127.0.0.1 PORT=8788 ROOM_SERVER_TEST_DICE=6 ROOM_SERVER_TEST_RECONNECT_GRACE_MS=500 npm run dev:room-server',
+      url: 'http://127.0.0.1:8788/health',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+  ],
+  projects: [
+    {
+      name: 'iphone-13-webkit',
+      use: {
+        ...devices['iPhone 13'],
+        browserName: 'webkit',
+      },
+    },
+  ],
+})

--- a/scripts/collect-safe-production-diagnostics.mjs
+++ b/scripts/collect-safe-production-diagnostics.mjs
@@ -1,0 +1,378 @@
+import { randomUUID } from 'node:crypto'
+import { execFile } from 'node:child_process'
+import { chmod, open, readFile, rename, stat, unlink } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const FORBIDDEN_KEY_PATTERN =
+  /password|passwd|secret|token|authorization|credential|smtp|api[_-]?key|private[_-]?key/i
+const FORBIDDEN_VALUE_PATTERNS = [
+  /\b[a-z][a-z0-9+.-]*:\/\/[^/\s:@]+:[^/\s@]+@/i,
+  /\bBearer\s+\S+/i,
+  /\bAuthorization\s*:/i,
+  /\b(?:PASSWORD|SECRET|TOKEN)\s*=/i,
+]
+const SOURCE_ERROR_CODES = [
+  ['roomService', 'ROOM_SERVICE_CHECK_FAILED'],
+  ['container', 'CONTAINER_CHECK_FAILED'],
+  ['roomHealth', 'ROOM_HEALTH_CHECK_FAILED'],
+  ['roomReady', 'ROOM_READY_CHECK_FAILED'],
+  ['discourseHealth', 'DISCOURSE_HEALTH_CHECK_FAILED'],
+  ['pendingMigrations', 'PENDING_MIGRATIONS_CHECK_FAILED'],
+  ['diskAvailable', 'DISK_CHECK_FAILED'],
+  ['kernelOomEvents', 'OOM_CHECK_FAILED'],
+]
+const SAFE_ERROR_CODES = new Set(SOURCE_ERROR_CODES.map(([, errorCode]) => errorCode))
+const REPORT_KEYS = ['schemaVersion', 'capturedAt', 'roomServer', 'discourse', 'host', 'errors']
+const ROOM_SERVER_KEYS = [
+  'serviceActive',
+  'containerRunning',
+  'containerHealthy',
+  'image',
+  'memoryLimitBytes',
+  'healthStatus',
+  'readyStatus',
+  'version',
+  'protocolVersion',
+  'buildSha',
+]
+const DISCOURSE_KEYS = ['serviceReachable', 'httpStatus', 'pendingMigrations']
+const HOST_KEYS = ['diskAvailableBytes', 'kernelOomEvents']
+
+export class SafeDiagnosticsError extends Error {
+  constructor(code) {
+    super(code)
+    this.code = code
+  }
+}
+
+function assertSafeReportValue(value) {
+  if (typeof value === 'string') {
+    if (FORBIDDEN_VALUE_PATTERNS.some(pattern => pattern.test(value))) {
+      throw new SafeDiagnosticsError('FORBIDDEN_VALUE')
+    }
+    return
+  }
+  if (!value || typeof value !== 'object') return
+  if (Array.isArray(value)) {
+    for (const item of value) assertSafeReportValue(item)
+    return
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_KEY_PATTERN.test(key)) throw new SafeDiagnosticsError('FORBIDDEN_KEY')
+    assertSafeReportValue(child)
+  }
+}
+
+function hasExactKeys(value, expectedKeys) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const actualKeys = Object.keys(value)
+  return (
+    actualKeys.length === expectedKeys.length &&
+    expectedKeys.every(expectedKey => actualKeys.includes(expectedKey))
+  )
+}
+
+function isUnsignedIntegerOrNull(value) {
+  return value === null || (Number.isSafeInteger(value) && value >= 0)
+}
+
+function isSafeStringOrNull(value, pattern) {
+  return value === null || (typeof value === 'string' && pattern.test(value))
+}
+
+function isIsoTimestamp(value) {
+  if (typeof value !== 'string') return false
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value
+}
+
+function assertFixedReportSchema(report) {
+  const roomServer = report?.roomServer
+  const discourse = report?.discourse
+  const host = report?.host
+  const valid =
+    hasExactKeys(report, REPORT_KEYS) &&
+    report.schemaVersion === 1 &&
+    isIsoTimestamp(report.capturedAt) &&
+    hasExactKeys(roomServer, ROOM_SERVER_KEYS) &&
+    typeof roomServer.serviceActive === 'boolean' &&
+    typeof roomServer.containerRunning === 'boolean' &&
+    typeof roomServer.containerHealthy === 'boolean' &&
+    isSafeStringOrNull(roomServer.image, /^[A-Za-z0-9][A-Za-z0-9._/:@+-]{0,199}$/) &&
+    isUnsignedIntegerOrNull(roomServer.memoryLimitBytes) &&
+    isUnsignedIntegerOrNull(roomServer.healthStatus) &&
+    isUnsignedIntegerOrNull(roomServer.readyStatus) &&
+    isSafeStringOrNull(roomServer.version, /^[0-9A-Za-z][0-9A-Za-z.+-]{0,63}$/) &&
+    isUnsignedIntegerOrNull(roomServer.protocolVersion) &&
+    isSafeStringOrNull(roomServer.buildSha, /^(?:unknown|[0-9a-f]{7,64})$/i) &&
+    hasExactKeys(discourse, DISCOURSE_KEYS) &&
+    typeof discourse.serviceReachable === 'boolean' &&
+    isUnsignedIntegerOrNull(discourse.httpStatus) &&
+    isUnsignedIntegerOrNull(discourse.pendingMigrations) &&
+    hasExactKeys(host, HOST_KEYS) &&
+    isUnsignedIntegerOrNull(host.diskAvailableBytes) &&
+    isUnsignedIntegerOrNull(host.kernelOomEvents) &&
+    Array.isArray(report.errors) &&
+    new Set(report.errors).size === report.errors.length &&
+    report.errors.every(errorCode => SAFE_ERROR_CODES.has(errorCode))
+  if (!valid) throw new SafeDiagnosticsError('SCHEMA_MISMATCH')
+}
+
+function parseUnsignedInteger(value) {
+  const normalized = String(value ?? '').trim()
+  if (!/^\d+$/.test(normalized)) return null
+  const parsed = Number(normalized)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
+
+function extractLastUnsignedInteger(value) {
+  const match = String(value ?? '')
+    .trim()
+    .split(/\r?\n/)
+    .reverse()
+    .find(line => /^\d+$/.test(line.trim()))
+  return match?.trim() ?? ''
+}
+
+function splitHttpOutput(value) {
+  const match = String(value ?? '').match(/^([\s\S]*)\r?\n(\d{3})$/)
+  if (!match) return null
+  return { body: match[1] ?? '', httpStatus: Number(match[2]) }
+}
+
+function parseContainerSummary(value) {
+  const [running, health, image, memoryLimitBytes] = String(value ?? '')
+    .trim()
+    .split('|')
+  return {
+    containerRunning: running === 'true',
+    containerHealthy: health === 'healthy',
+    image: image || null,
+    memoryLimitBytes: parseUnsignedInteger(memoryLimitBytes),
+  }
+}
+
+/**
+ * Projects untrusted diagnostic sources onto the only fields permitted in a report.
+ * Unknown source fields are deliberately ignored rather than copied through.
+ */
+export function createSafeDiagnosticsReport(source) {
+  const container = parseContainerSummary(source?.container?.stdout)
+  const roomHealth = source?.roomHealth?.body ?? {}
+  const errors = SOURCE_ERROR_CODES.flatMap(([sourceName, errorCode]) =>
+    source?.[sourceName]?.exitCode === 0 ? [] : [errorCode]
+  )
+  return {
+    schemaVersion: 1,
+    capturedAt: source?.capturedAt ?? new Date().toISOString(),
+    roomServer: {
+      serviceActive:
+        source?.roomService?.exitCode === 0 &&
+        String(source?.roomService?.stdout ?? 'active').trim() === 'active',
+      ...container,
+      healthStatus: parseUnsignedInteger(source?.roomHealth?.httpStatus),
+      readyStatus: parseUnsignedInteger(source?.roomReady?.httpStatus),
+      version: typeof roomHealth.version === 'string' ? roomHealth.version : null,
+      protocolVersion: parseUnsignedInteger(roomHealth.protocolVersion),
+      buildSha: typeof roomHealth.buildSha === 'string' ? roomHealth.buildSha : null,
+    },
+    discourse: {
+      serviceReachable: source?.discourseHealth?.exitCode === 0,
+      httpStatus: parseUnsignedInteger(source?.discourseHealth?.httpStatus),
+      pendingMigrations: parseUnsignedInteger(source?.pendingMigrations?.stdout),
+    },
+    host: {
+      diskAvailableBytes: parseUnsignedInteger(source?.diskAvailable?.stdout),
+      kernelOomEvents: parseUnsignedInteger(source?.kernelOomEvents?.stdout),
+    },
+    errors,
+  }
+}
+
+function defaultExecuteCommand(command) {
+  return new Promise(resolve => {
+    execFile(
+      command.file,
+      command.args,
+      {
+        encoding: 'utf8',
+        maxBuffer: 64 * 1_024,
+        timeout: command.timeoutMs,
+        windowsHide: true,
+      },
+      (error, stdout) => {
+        resolve({
+          exitCode: error ? (typeof error.code === 'number' ? error.code : 1) : 0,
+          stdout: typeof stdout === 'string' ? stdout : '',
+        })
+      }
+    )
+  })
+}
+
+function command(file, args) {
+  return { file, args, timeoutMs: 5_000 }
+}
+
+function httpCommand(url) {
+  return command('curl', [
+    '--silent',
+    '--max-time',
+    '5',
+    '--connect-timeout',
+    '2',
+    '--output',
+    '-',
+    '--write-out',
+    '\n%{http_code}',
+    url,
+  ])
+}
+
+function normalizeHttpSource(result, parseJson) {
+  if (result.exitCode !== 0) return { exitCode: result.exitCode }
+  const parsed = splitHttpOutput(result.stdout)
+  if (!parsed) return { exitCode: 1 }
+  if (!parseJson) return { exitCode: 0, httpStatus: parsed.httpStatus }
+  try {
+    return { exitCode: 0, httpStatus: parsed.httpStatus, body: JSON.parse(parsed.body) }
+  } catch {
+    return { exitCode: 1, httpStatus: parsed.httpStatus }
+  }
+}
+
+function normalizeNumericSource(result) {
+  if (result.exitCode !== 0) return { exitCode: result.exitCode }
+  const stdout = extractLastUnsignedInteger(result.stdout)
+  return stdout ? { exitCode: 0, stdout } : { exitCode: 1 }
+}
+
+/**
+ * Runs only fixed, timeout-bounded commands. The adapter intentionally never returns stderr.
+ */
+export async function collectProductionDiagnosticSources({
+  executeCommand = defaultExecuteCommand,
+  capturedAt = new Date().toISOString(),
+} = {}) {
+  const commands = {
+    roomService: command('systemctl', [
+      'show',
+      '--property=ActiveState',
+      '--value',
+      'flying-chess-room.service',
+    ]),
+    container: command('docker', [
+      'inspect',
+      '--format',
+      '{{.State.Running}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}|{{.Config.Image}}|{{.HostConfig.Memory}}',
+      'flying-chess-room',
+    ]),
+    roomHealth: httpCommand('http://127.0.0.1:8787/health'),
+    roomReady: httpCommand('http://127.0.0.1:8787/ready'),
+    discourseHealth: httpCommand('https://atang-sp.run.place/srv/status'),
+    pendingMigrations: command('docker', [
+      'exec',
+      'app',
+      'bash',
+      '-lc',
+      "cd /var/www/discourse && bundle exec rails runner 'puts ActiveRecord::Base.connection.migration_context.open.pending_migrations.length'",
+    ]),
+    diskAvailable: command('df', ['--block-size=1', '--output=avail', '/var/discourse']),
+    kernelOomEvents: command('awk', ['$1 == "oom_kill" { print $2 }', '/proc/vmstat']),
+  }
+  const [
+    roomService,
+    container,
+    roomHealth,
+    roomReady,
+    discourseHealth,
+    pendingMigrations,
+    diskAvailable,
+    kernelOomEvents,
+  ] = await Promise.all(Object.values(commands).map(descriptor => executeCommand(descriptor)))
+
+  return {
+    capturedAt,
+    roomService: { exitCode: roomService.exitCode, stdout: roomService.stdout },
+    container: { exitCode: container.exitCode, stdout: container.stdout },
+    roomHealth: normalizeHttpSource(roomHealth, true),
+    roomReady: normalizeHttpSource(roomReady, true),
+    discourseHealth: normalizeHttpSource(discourseHealth, false),
+    pendingMigrations: normalizeNumericSource(pendingMigrations),
+    diskAvailable: normalizeNumericSource(diskAvailable),
+    kernelOomEvents: normalizeNumericSource(kernelOomEvents),
+  }
+}
+
+export async function writeSafeDiagnosticsReport(outputPath, report) {
+  assertSafeReportValue(report)
+  assertFixedReportSchema(report)
+  const outputDirectory = dirname(outputPath)
+  const directory = await stat(outputDirectory).catch(() => null)
+  if (!directory?.isDirectory()) throw new SafeDiagnosticsError('OUTPUT_DIRECTORY_INVALID')
+
+  const temporaryPath = `${outputPath}.tmp-${process.pid}-${randomUUID()}`
+  let handle
+  try {
+    handle = await open(temporaryPath, 'wx', 0o600)
+    await handle.writeFile(`${JSON.stringify(report, null, 2)}\n`, 'utf8')
+    await handle.sync()
+    await handle.close()
+    handle = undefined
+    await chmod(temporaryPath, 0o600)
+    await rename(temporaryPath, outputPath)
+    await chmod(outputPath, 0o600)
+  } catch (error) {
+    await handle?.close().catch(() => undefined)
+    await unlink(temporaryPath).catch(() => undefined)
+    throw error
+  }
+}
+
+function parseCliArguments(arguments_) {
+  let fixturePath
+  let outputPath
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const name = arguments_[index]
+    const value = arguments_[index + 1]
+    if (!value) throw new SafeDiagnosticsError('ARGUMENTS_INVALID')
+    if (name === '--fixture') fixturePath = value
+    else if (name === '--output') outputPath = value
+    else throw new SafeDiagnosticsError('ARGUMENTS_INVALID')
+  }
+  if (!outputPath) throw new SafeDiagnosticsError('ARGUMENTS_INVALID')
+  return { fixturePath, outputPath }
+}
+
+async function runCli(arguments_) {
+  const { fixturePath, outputPath } = parseCliArguments(arguments_)
+  let source
+  if (fixturePath) {
+    try {
+      source = JSON.parse(await readFile(fixturePath, 'utf8'))
+    } catch {
+      throw new SafeDiagnosticsError('FIXTURE_INVALID')
+    }
+  } else {
+    source = await collectProductionDiagnosticSources()
+  }
+  await writeSafeDiagnosticsReport(outputPath, createSafeDiagnosticsReport(source))
+  process.stdout.write('SAFE_DIAGNOSTICS_WRITTEN\n')
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined && pathToFileURL(process.argv[1]).href === import.meta.url
+
+if (isDirectExecution) {
+  try {
+    await runCli(process.argv.slice(2))
+  } catch (error) {
+    const code =
+      error instanceof SafeDiagnosticsError && /^[A-Z_]+$/.test(error.code)
+        ? error.code
+        : 'UNEXPECTED'
+    process.stderr.write(`SAFE_DIAGNOSTICS_FAILED:${code}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/collect-safe-production-diagnostics.test.mjs
+++ b/scripts/collect-safe-production-diagnostics.test.mjs
@@ -1,0 +1,253 @@
+import { spawnSync } from 'node:child_process'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  collectProductionDiagnosticSources,
+  createSafeDiagnosticsReport,
+  writeSafeDiagnosticsReport,
+} from './collect-safe-production-diagnostics.mjs'
+
+const scriptPath = fileURLToPath(
+  new URL('./collect-safe-production-diagnostics.mjs', import.meta.url)
+)
+const fixturePath = fileURLToPath(
+  new URL('./fixtures/safe-production-diagnostics.synthetic.json', import.meta.url)
+)
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf8'))
+
+describe('safe production diagnostics', () => {
+  it('projects raw diagnostic sources onto the fixed report allowlist', () => {
+    const report = createSafeDiagnosticsReport(fixture)
+
+    expect(report).toEqual({
+      schemaVersion: 1,
+      capturedAt: '2026-08-08T00:00:00.000Z',
+      roomServer: {
+        serviceActive: true,
+        containerRunning: true,
+        containerHealthy: true,
+        image: 'flying-chess-room:1.15.0',
+        memoryLimitBytes: 134217728,
+        healthStatus: 200,
+        readyStatus: 200,
+        version: '1.15.0',
+        protocolVersion: 1,
+        buildSha: 'df974cf9cbc003fc8624629983c068aa3573ed22',
+      },
+      discourse: {
+        serviceReachable: true,
+        httpStatus: 200,
+        pendingMigrations: 0,
+      },
+      host: {
+        diskAvailableBytes: 123456789,
+        kernelOomEvents: 0,
+      },
+      errors: [],
+    })
+  })
+
+  it('records only fixed error codes when a command source contains raw stderr', () => {
+    const source = structuredClone(fixture)
+    source.roomHealth.exitCode = 28
+    source.roomHealth.errorCode = 'ROOM_HEALTH_CHECK_FAILED'
+    source.roomHealth.stderr = 'TOKEN=FAKE_TOKEN_FOR_REDACTION_TEST_ONLY'
+
+    const report = createSafeDiagnosticsReport(source)
+
+    expect(report.errors).toEqual(['ROOM_HEALTH_CHECK_FAILED'])
+    expect(JSON.stringify(report).includes('FAKE_')).toBe(false)
+    expect(JSON.stringify(report).includes('stderr')).toBe(false)
+  })
+
+  it('fails closed when any nested report key is forbidden', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'flying-chess-safe-diagnostics-'))
+    const outputPath = join(directory, 'report.json')
+    try {
+      const report = createSafeDiagnosticsReport(fixture)
+      report.roomServer.secret = 'FAKE_VALUE_FOR_REDACTION_TEST_ONLY'
+
+      await expect(writeSafeDiagnosticsReport(outputPath, report)).rejects.toMatchObject({
+        code: 'FORBIDDEN_KEY',
+      })
+      expect(existsSync(outputPath)).toBe(false)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects harmless-looking fields outside the fixed schema allowlist', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'flying-chess-safe-diagnostics-'))
+    const outputPath = join(directory, 'report.json')
+    try {
+      const report = createSafeDiagnosticsReport(fixture)
+      report.roomServer.diagnosticNote = 'not part of schema v1'
+
+      await expect(writeSafeDiagnosticsReport(outputPath, report)).rejects.toMatchObject({
+        code: 'SCHEMA_MISMATCH',
+      })
+      expect(existsSync(outputPath)).toBe(false)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it.each([
+    'https://fake-user:FAKE_URI_PASSWORD_FOR_REDACTION_TEST_ONLY@example.test/image',
+    'Bearer FAKE_BEARER_TOKEN_FOR_REDACTION_TEST_ONLY',
+    'Authorization: FAKE_AUTHORIZATION_VALUE_FOR_REDACTION_TEST_ONLY',
+    'PASSWORD=FAKE_PASSWORD_FOR_REDACTION_TEST_ONLY',
+    'SECRET=FAKE_SECRET_FOR_REDACTION_TEST_ONLY',
+    'TOKEN=FAKE_TOKEN_FOR_REDACTION_TEST_ONLY',
+  ])('fails closed when a report string matches a forbidden credential form', async value => {
+    const directory = mkdtempSync(join(tmpdir(), 'flying-chess-safe-diagnostics-'))
+    const outputPath = join(directory, 'report.json')
+    try {
+      const report = createSafeDiagnosticsReport(fixture)
+      report.roomServer.image = value
+
+      await expect(writeSafeDiagnosticsReport(outputPath, report)).rejects.toMatchObject({
+        code: 'FORBIDDEN_VALUE',
+      })
+      expect(existsSync(outputPath)).toBe(false)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('writes an atomic 0600 report without raw stderr or temporary files', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'flying-chess-safe-diagnostics-'))
+    const outputPath = join(directory, 'report.json')
+    try {
+      await writeSafeDiagnosticsReport(outputPath, createSafeDiagnosticsReport(fixture))
+
+      expect(statSync(outputPath).mode & 0o777).toBe(0o600)
+      expect(readdirSync(directory)).toEqual(['report.json'])
+      const serialized = readFileSync(outputPath, 'utf8')
+      expect(serialized.includes('FAKE_')).toBe(false)
+      expect(serialized.includes('stderr')).toBe(false)
+      expect(serialized.includes('launcherCommand')).toBe(false)
+      expect(serialized.includes('environment')).toBe(false)
+      expect(serialized.includes('roomCode')).toBe(false)
+      expect(serialized.includes('resumeToken')).toBe(false)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('cleans the temporary file and leaves no partial report when atomic rename fails', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'flying-chess-safe-diagnostics-'))
+    const outputPath = join(directory, 'report.json')
+    mkdirSync(outputPath)
+    try {
+      await expect(
+        writeSafeDiagnosticsReport(outputPath, createSafeDiagnosticsReport(fixture))
+      ).rejects.toBeDefined()
+      expect(readdirSync(directory)).toEqual(['report.json'])
+      expect(readdirSync(outputPath)).toEqual([])
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('does not create a missing output directory implicitly', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'flying-chess-safe-diagnostics-'))
+    const missingDirectory = join(directory, 'missing')
+    try {
+      await expect(
+        writeSafeDiagnosticsReport(
+          join(missingDirectory, 'report.json'),
+          createSafeDiagnosticsReport(fixture)
+        )
+      ).rejects.toMatchObject({ code: 'OUTPUT_DIRECTORY_INVALID' })
+      expect(existsSync(missingDirectory)).toBe(false)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('supports a fixture-only CLI run without echoing fixture contents', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'flying-chess-safe-diagnostics-'))
+    const outputPath = join(directory, 'report.json')
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [scriptPath, '--fixture', fixturePath, '--output', outputPath],
+        { encoding: 'utf8' }
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.stdout).toBe('SAFE_DIAGNOSTICS_WRITTEN\n')
+      expect(result.stderr).toBe('')
+      expect(`${result.stdout}${result.stderr}`.includes('FAKE_')).toBe(false)
+      expect(statSync(outputPath).mode & 0o777).toBe(0o600)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('collects through fixed timeout-bounded commands and drops command stderr', async () => {
+    const commands = []
+    const executeCommand = async command => {
+      commands.push(command)
+      const joined = [command.file, ...command.args].join(' ')
+      let stdout = ''
+      if (joined.includes('systemctl')) stdout = 'active\n'
+      else if (joined.includes('docker inspect')) {
+        stdout = 'true|healthy|flying-chess-room:1.15.0|134217728\n'
+      } else if (joined.includes('/health')) {
+        stdout = `${JSON.stringify({
+          status: 'ok',
+          version: '1.15.0',
+          protocolVersion: 1,
+          buildSha: 'df974cf9cbc003fc8624629983c068aa3573ed22',
+        })}\n200`
+      } else if (joined.includes('/ready')) stdout = '{"status":"ready"}\n200'
+      else if (joined.includes('/srv/status')) stdout = 'ok\n200'
+      else if (joined.includes('rails runner')) stdout = '0\n'
+      else if (joined.includes('df')) stdout = 'Avail\n123456789\n'
+      else if (joined.includes('awk')) stdout = '0\n'
+      return {
+        exitCode: 0,
+        stdout,
+        stderr: 'TOKEN=FAKE_TOKEN_FOR_REDACTION_TEST_ONLY',
+      }
+    }
+
+    const source = await collectProductionDiagnosticSources({
+      executeCommand,
+      capturedAt: '2026-08-08T00:00:00.000Z',
+    })
+    const report = createSafeDiagnosticsReport(source)
+
+    expect(commands).toHaveLength(8)
+    expect(commands.every(command => command.timeoutMs > 0 && command.timeoutMs <= 5_000)).toBe(
+      true
+    )
+    const dockerInspect = commands.find(
+      command => command.file === 'docker' && command.args[0] === 'inspect'
+    )
+    expect(dockerInspect?.args.join(' ')).toContain('--format')
+    expect(dockerInspect?.args.join(' ')).not.toContain('.Config.Env')
+    expect(dockerInspect?.args.join(' ')).not.toContain('.Path')
+    expect(dockerInspect?.args.join(' ')).not.toContain('.Args')
+    expect(JSON.stringify(source).includes('FAKE_')).toBe(false)
+    expect(report).toMatchObject({
+      roomServer: { healthStatus: 200, readyStatus: 200, containerHealthy: true },
+      discourse: { httpStatus: 200, pendingMigrations: 0 },
+      host: { diskAvailableBytes: 123456789, kernelOomEvents: 0 },
+      errors: [],
+    })
+  })
+})

--- a/scripts/fixtures/safe-production-diagnostics.synthetic.json
+++ b/scripts/fixtures/safe-production-diagnostics.synthetic.json
@@ -1,0 +1,57 @@
+{
+  "capturedAt": "2026-08-08T00:00:00.000Z",
+  "roomService": {
+    "exitCode": 0,
+    "stdout": "active",
+    "stderr": "SMTP_PASSWORD=FAKE_SMTP_PASSWORD_FOR_REDACTION_TEST_ONLY"
+  },
+  "container": {
+    "exitCode": 0,
+    "stdout": "true|healthy|flying-chess-room:1.15.0|134217728",
+    "environment": [
+      "ROOM_METRICS_TOKEN=FAKE_METRICS_TOKEN_FOR_REDACTION_TEST_ONLY",
+      "SMTP_PASSWORD=FAKE_SMTP_PASSWORD_FOR_REDACTION_TEST_ONLY"
+    ],
+    "launcherCommand": "launcher start --smtp-password FAKE_SMTP_PASSWORD_FOR_REDACTION_TEST_ONLY"
+  },
+  "roomHealth": {
+    "exitCode": 0,
+    "httpStatus": 200,
+    "body": {
+      "status": "ok",
+      "version": "1.15.0",
+      "protocolVersion": 1,
+      "buildSha": "df974cf9cbc003fc8624629983c068aa3573ed22",
+      "roomCode": "FAKE23",
+      "resumeToken": "FAKE_RESUME_TOKEN_FOR_REDACTION_TEST_ONLY"
+    },
+    "stderr": "Authorization: Bearer FAKE_BEARER_TOKEN_FOR_REDACTION_TEST_ONLY"
+  },
+  "roomReady": {
+    "exitCode": 0,
+    "httpStatus": 200,
+    "body": {
+      "status": "ready",
+      "acceptingNewRooms": true,
+      "draining": false
+    }
+  },
+  "discourseHealth": {
+    "exitCode": 0,
+    "httpStatus": 200,
+    "stderr": "https://fake-user:FAKE_URI_PASSWORD_FOR_REDACTION_TEST_ONLY@example.test"
+  },
+  "pendingMigrations": {
+    "exitCode": 0,
+    "stdout": "0",
+    "appYmlStyle": "DISCOURSE_SMTP_PASSWORD: FAKE_SMTP_PASSWORD_FOR_REDACTION_TEST_ONLY"
+  },
+  "diskAvailable": {
+    "exitCode": 0,
+    "stdout": "123456789"
+  },
+  "kernelOomEvents": {
+    "exitCode": 0,
+    "stdout": "0"
+  }
+}

--- a/tests/webkit/webkit-smoke.spec.ts
+++ b/tests/webkit/webkit-smoke.spec.ts
@@ -52,6 +52,13 @@ test('iPhone WebKit completes create, join, start, disconnect, resume, and refre
   let guest = await guestContext.newPage()
   observePage(host, consoleErrors, hostFrames)
   observePage(guest, consoleErrors, guestFrames)
+  await host.addInitScript(() => {
+    localStorage.setItem('autoGuideEnabled', 'false')
+    localStorage.setItem(
+      'hasShownGuide',
+      JSON.stringify(['intro', 'board_settings', 'settings', 'game'])
+    )
+  })
 
   try {
     await host.goto('/flying-chess/')

--- a/tests/webkit/webkit-smoke.spec.ts
+++ b/tests/webkit/webkit-smoke.spec.ts
@@ -1,0 +1,168 @@
+import { devices, expect, test, type BrowserContextOptions, type Page } from '@playwright/test'
+import packageJson from '../../package.json' with { type: 'json' }
+
+const SESSION_STORAGE_KEY = 'flying-chess-online-session-v1'
+
+interface StoredSession {
+  readonly roomCode: string
+  readonly playerId: string
+  readonly resumeToken: string
+}
+
+function iphoneContextOptions(): BrowserContextOptions {
+  const device = devices['iPhone 13']
+  return {
+    userAgent: device.userAgent,
+    viewport: device.viewport,
+    screen: device.screen,
+    deviceScaleFactor: device.deviceScaleFactor,
+    isMobile: device.isMobile,
+    hasTouch: device.hasTouch,
+  }
+}
+
+function observePage(page: Page, consoleErrors: string[], receivedFrames: string[]): void {
+  page.on('console', message => {
+    if (message.type() === 'error') consoleErrors.push(message.text())
+  })
+  page.on('pageerror', error => consoleErrors.push(error.message))
+  page.on('websocket', socket => {
+    socket.on('framereceived', event => receivedFrames.push(event.payload.toString()))
+  })
+}
+
+async function readStoredSession(page: Page): Promise<StoredSession> {
+  return page.evaluate(key => {
+    const value = sessionStorage.getItem(key)
+    if (!value) throw new Error('expected stored online session')
+    return JSON.parse(value) as StoredSession
+  }, SESSION_STORAGE_KEY)
+}
+
+test('iPhone WebKit completes create, join, start, disconnect, resume, and refresh privately', async ({
+  browser,
+}) => {
+  const hostContext = await browser.newContext(iphoneContextOptions())
+  const guestContext = await browser.newContext(iphoneContextOptions())
+  const consoleErrors: string[] = []
+  const hostFrames: string[] = []
+  const guestFrames: string[] = []
+  const resumedFrames: string[] = []
+  const host = await hostContext.newPage()
+  let guest = await guestContext.newPage()
+  observePage(host, consoleErrors, hostFrames)
+  observePage(guest, consoleErrors, guestFrames)
+
+  try {
+    await host.goto('/flying-chess/')
+    await expect(host.locator('.version-display')).toHaveText(`v${packageJson.version}`)
+    await expect(host.getByTestId('mode-classic')).toHaveAttribute('aria-pressed', 'true')
+    await host.getByTestId('mode-party').click()
+    await host.getByTestId('online-party-entry').click()
+    await expect(host).toHaveURL(/\/flying-chess\/online\.html$/)
+    await expect(host.getByText('房间服务已连接')).toBeVisible()
+    await expect(host.getByText(`应用 v${packageJson.version}`, { exact: false })).toBeVisible()
+
+    await host.getByTestId('nickname').fill('WebKit 主持人')
+    await host.getByTestId('create-room').click()
+    const roomCode = (await host.getByTestId('room-code').textContent())?.trim()
+    expect(roomCode).toMatch(/^[A-Z2-9]{6}$/)
+
+    await guest.goto(`/flying-chess/online.html?room=${roomCode}`)
+    await expect(guest.getByText('房间服务已连接')).toBeVisible()
+    await guest.getByTestId('nickname').fill('WebKit 玩家二')
+    await guest.getByTestId('color').selectOption('#4ecdc4')
+    await guest.getByTestId('join-room').click()
+    await expect(host.getByTestId('room-player')).toHaveCount(2)
+
+    const guestSession = await readStoredSession(guest)
+    expect(hostFrames.join('').includes(guestSession.resumeToken)).toBe(false)
+    expect((await readStoredSession(host)).resumeToken === guestSession.resumeToken).toBe(false)
+
+    await Promise.all([host, guest].map(page => page.getByTestId('confirm-settings').click()))
+    await expect(host.getByTestId('start-online-game')).toBeEnabled()
+    await host.getByTestId('start-online-game').click()
+    await expect(guest.getByTestId('predict-high')).toBeVisible()
+    await expect(host.getByRole('region', { name: '飞行棋赛道' })).toBeVisible()
+
+    await guest.close()
+    await expect(host.getByText(/WebKit 玩家二 离线/)).toBeVisible()
+
+    guest = await guestContext.newPage()
+    observePage(guest, consoleErrors, resumedFrames)
+    await guest.addInitScript(
+      ({ key, storedSession }) => {
+        if (sessionStorage.getItem(key) === null) {
+          sessionStorage.setItem(key, JSON.stringify(storedSession))
+        }
+      },
+      { key: SESSION_STORAGE_KEY, storedSession: guestSession }
+    )
+    await guest.goto('/flying-chess/online.html')
+    await expect(guest.getByText('房间服务已连接')).toBeVisible()
+    await expect(guest.getByTestId('predict-high')).toBeVisible()
+    const resumedSession = await readStoredSession(guest)
+    expect(resumedSession.playerId === guestSession.playerId).toBe(true)
+    expect(resumedSession.resumeToken === guestSession.resumeToken).toBe(false)
+    expect(resumedFrames.join('').includes(resumedSession.resumeToken)).toBe(true)
+    expect(hostFrames.join('').includes(resumedSession.resumeToken)).toBe(false)
+
+    await guest.reload()
+    await expect(guest).toHaveURL(/\/flying-chess\/online\.html$/)
+    await expect(guest.getByText('房间服务已连接')).toBeVisible()
+    await expect(guest.getByTestId('predict-high')).toBeVisible()
+    await expect(guest.getByTestId('mode-classic')).toHaveCount(0)
+    expect(consoleErrors).toEqual([])
+  } finally {
+    await hostContext.close()
+    await guestContext.close()
+  }
+})
+
+test('iPhone WebKit shows an actionable incompatible-protocol error and never reconnects', async ({
+  browser,
+}) => {
+  const context = await browser.newContext(iphoneContextOptions())
+  const page = await context.newPage()
+  const consoleErrors: string[] = []
+  const frames: string[] = []
+  let connectionCount = 0
+  const storedSession: StoredSession = {
+    roomCode: 'ABC234',
+    playerId: 'fake-player-for-webkit-test',
+    resumeToken: 'FAKE_RESUME_TOKEN_FOR_WEBKIT_TEST_ONLY',
+  }
+  observePage(page, consoleErrors, frames)
+  await page.clock.install()
+  await page.addInitScript(({ key, value }) => sessionStorage.setItem(key, JSON.stringify(value)), {
+    key: SESSION_STORAGE_KEY,
+    value: storedSession,
+  })
+  await page.routeWebSocket(/^ws:\/\/127\.0\.0\.1:8788\/?$/, socket => {
+    connectionCount += 1
+    socket.onMessage(() => {
+      socket.send(
+        JSON.stringify({
+          type: 'error',
+          code: 'INCOMPATIBLE_PROTOCOL',
+          message: '联机协议版本不兼容，请刷新页面或关闭后重新打开。',
+        })
+      )
+    })
+  })
+
+  try {
+    await page.goto('/flying-chess/online.html')
+    await expect(page.getByRole('alert')).toHaveText(
+      '联机协议版本不兼容，请刷新页面或关闭后重新打开。'
+    )
+    const preservedSession = await readStoredSession(page)
+    expect(JSON.stringify(preservedSession) === JSON.stringify(storedSession)).toBe(true)
+
+    await page.clock.fastForward(30_000)
+    expect(connectionCount).toBe(1)
+    expect(consoleErrors).toEqual([])
+  } finally {
+    await context.close()
+  }
+})


### PR DESCRIPTION
## Background

This is the automation-only field-readiness iteration requested before physical-device and multi-person acceptance. It keeps package version `1.15.0`, the classic default/Party opt-in UX, the existing Chrome matrix, and all production boundaries unchanged.

## SMTP exposure follow-up boundary

The previous SMTP exposure requires an operator-side Mailgun rotation outside this repository. This PR only adds a safe diagnostic collection path and never attempts credential recovery or rotation.

SMTP credential rotation remains SMTP_CREDENTIAL_ROTATION_REQUIRED_MANUAL.
No SMTP credential was read, printed, changed, or stored by this PR.

## Safe diagnostics allowlist

- Adds a schema-v1 JSON projection for service/container booleans, formatted image and memory limit, local health/readiness status plus public version/protocol/build SHA, Discourse reachability and migration count, disk availability, kernel OOM count, and fixed error codes.
- Uses only fixed, timeout-bounded commands; Docker inspect is format-only, stderr is discarded, and command failures map to fixed codes.
- Validates an exact recursive schema plus forbidden key/value patterns before atomic same-directory rename with final mode `0600`.
- Tests a synthetic fixture containing only obvious `FAKE_*_FOR_REDACTION_TEST_ONLY` values.

Explicitly prohibited: command lines/process args, environment dumps, SMTP host/user/password, API keys, tokens, room codes, nicknames, player IDs, resume tokens, achievement claims, Authorization headers, plugin secrets, full Nginx config, `app.yml`, raw logs, and chat/punishment content.

## WebKit coverage

An independent `Mobile WebKit Smoke` job installs Playwright WebKit with dependencies and runs an `iPhone 13` project. It covers homepage/version/classic default, Party-to-online entry, local room-server connection, two-context create/join/confirm/start, private session projection, disconnect/resume with credential rotation, online-page reload, console errors, and an actionable incompatible-protocol stop-without-reconnect path. Failure traces retain for 7 days. The existing Chrome job is unchanged and does not collect this spec.

Automated WebKit coverage does not replace physical-device acceptance.

## Deterministic lifecycle and chaos coverage

Nine tests cover duplicate move/reroll, fail-closed request tracking at capacity without ID eviction, an old frame queued at the server and released after resume, private RPS across two resumes, host grace-expiry transfer and late original-host resume, action-first and timeout-first deadline ordering, and drain with create rejection plus existing join/resume/play/finish. Tests inject clock/RNG/schedulers, wait on messages rather than long sleeps, assert public/private projection and cleanup, and the final file passed 10/10 consecutive runs (90 test executions).

## Metrics schema v2

All schema-v1 fields remain, with fixed counters:

- `legacyProtocolAcceptedTotal`: valid initial create/join/resume messages accepted through missing-version compatibility.
- `explicitProtocolAcceptedTotal`: valid supported explicit versions, including later business rejection.
- `roomResumeAttemptsTotal`: deduplicated compatible requests entering resume handling.
- `roomResumeSucceededTotal`: a rotated private session was returned.
- `roomResumeRejectedTotal`: resume business handling ended in a fixed rejection.

Unknown counters still fail closed; there are no dynamic labels or private identifiers. Accepted initial request IDs are retained up to a fixed 1,024-entry fail-closed boundary: unseen IDs are rejected at capacity, while old IDs are never evicted or recounted.

Legacy compatibility remains. It may only be removed in a later version after an internal continuous zero-use observation window and expiry of old PWA/static caches; this PR adds observation only.

## Validation and test delta

- `npm ci` — pass (689 packages; the full dev tree reports 1 high issue).
- `npm run format:check` — pass.
- `npm run lint:check` — pass.
- `npm run type-check` — pass.
- `npm run validate-config` — pass.
- `npm test` — 337/337 pass across 43 files (known baseline ~310, +27).
- `npm run test:safe-diagnostics` — 15/15 pass.
- `npm run build` and `npm run build:room-server` — pass.
- `npm run test:room-server` — 67/67 pass across 9 files (known baseline ~55, +12).
- `npm run test:room-server-smoke` — pass.
- `npm run test:room-server-load` — pass: 20 rooms, 160 connections, 320 samples, p95 0.5 ms.
- `npm run test:e2e` — 67 pass, 59 existing project skips; no new skip and no WebKit-spec leakage into Chrome.
- `npm audit --omit=dev --audit-level=high` — 0 production vulnerabilities.
- `git diff origin/master...HEAD --check` — pass.
- WebKit discovery lists 2/2 tests. On the Arch development host, `playwright install --with-deps webkit` cannot use `apt-get`, and the downloaded Ubuntu WebKit binary cannot launch against the host ICU ABI; the Ubuntu CI job is the authoritative real-WebKit execution.

Added automated cases: 27 Vitest tests (15 safe diagnostics, 9 lifecycle/chaos, 3 metrics/capacity semantics) plus 2 WebKit smoke tests.

## CI

Final run [31246152745](https://github.com/atang-sp/flying-chess/actions/runs/31246152745) passed all four jobs:

- `Quality` — pass (57s).
- `Room Server Operability` — pass (23s).
- `Mobile WebKit Smoke` — pass (1m25s), 2/2 on the installed Playwright WebKit engine.
- `Browser E2E` — pass (3m49s), preserving the existing Chrome matrix.

The first WebKit run exposed a real test-isolation issue: the first-visit onboarding dialog covered the Party mode button only on slower WebKit startup. The retained trace identified that exact click. The test now applies the repository's existing E2E convention for disabling non-target onboarding state before navigation; no online assertion, timeout, or skip was weakened.

## Manual acceptance and release boundary

Real iOS/Android and 4/6/8-person field acceptance remain
PENDING_MANUAL_ACCEPTANCE.

No production diagnostic collection, public smoke, server restart, Discourse rebuild, version bump, release, or deployment was performed.

No Git Tag or production deployment was performed.

## Rollback

Revert the squash merge. There are no migrations, persistent data changes, production configuration changes, tags, or deployed artifacts to unwind. The added CI job and metrics counters disappear with the revert; schema-v1 consumers must already treat schema changes explicitly.
