### PR TITLE
chore: release v1.16.0

### DIFF
--- a/apps/room-server/package.json
+++ b/apps/room-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/room-server",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@flying-chess/game-core": "1.15.0",
+    "@flying-chess/game-core": "1.16.0",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/deploy/room-server/ACCEPTANCE.md
+++ b/deploy/room-server/ACCEPTANCE.md
@@ -1,6 +1,6 @@
 # 联机升温局发布验收
 
-当前目标：`v1.15.0`
+当前目标：`v1.16.0`
 
 当前状态：`PENDING_MANUAL_ACCEPTANCE`
 
@@ -22,9 +22,9 @@
 证据不得提交到仓库。先复制模板到已被 `.gitignore` 排除的目录：
 
 ```bash
-mkdir -p .acceptance-evidence/v1.15.0/{evidence,artifacts}
+mkdir -p .acceptance-evidence/v1.16.0/{evidence,artifacts}
 cp deploy/room-server/acceptance-evidence.template.json \
-  .acceptance-evidence/v1.15.0/evidence.json
+  .acceptance-evidence/v1.16.0/evidence.json
 ```
 
 每个 `evidenceRefs` 都必须指向结构化 JSON 证明，可从 `acceptance-proof.template.json` 复制。证明必须包含同一个发布标签、UTC 时间、证明类别、与主清单完全一致的 `claims`，以及至少一个原始材料文件和它的 SHA-256。校验器会读取原始文件并重新计算摘要；空文件、目录、错误摘要、错误版本、错误类别、声明不一致或私人字段都会失败。
@@ -47,7 +47,7 @@ cp deploy/room-server/acceptance-evidence.template.json \
 计算摘要示例：
 
 ```bash
-sha256sum .acceptance-evidence/v1.15.0/artifacts/<已脱敏材料>
+sha256sum .acceptance-evidence/v1.16.0/artifacts/<已脱敏材料>
 ```
 
 生产资源证据至少在现场验收前、中、后各采样一次。`swapSamplesMiB` 至少填 3 个数；校验器将峰峰值不超过 128MiB 作为“无 swap 振荡”的保守可重复判据。
@@ -82,7 +82,7 @@ sha256sum .acceptance-evidence/v1.15.0/artifacts/<已脱敏材料>
 
 ```bash
 npm run verify:online-acceptance -- \
-  .acceptance-evidence/v1.15.0/evidence.json
+  .acceptance-evidence/v1.16.0/evidence.json
 ```
 
 退出码 `0` 且输出 `PASS` 才表示证据合同满足；退出码 `1` 表示一个或多个硬门槛失败，退出码 `2` 表示文件/JSON 用法错误。该命令只校验证据完整性，不会替代人工核对材料真实性。

--- a/deploy/room-server/README.md
+++ b/deploy/room-server/README.md
@@ -3,17 +3,17 @@
 生产拓扑：GitHub Pages 前端连接 `wss://rooms.atang-sp.run.place`；Discourse 容器内的 Nginx 终止 TLS，并反代到 Docker 网桥 `172.17.0.1:8787`。房间容器使用 host 网络并只监听该网桥地址，避免 Docker 发布端口在同机容器间被防火墙阻断，也不会把 `8787` 暴露到公网。房间服务不写磁盘，容器限制为 128 MiB 内存、1 CPU、只读根文件系统。
 
 完整协议、health/readiness、drain blocker、metrics、smoke、发布和回滚合同见
-[`docs/ONLINE_OPERABILITY.md`](../../docs/ONLINE_OPERABILITY.md)。本文件只记录生产操作形状；本轮 PR 不执行这些操作。
+[`docs/ONLINE_OPERABILITY.md`](../../docs/ONLINE_OPERABILITY.md)。本文件只记录生产操作形状；仓库变更本身不代表生产已经部署，必须以目标版本的发布核验为准。
 
 ## 构建与版本注入
 
-在已检出不可变 `v1.15.0` 标签的仓库根目录构建同一 commit。`ROOM_SERVER_BUILD_SHA` 只能是公开 Git commit 标识：
+在已检出不可变 `v1.16.0` 标签的仓库根目录构建同一 commit。`ROOM_SERVER_BUILD_SHA` 只能是公开 Git commit 标识：
 
 ```bash
 docker build -f apps/room-server/Dockerfile \
-  --build-arg ROOM_SERVER_VERSION=1.15.0 \
+  --build-arg ROOM_SERVER_VERSION=1.16.0 \
   --build-arg ROOM_SERVER_BUILD_SHA=<公开完整 commit SHA> \
-  -t flying-chess-room:1.15.0 .
+  -t flying-chess-room:1.16.0 .
 ```
 
 不要把 metrics、achievement 或其他 secret 作为 build arg；它们不得进入镜像层。
@@ -22,7 +22,7 @@ docker build -f apps/room-server/Dockerfile \
 `0600`。至少写入：
 
 ```dotenv
-ROOM_SERVER_VERSION=1.15.0
+ROOM_SERVER_VERSION=1.16.0
 ROOM_SERVER_BUILD_SHA=<公开完整 commit SHA>
 ROOM_DRAIN_TIMEOUT_MS=1800000
 ```
@@ -99,7 +99,7 @@ health 中的 `version`、`buildSha` 和 `protocolVersion` 必须与同一发布
 node scripts/room-server-release-smoke.mjs \
   --health-url https://rooms.atang-sp.run.place/health \
   --ws-url wss://rooms.atang-sp.run.place \
-  --expected-server-version 1.15.0 \
+  --expected-server-version 1.16.0 \
   --expected-protocol-version 1 \
   --origin https://atang-sp.github.io \
   --timeout-ms 5000

--- a/deploy/room-server/acceptance-evidence.template.json
+++ b/deploy/room-server/acceptance-evidence.template.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "release": "v1.15.0",
+  "release": "v1.16.0",
   "publicGateway": {
     "dnsResolved": false,
     "certificateSans": [],

--- a/deploy/room-server/acceptance-proof.template.json
+++ b/deploy/room-server/acceptance-proof.template.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "release": "v1.15.0",
+  "release": "v1.16.0",
   "recordedAtUtc": "2026-08-02T00:00:00.000Z",
   "kind": "replace_with_required_kind",
   "artifacts": [

--- a/deploy/room-server/flying-chess-room.service
+++ b/deploy/room-server/flying-chess-room.service
@@ -6,8 +6,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=ROOM_IMAGE=flying-chess-room:1.15.0
-Environment=ROOM_SERVER_VERSION=1.15.0
+Environment=ROOM_IMAGE=flying-chess-room:1.16.0
+Environment=ROOM_SERVER_VERSION=1.16.0
 Environment=ROOM_SERVER_BUILD_SHA=unknown
 Environment=ROOM_DRAIN_TIMEOUT_MS=1800000
 EnvironmentFile=/etc/flying-chess-room.env

--- a/docs/ONLINE_OPERABILITY.md
+++ b/docs/ONLINE_OPERABILITY.md
@@ -1,6 +1,6 @@
 # 联机协议与可运维合同
 
-目标版本：`1.15.0`
+目标版本：`1.16.0`
 
 工程状态：自动化门槛由 CI 验证；真机与 4/6/8 人现场门槛保持
 `PENDING_MANUAL_ACCEPTANCE`。
@@ -115,7 +115,7 @@ Shallow smoke 只读 health/readiness 并完成一次 WebSocket 连接，不创�
 node scripts/room-server-release-smoke.mjs \
   --health-url https://rooms.example/health \
   --ws-url wss://rooms.example \
-  --expected-server-version 1.15.0 \
+  --expected-server-version 1.16.0 \
   --expected-protocol-version 1 \
   --origin https://atang-sp.github.io \
   --timeout-ms 5000
@@ -136,7 +136,7 @@ Automated WebKit coverage does not replace real iOS Safari acceptance.
 
 ## 发布顺序
 
-本轮只实现并验证流程，不执行生产发布：
+版本发布必须按以下顺序执行，并分别保留 room server 与 Pages 的核验结论：
 
 1. 从同一个 commit 构建前端与 room server，并注入 release version 与公开 build SHA；
 2. 先部署仍兼容缺字段旧页面的新 room server；

--- a/docs/SAFE_PRODUCTION_DIAGNOSTICS.md
+++ b/docs/SAFE_PRODUCTION_DIAGNOSTICS.md
@@ -51,7 +51,7 @@ node scripts/collect-safe-production-diagnostics.mjs \
   --output /tmp/flying-chess-safe-diagnostics.json
 ```
 
-第二条命令要求目标目录已存在。本轮工程迭代只执行 fixture/dry-run 测试，不运行真实生产采集。
+第二条命令要求目标目录已存在。常规本地验证只执行 fixture/dry-run；生产采集必须有明确的发布或核验授权。
 
 未来经授权进行生产核验时才可省略 `--fixture`，并且仍必须指定 `--output`。报告只能用于聚合状态
 核验，不能证明真人验收或 SMTP credential 已轮换。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ludo-vue-demo",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -54,9 +54,9 @@
     },
     "apps/room-server": {
       "name": "@flying-chess/room-server",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "dependencies": {
-        "@flying-chess/game-core": "1.15.0",
+        "@flying-chess/game-core": "1.16.0",
         "ws": "^8.18.3"
       },
       "devDependencies": {
@@ -11186,7 +11186,7 @@
     },
     "packages/game-core": {
       "name": "@flying-chess/game-core",
-      "version": "1.15.0"
+      "version": "1.16.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludo-vue-demo",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/game-core/package.json
+++ b/packages/game-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flying-chess/game-core",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- bump the root, game-core, room-server, and lockfile versions to `1.16.0`
- align the production room-service unit, deployment smoke examples, and anonymous acceptance templates with `v1.16.0`
- replace iteration-only wording with durable release and safe-production-diagnostics boundaries

## Why

PR #42 merged the field-readiness automation, safe allowlisted production diagnostics, deterministic lifecycle/chaos coverage, Mobile WebKit smoke, and internal metrics schema v2 while intentionally retaining `1.15.0`. This release commit packages that merged work as the next backward-compatible minor version.

## Impact

- no gameplay, UX, persistence, database, or WebSocket protocol change
- Classic remains the default and Party/online remain opt-in
- protocol version remains `1`; legacy compatibility remains enabled
- physical iOS/Android and 4/6/8-person field acceptance remains `PENDING_MANUAL_ACCEPTANCE`
- SMTP credential rotation remains `SMTP_CREDENTIAL_ROTATION_REQUIRED_MANUAL`

## Validation

- `npm ci`
- `npm run format:check`
- `npm run lint:check`
- `npm run type-check`
- `npm run validate-config`
- `npm test` — 337/337
- `npm run test:safe-diagnostics` — 15/15; fixture output mode `0600`
- `npm run build`
- `npm run build:room-server`
- `npm run test:room-server` — 67/67
- `npm run test:room-server-smoke`
- `npm run test:room-server-load` — 20 rooms, 160 connections, p95 0.5 ms, RSS 77.8 MiB
- `npm audit --omit=dev --audit-level=high` — 0 production vulnerabilities
- `git diff --check`

## Release plan

1. Merge after all required CI jobs pass.
2. Deploy the room server from the merged commit as `1.16.0`, preserving the `1.15.0` image for rollback.
3. Verify public health/readiness and shallow WebSocket smoke without creating a room.
4. Create the immutable annotated `v1.16.0` tag and GitHub Release from that same merged commit.
5. Wait for the tag-triggered Pages workflow and verify the live site, Service Worker, version, and browser console.

