### PR TITLE
fix: use production room bridge for diagnostics

### DIFF
--- a/docs/SAFE_PRODUCTION_DIAGNOSTICS.md
+++ b/docs/SAFE_PRODUCTION_DIAGNOSTICS.md
@@ -18,7 +18,8 @@ schema v1 JSON。它用于替代复制 launcher 启动行、完整进程参数�
 
 - `systemctl show` 只读取 room service 的 `ActiveState`；
 - Docker 只通过 `inspect --format` 读取 running、health、image 和 memory limit；
-- `curl` 只访问固定 health/readiness 地址并提取 HTTP 状态及 health 的公开字段；
+- `curl` 只访问固定的 Docker 网桥 health/readiness 地址
+  `http://172.17.0.1:8787/{health,ready}`，并提取 HTTP 状态及 health 的公开字段；
 - migration 检查只输出非负整数；
 - `df` 和 `/proc/vmstat` 检查只输出非负整数。
 

--- a/scripts/collect-safe-production-diagnostics.mjs
+++ b/scripts/collect-safe-production-diagnostics.mjs
@@ -23,6 +23,7 @@ const SOURCE_ERROR_CODES = [
   ['kernelOomEvents', 'OOM_CHECK_FAILED'],
 ]
 const SAFE_ERROR_CODES = new Set(SOURCE_ERROR_CODES.map(([, errorCode]) => errorCode))
+const ROOM_SERVER_INTERNAL_ORIGIN = 'http://172.17.0.1:8787'
 const REPORT_KEYS = ['schemaVersion', 'capturedAt', 'roomServer', 'discourse', 'host', 'errors']
 const ROOM_SERVER_KEYS = [
   'serviceActive',
@@ -268,8 +269,8 @@ export async function collectProductionDiagnosticSources({
       '{{.State.Running}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}|{{.Config.Image}}|{{.HostConfig.Memory}}',
       'flying-chess-room',
     ]),
-    roomHealth: httpCommand('http://127.0.0.1:8787/health'),
-    roomReady: httpCommand('http://127.0.0.1:8787/ready'),
+    roomHealth: httpCommand(`${ROOM_SERVER_INTERNAL_ORIGIN}/health`),
+    roomReady: httpCommand(`${ROOM_SERVER_INTERNAL_ORIGIN}/ready`),
     discourseHealth: httpCommand('https://atang-sp.run.place/srv/status'),
     pendingMigrations: command('docker', [
       'exec',

--- a/scripts/collect-safe-production-diagnostics.test.mjs
+++ b/scripts/collect-safe-production-diagnostics.test.mjs
@@ -242,6 +242,13 @@ describe('safe production diagnostics', () => {
     expect(dockerInspect?.args.join(' ')).not.toContain('.Config.Env')
     expect(dockerInspect?.args.join(' ')).not.toContain('.Path')
     expect(dockerInspect?.args.join(' ')).not.toContain('.Args')
+    const curlTargets = commands
+      .filter(command => command.file === 'curl')
+      .map(command => command.args.at(-1))
+    expect(curlTargets).toContain('http://172.17.0.1:8787/health')
+    expect(curlTargets).toContain('http://172.17.0.1:8787/ready')
+    expect(curlTargets).not.toContain('http://127.0.0.1:8787/health')
+    expect(curlTargets).not.toContain('http://127.0.0.1:8787/ready')
     expect(JSON.stringify(source).includes('FAKE_')).toBe(false)
     expect(report).toMatchObject({
       roomServer: { healthStatus: 200, readyStatus: 200, containerHealthy: true },


### PR DESCRIPTION
## Summary

- make the safe production diagnostics collector probe the room service on the fixed Docker bridge origin used by the production topology
- add exact command-descriptor assertions that reject the unreachable loopback targets
- document the fixed internal health/readiness addresses

## Root cause

The room service intentionally binds `172.17.0.1:8787` so the Discourse container can reach it without exposing port 8787 publicly. The production unit, health timer, Nginx proxy, and deployment documentation all use that address, but the new diagnostics collector alone hard-coded `127.0.0.1:8787`.

During the v1.16.0 rollout, the guarded deployment script used the collector's target and exited at its first read-only preflight with curl exit 7. This occurred before backups, environment edits, unit installation, or service restart. Production remained healthy on `v1.15.0` throughout.

## Red/green evidence

- production reproduction, twice: `loopback=000 bridge=200`
- regression assertion before the fix: failed because curl targets did not include `http://172.17.0.1:8787/health`
- the same targeted test after the fix: pass
- live fixed-target check: `health=200 ready=200`

## Validation

- `npm run format:check`
- `npm run lint:check`
- `npm run type-check`
- `npm run test:safe-diagnostics` — 15/15
- `npm test` — 337/337
- `git diff --check`

No secret, environment value, raw log, process arguments, or full container configuration was read or printed. SMTP credential rotation remains `SMTP_CREDENTIAL_ROTATION_REQUIRED_MANUAL`, and field acceptance remains `PENDING_MANUAL_ACCEPTANCE`.

